### PR TITLE
Update dex-contracts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "networks-inject": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/inject_network_info.js"
   },
   "dependencies": {
-    "@gnosis.pm/dex-contracts": "^0.2.1",
+    "@gnosis.pm/dex-contracts": "^0.2.3",
     "@gnosis.pm/owl-token": "^3.1.0",
     "@gnosis.pm/safe-contracts": "gnosis/safe-contracts#v1.1.1-dev.1",
     "@gnosis.pm/solidity-data-structures": "^1.2.2",

--- a/scripts/deploy_safes.js
+++ b/scripts/deploy_safes.js
@@ -19,7 +19,7 @@ module.exports = async callback => {
   try {
     console.log(`Deploying ${argv.fleetSize} subsafes `)
     console.log("Master Safe:", argv.masterSafe)
-    const slaves = await deployFleetOfSafes(argv.masterSafe, argv.fleetSize, artifacts)
+    const slaves = await deployFleetOfSafes(argv.masterSafe, argv.fleetSize, artifacts, true)
     console.log("Slave Addresses", slaves)
     callback()
   } catch (error) {

--- a/scripts/trading_strategy_helpers.js
+++ b/scripts/trading_strategy_helpers.js
@@ -184,7 +184,8 @@ const getExecTransactionTransaction = async function(masterAddress, traderAddres
  * @param {integer} fleetSize number of sub-Safes to be created with fleetOwner as owner
  * @return {EthereumAddress[]} list of Ethereum Addresses for the subsafes that were deployed
  */
-const deployFleetOfSafes = async function(fleetOwner, fleetSize, artifacts) {
+const deployFleetOfSafes = async function(fleetOwner, fleetSize, artifacts, debug=false) {
+  const log = debug ? (...a) => console.log(...a) : () => {}
   const GnosisSafe = artifacts.require("GnosisSafe")
   const ProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
 
@@ -195,7 +196,7 @@ const deployFleetOfSafes = async function(fleetOwner, fleetSize, artifacts) {
   const slaveSafes = []
   for (let i = 0; i < fleetSize; i++) {
     const newSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [fleetOwner], 1, artifacts)
-    console.log("New Safe Created", newSafe.address)
+    log("New Safe Created", newSafe.address)
     slaveSafes.push(newSafe.address)
   }
   return slaveSafes

--- a/test/dfusionMultiSafes.js
+++ b/test/dfusionMultiSafes.js
@@ -1,11 +1,12 @@
 const utils = require("@gnosis.pm/safe-contracts/test/utils/general")
+const exchangeUtils = require("@gnosis.pm/dex-contracts")
 const Contract = require("@truffle/contract")
 const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
 const TokenOWL = artifacts.require("TokenOWL")
 
-const GnosisSafe = artifacts.require("GnosisSafe.sol")
-const ProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
-const MultiSend = artifacts.require("MultiSend.sol")
+const GnosisSafe = artifacts.require("GnosisSafe")
+const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
+const MultiSend = artifacts.require("MultiSend")
 
 const TestToken = artifacts.require("DetailedMintableToken")
 
@@ -21,7 +22,7 @@ const {
   maxUINT,
   DELEGATECALL,
 } = require("../scripts/trading_strategy_helpers")
-const { waitForNSeconds, toETH, execTransaction, deploySafe, decodeOrdersBN } = require("./utils.js")
+const { waitForNSeconds, toETH, execTransaction, deploySafe } = require("./utils.js")
 
 contract("GnosisSafe", function(accounts) {
   let lw
@@ -80,7 +81,7 @@ contract("GnosisSafe", function(accounts) {
     // Note that we are have NOT registered the tokens on the exchange but can deposit them nontheless.
 
     const deposits = slaveSafes.map(slaveAddress => ({
-      amount: depositAmount,
+      amount: depositAmount.toString(),
       tokenAddress: testToken.address,
       userAddress: slaveAddress,
     }))
@@ -125,7 +126,7 @@ contract("GnosisSafe", function(accounts) {
 
     // Correctness assertions
     for (const slaveAddress of slaveSafes) {
-      const auctionElements = decodeOrdersBN(await exchange.getEncodedUserOrders(slaveAddress))
+      const auctionElements = exchangeUtils.decodeOrdersBN(await exchange.getEncodedUserOrders(slaveAddress))
       assert.equal(auctionElements.length, 2)
       const [buyOrder, sellOrder] = auctionElements
       assert(buyOrder.priceDenominator.eq(max128))

--- a/test/utils.js
+++ b/test/utils.js
@@ -109,21 +109,6 @@ async function getParamFromTxEvent(transaction, eventName, paramName, contract, 
   }
 }
 
-// TODO - move this once dex-contracts updates npm package.
-function decodeOrdersBN(bytes) {
-  return decodeOrders(bytes).map(e => ({
-    user: e.user,
-    sellTokenBalance: new BN(e.sellTokenBalance),
-    buyToken: parseInt(e.buyToken),
-    sellToken: parseInt(e.sellToken),
-    validFrom: parseInt(e.validFrom),
-    validUntil: parseInt(e.validUntil),
-    priceNumerator: new BN(e.priceNumerator),
-    priceDenominator: new BN(e.priceDenominator),
-    remainingAmount: new BN(e.remainingAmount),
-  }))
-}
-
 async function createLightwallet() {
   // Create lightwallet accounts
   const createVault = util.promisify(lightwallet.keystore.createVault).bind(lightwallet.keystore)
@@ -164,7 +149,6 @@ module.exports = {
   execTransactionData,
   deploySafe,
   encodeMultiSend,
-  decodeOrdersBN,
   createLightwallet,
   signTransaction,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,10 +115,10 @@
     "@ethersproject/constants" ">=5.0.0-beta.128"
     "@ethersproject/logger" ">=5.0.0-beta.129"
 
-"@gnosis.pm/dex-contracts@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.2.1.tgz#c36c8538568168526fc951e7ba78f7754610b519"
-  integrity sha512-6s4dJbgdX57cSgbXIUL1vnAN/B8gNqmZwb4w0LgDtunVMPj1AdhuIi1umdLqmFvsyPhYngDhhqbLJmdbn7YGrg==
+"@gnosis.pm/dex-contracts@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.2.3.tgz#101d37aa50375586cce95d4b24a34c2017633988"
+  integrity sha512-665DPYBCfp3qcchN7Hfm8oCESrLxS1/xtonocy3R8aAztvjA3GTW8ifaXyaiVE291zAuJq/BIWmHGWGTGH6mKQ==
   dependencies:
     bn.js "^5.1.1"
 


### PR DESCRIPTION
The most recent npm release of dex-contracts exposes the `decodeOrdersBN` function so that it does not need to be copy-pasted here, but merely used. A couple other simple changes (like log statements not appearsing in truffle tests) made here also.