### PR TITLE
Waiting shortly after deployment of safes in order to let infura nodes sync

### DIFF
--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -87,7 +87,13 @@ const deploySafe = async function(gnosisSafeMasterCopy, proxyFactory, owners, th
     .setup(owners, threshold, ADDRESS_0, "0x", ADDRESS_0, ADDRESS_0, 0, ADDRESS_0)
     .encodeABI()
   const transaction = await proxyFactory.createProxy(gnosisSafeMasterCopy.address, initData)
+  // waiting two second to make sure infura can catch up
+  await sleep(2000)
   return await getParamFromTxEvent(transaction, "ProxyCreation", "proxy", proxyFactory.address, GnosisSafe, null)
+}
+
+const sleep = function(milliseconds) {
+  return new Promise(r => setTimeout(r, milliseconds))
 }
 
 // Need some small adjustments to default implementation for web3js 1.x

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -88,7 +88,7 @@ const deploySafe = async function(gnosisSafeMasterCopy, proxyFactory, owners, th
     .encodeABI()
   const transaction = await proxyFactory.createProxy(gnosisSafeMasterCopy.address, initData)
   // waiting two second to make sure infura can catch up
-  await sleep(2000)
+  await sleep(1000)
   return await getParamFromTxEvent(transaction, "ProxyCreation", "proxy", proxyFactory.address, GnosisSafe, null)
 }
 


### PR DESCRIPTION
closes #38 


There were two possible fixes for this issue:

Either:
-making sure that all infura nodes have synced with the current top of the chain(implemented) or - 
 - using only one gnosis internal node

I have chosen the first one, as we don't want to require users to have access to a specific ethereum node.

The longterm fix is to deploy all safes in one transaction