### PR TITLE
Use ERC20 printing functions in the code 

### DIFF
--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -6,7 +6,7 @@ const {
   checkSufficiencyOfBalance,
 } = require("./utils/trading_strategy_helpers")
 const { signAndSend, promptUser } = require("./utils/sign_and_send")
-const { toETH } = require("./utils/internals")
+const { toErc20Units } = require("./utils/printing_tools")
 const assert = require("assert")
 
 const argv = require("yargs")
@@ -52,8 +52,8 @@ module.exports = async callback => {
     // Init params
     const GnosisSafe = artifacts.require("GnosisSafe")
     const masterSafe = await GnosisSafe.at(argv.masterSafe)
-    const investmentTargetToken = toETH(argv.investmentTargetToken)
-    const investmentStableToken = toETH(argv.investmentStableToken)
+    const investmentTargetToken = toErc20Units(argv.investmentTargetToken, 18)
+    const investmentStableToken = toErc20Units(argv.investmentStableToken, 18)
     const ERC20Detailed = artifacts.require("ERC20Detailed")
     const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
     BatchExchange.setProvider(web3.currentProvider)

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -1,6 +1,5 @@
 const util = require("util")
 const lightwallet = require("eth-lightwallet")
-const BN = require("bn.js")
 const assert = require("assert")
 const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
 const CALL = 0

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -46,11 +46,6 @@ const waitForNSeconds = async function(seconds, web3Provider = web3) {
   await send("evm_mine", [], web3Provider)
 }
 
-function toETH(value) {
-  const GWEI = 1000000000
-  return new BN(value * GWEI).mul(new BN(GWEI))
-}
-
 const execTransaction = async function(safe, lightWallet, transaction) {
   const nonce = await safe.nonce()
   const transactionHash = await safe.getTransactionHash(
@@ -233,7 +228,6 @@ function logGasUsage(subject, transactionOrReceipt) {
 
 module.exports = {
   waitForNSeconds,
-  toETH,
   execTransaction,
   deploySafe,
   encodeMultiSend,

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -5,7 +5,7 @@ const assert = require("assert")
 const BN = require("bn.js")
 const fs = require("fs")
 const { deploySafe, buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")
-const { shortenedAddress, toErc20Units } = require("./printing_tools")
+const { shortenedAddress, fromErc20Units, toErc20Units } = require("./printing_tools")
 const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
 const maxU32 = 2 ** 32 - 1
 const max128 = new BN(2).pow(new BN(128)).subn(1)
@@ -331,7 +331,8 @@ const buildTransferApproveDepositFromList = async function(masterAddress, deposi
     )
     const depositToken = await ERC20.at(deposit.tokenAddress)
     const tokenSymbol = await depositToken.symbol.call()
-    const unitAmount = web3.utils.fromWei(deposit.amount, "ether")
+    const tokenDecimals = await depositToken.decimals.call()
+    const unitAmount = fromErc20Units(deposit.amount, tokenDecimals)
     log(
       `Safe ${deposit.bracketAddress} receiving (from ${shortenedAddress(
         masterAddress

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -4,7 +4,7 @@ const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts
 const assert = require("assert")
 const BN = require("bn.js")
 const fs = require("fs")
-const { deploySafe, buildBundledTransaction, buildExecTransaction, toETH, CALL } = require("./internals")
+const { deploySafe, buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")
 const { shortenedAddress, toErc20Units } = require("./printing_tools")
 const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
 const maxU32 = 2 ** 32 - 1
@@ -239,16 +239,16 @@ const calculateBuyAndSellAmountsFromPrice = function(price, targetToken) {
   const priceFormatted = toErc20Units(price, targetToken.decimals)
   let sellAmount
   let buyAmount
-  if (priceFormatted.gt(toETH(1))) {
+  if (priceFormatted.gt(toErc20Units(1, 18))) {
     sellAmount = max128
-      .mul(toETH(1))
+      .mul(toErc20Units(1, 18))
       .div(priceFormatted)
       .toString()
     buyAmount = max128.toString()
   } else {
     buyAmount = max128
       .mul(priceFormatted)
-      .div(toETH(1))
+      .div(toErc20Units(1, 18))
       .toString()
     sellAmount = max128.toString()
   }

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -122,7 +122,7 @@ module.exports = async callback => {
 
       if (argv.requestWithdraw)
         console.log(
-          `Requesting withdrawal of ${fromErc20Units(userAmount, tokenDecimals)} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`
+          `Requesting withdrawal of ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`
         )
       else if (argv.withdraw && !argv.transferBackToMaster)
         console.log(`Withdrawing ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`)

--- a/test/dfusionMultiSafes.js
+++ b/test/dfusionMultiSafes.js
@@ -21,7 +21,8 @@ const {
   max128,
   maxU32,
 } = require("../scripts/utils/trading_strategy_helpers")
-const { waitForNSeconds, toETH, execTransaction, deploySafe } = require("../scripts/utils/internals")
+const { waitForNSeconds, execTransaction, deploySafe } = require("../scripts/utils/internals")
+const { toErc20Units } = require("../scripts/utils/printing_tools")
 
 const checkPricesOfBracketStrategy = async function(targetPrice, bracketSafes, exchange) {
   const rangePercentage = 0.2
@@ -84,8 +85,8 @@ contract("GnosisSafe", function(accounts) {
   async function prepareTokenRegistration(account) {
     const owlToken = await TokenOWL.at(await exchange.feeToken())
     await owlToken.setMinter(account)
-    await owlToken.mintOWL(account, toETH(10))
-    await owlToken.approve(exchange.address, toETH(10))
+    await owlToken.mintOWL(account, toErc20Units(10, 18))
+    await owlToken.approve(exchange.address, toErc20Units(10, 18))
   }
   describe("Exchange interaction test:", async function() {
     it("Adds tokens to the exchange", async () => {
@@ -208,7 +209,7 @@ contract("GnosisSafe", function(accounts) {
         const [buyOrder, sellOrder] = auctionElements
 
         // Checks that bracket orders are profitable for liquidity provider
-        const initialAmount = new BN(10).pow(new BN(18))
+        const initialAmount = toErc20Units(1, 18)
         const amountAfterSelling = initialAmount.mul(sellOrder.priceNumerator).div(sellOrder.priceDenominator)
         const amountAfterBuying = amountAfterSelling.mul(buyOrder.priceNumerator).div(buyOrder.priceDenominator)
         assert.equal(amountAfterBuying.gt(initialAmount), true, "Brackets are not profitable")
@@ -349,7 +350,7 @@ contract("GnosisSafe", function(accounts) {
     it("Withdraw full amount, three steps", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2, artifacts)
-      const depositAmount = toETH(200)
+      const depositAmount = toErc20Units(200, 18)
       const fullTokenAmount = depositAmount * bracketAddresses.length
 
       await testToken.mint(accounts[0], fullTokenAmount.toString())
@@ -373,7 +374,7 @@ contract("GnosisSafe", function(accounts) {
       // that extra amounts are ignored by the script and just the maximal possible value is withdrawn
       const withdrawalsModified = withdrawals
       withdrawalsModified.map(withdraw => {
-        withdraw.amount = withdraw.amount.add(toETH(1))
+        withdraw.amount = withdraw.amount.add(toErc20Units(1, 18))
         withdraw
       })
       const withdrawalTransaction = await buildWithdraw(masterSafe.address, withdrawalsModified, web3, artifacts)
@@ -429,7 +430,7 @@ contract("GnosisSafe", function(accounts) {
     it("Withdraw full amount, two steps", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2, artifacts)
-      const depositAmount = toETH(200)
+      const depositAmount = toErc20Units(200, 18)
       const fullTokenAmount = depositAmount * bracketAddresses.length
 
       await testToken.mint(accounts[0], fullTokenAmount.toString())


### PR DESCRIPTION
This PR removes some ad hoc functions we were using to handle token decimals and fixes a related bug in the withdraw scripts.

One step further in solving #24.