### PR TITLE
Faster withdrawal scripts

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -1,7 +1,7 @@
 const axios = require("axios")
 const Contract = require("@truffle/contract")
 const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
-const { buildOrders, fetchTokenInfo } = require("./utils/trading_strategy_helpers")
+const { buildOrders, fetchTokenInfoFromExchange } = require("./utils/trading_strategy_helpers")
 const { signAndSend, promptUser } = require("./utils/sign_and_send")
 
 const argv = require("yargs")
@@ -68,9 +68,9 @@ const getDexagPrice = async function(tokenBought, tokenSold) {
 
 const acceptedPriceDeviationInPercentage = 2
 const isPriceReasonable = async function(exchange, targetTokenId, stableTokenId, price) {
-  const tokenInfo = await fetchTokenInfo(exchange, [targetTokenId, stableTokenId], artifacts)
-  const targetToken = tokenInfo[targetTokenId]
-  const stableToken = tokenInfo[stableTokenId]
+  const tokenInfoPromises = await fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId], artifacts)
+  const targetToken = await tokenInfoPromises[targetTokenId]
+  const stableToken = await tokenInfoPromises[stableTokenId]
   const dexagPrice = await getDexagPrice(targetToken.symbol, stableToken.symbol)
   // TODO add unit test checking whether getDexagPrice works as expected
   if (dexagPrice === undefined) {

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -68,7 +68,7 @@ const getDexagPrice = async function(tokenBought, tokenSold) {
 
 const acceptedPriceDeviationInPercentage = 2
 const isPriceReasonable = async function(exchange, targetTokenId, stableTokenId, price) {
-  const tokenInfoPromises = await fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId], artifacts)
+  const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId], artifacts)
   const targetToken = await tokenInfoPromises[targetTokenId]
   const stableToken = await tokenInfoPromises[stableTokenId]
   const dexagPrice = await getDexagPrice(targetToken.symbol, stableToken.symbol)

--- a/scripts/utils/js_helpers.js
+++ b/scripts/utils/js_helpers.js
@@ -1,0 +1,12 @@
+/**
+ * returns the input array without duplicate elements
+ * @param {*[]} array an array
+ * @return {*[]} the same array without ducplicate elements
+ */
+const allElementsOnlyOnce = function(array) {
+  return array.filter((value, index, self) => self.indexOf(value) === index)
+}
+
+module.exports = {
+  allElementsOnlyOnce,
+}

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -572,7 +572,7 @@ const buildTransferFundsToMaster = async function(masterAddress, withdrawals, li
   const ERC20 = artifacts.require("ERC20Mintable")
 
   // TODO: enforce that there are no overlapping withdrawals
-  const masterTransactionsPromises = withdrawals.map((withdrawal) => (async () => {
+  const masterTransactions = await Promise.all(withdrawals.map(async withdrawal => {
     const token = await ERC20.at(withdrawal.tokenAddress)
     let amount
     if (limitToMaxWithdrawableAmount) {
@@ -592,10 +592,7 @@ const buildTransferFundsToMaster = async function(masterAddress, withdrawals, li
     }
     // build transaction to execute previous transaction through master
     return buildExecTransaction(masterAddress, withdrawal.bracketAddress, transactionToExecute, artifacts)
-  }).call())
-
-  const masterTransactions = []
-  for (const transactionPromise of masterTransactionsPromises) masterTransactions.push(await transactionPromise)
+  }))
 
   return buildBundledTransaction(masterTransactions, web3, artifacts)
 }

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -333,18 +333,18 @@ const buildGenericFundMovement = async function(masterAddress, withdrawals, func
   const exchange = await getExchange(web3)
   
   // it's not necessary to avoid overlapping withdraws, since the full amount is withdrawn for each entry TODO: is this still true?
-  const masterTransactionsPromises = withdrawals.map((withdrawal) => (async () => {
+  const masterTransactionsPromises = withdrawals.map(withdrawal => {
     // create transaction for the token
     let transactionData
     switch (functionName) {
       case "requestWithdraw":
-        transactionData = await exchange.contract.methods["requestWithdraw"](
+        transactionData = exchange.contract.methods["requestWithdraw"](
           withdrawal.tokenAddress,
           withdrawal.amount.toString()
         ).encodeABI()
         break
       case "withdraw":
-        transactionData = await exchange.contract.methods["withdraw"](
+        transactionData = exchange.contract.methods["withdraw"](
           withdrawal.bracketAddress,
           withdrawal.tokenAddress
         ).encodeABI()
@@ -362,7 +362,7 @@ const buildGenericFundMovement = async function(masterAddress, withdrawals, func
     }
     // build transaction to execute previous transaction through master
     return buildExecTransaction(masterAddress, withdrawal.bracketAddress, transactionToExecute, artifacts)
-  }).call())
+  })
 
   // safe pushing to array
   const masterTransactions = []

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -140,8 +140,8 @@ const fetchTokenInfoAtAddresses = function(tokenAddresses, artifacts, debug = fa
         log(`Found token ${tokenInfo.symbol} at address ${tokenInfo.address} with ${tokenInfo.decimals} decimals`)
         return tokenInfo
       }).call()
-      tokenPromises[tokenAddress] = globalTokenPromisesFromAddress[tokenAddress]
     }
+    tokenPromises[tokenAddress] = globalTokenPromisesFromAddress[tokenAddress]
   }
   return tokenPromises
 }

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -605,10 +605,8 @@ const buildTransferFundsToMaster = async function(masterAddress, withdrawals, li
  * @return {Transaction} Multisend transaction that has to be sent from the master address to transfer back the funds stored in the exchange
  */
 const buildWithdrawAndTransferFundsToMaster = async function(masterAddress, withdrawals, web3 = web3, artifacts = artifacts) {
-  const [withdrawalTransaction, transferFundsToMasterTransaction] = await Promise.all([
-    buildWithdraw(masterAddress, withdrawals, web3, artifacts),
-    buildTransferFundsToMaster(masterAddress, withdrawals, false, web3, artifacts)
-  ])
+  const withdrawalTransaction = await buildWithdraw(masterAddress, withdrawals, web3, artifacts)
+  const transferFundsToMasterTransaction = await buildTransferFundsToMaster(masterAddress, withdrawals, false, web3, artifacts)
   return buildBundledTransaction([withdrawalTransaction, transferFundsToMasterTransaction], web3, artifacts)
 }
 

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -71,6 +71,22 @@ const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))
  */
 
 /**
+ * Returns an instance of the exchange contract
+ */
+const getExchange = async function(web3) {
+  await Promise.all([BatchExchange.setProvider(web3.currentProvider), BatchExchange.setNetwork(web3.network_id)])
+  return BatchExchange.deployed()
+}
+
+/**
+ * Returns an instance of the safe contract at the given address
+ * @param {Address} safeAddress address of the safe of which to create an instance
+ */
+const getSafe = function(safeAddress, artifacts) {
+  return artifacts.require("GnosisSafe").at(safeAddress)
+}
+
+/**
  * Checks that the first input address is the only owner of the first input address
  * @param {Address} masterAddress address that should be the only owner
  * @param {Address} ownedAddress address that is owned
@@ -556,6 +572,8 @@ const buildWithdrawAndTransferFundsToMaster = async function(masterAddress, with
 }
 
 module.exports = {
+  getSafe,
+  getExchange,
   deployFleetOfSafes,
   buildOrders,
   buildBundledTransaction,

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -333,7 +333,7 @@ withdrawal of or to withdraw the desired funds
 const buildGenericFundMovement = async function(masterAddress, withdrawals, functionName, web3 = web3, artifacts = artifacts) { // TODO: do we need artifacts here?
   const exchange = await getExchange(web3)
   
-  // it's not necessary to avoid overlapping withdraws, since the full amount is withdrawn for each entry TODO: is this still true?
+  // it's not necessary to avoid overlapping withdraws, since the full amount is withdrawn for each entry
   const masterTransactionsPromises = withdrawals.map(withdrawal => {
     // create transaction for the token
     let transactionData

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -544,7 +544,7 @@ const buildBracketTransactionForTransferApproveDeposit = async (
  * @return {Transaction} Multisend transaction that has to be sent from the master address to request
 withdrawal of the desired funds
 */
-const buildRequestWithdraw = async function(masterAddress, withdrawals, web3, artifacts) {
+const buildRequestWithdraw = function(masterAddress, withdrawals, web3, artifacts) {
   return buildGenericFundMovement(masterAddress, withdrawals, "requestWithdraw", web3, artifacts)
 }
 
@@ -558,7 +558,7 @@ const buildRequestWithdraw = async function(masterAddress, withdrawals, web3, ar
  * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
  * @return {Transaction} Multisend transaction that has to be sent from the master address to withdraw the desired funds
  */
-const buildWithdraw = async function(masterAddress, withdrawals, web3, artifacts) {
+const buildWithdraw = function(masterAddress, withdrawals, web3, artifacts) {
   return buildGenericFundMovement(masterAddress, withdrawals, "withdraw", web3, artifacts)
 }
 

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -155,7 +155,7 @@ const globalTokenPromisesFromId = {}
  * @param {integer[]} tokenIds list of *unique* token ids whose data is to be fetch from EVM
  * @return {Promise<TokenObject>[]} list of detailed/relevant token information
  */
-const fetchTokenInfoFromExchange = async function(exchange, tokenIds, artifacts, debug = false) {
+const fetchTokenInfoFromExchange = function(exchange, tokenIds, artifacts, debug = false) {
   const log = debug ? () => console.log.apply(arguments) : () => {}
 
   log("Fetching token data from EVM")

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -89,7 +89,8 @@ const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))
  * Returns an instance of the exchange contract
  */
 const getExchange = async function(web3) {
-  await Promise.all([BatchExchange.setProvider(web3.currentProvider), BatchExchange.setNetwork(web3.network_id)])
+  BatchExchange.setNetwork(web3.network_id)
+  BatchExchange.setProvider(web3.currentProvider)
   return BatchExchange.deployed()
 }
 

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -88,7 +88,7 @@ const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))
 /**
  * Returns an instance of the exchange contract
  */
-const getExchange = async function(web3) {
+const getExchange = function(web3) {
   BatchExchange.setNetwork(web3.network_id)
   BatchExchange.setProvider(web3.currentProvider)
   return BatchExchange.deployed()

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -114,13 +114,13 @@ const isOnlySafeOwner = async function(masterAddress, ownedAddress, artifacts) {
   return ownerAddresses.length == 1 && ownerAddresses[0] == masterAddress
 }
 
+const globalTokenPromisesFromAddress = {}
 /**
  * Queries EVM for ERC20 token details by address
  * and returns a list of promises of detailed token information.
  * @param {Address[]} tokenAddresses list of *unique* token addresses whose data is to be fetch from the EVM
  * @return {Promise<TokenObject>[]} list of detailed/relevant token information
  */
-const globalTokenPromisesFromAddress = {}
 const fetchTokenInfoAtAddresses = function(tokenAddresses, artifacts, debug = false) {
   const log = debug ? () => console.log.apply(arguments) : () => {}
   const ERC20 = artifacts.require("ERC20Detailed")
@@ -146,6 +146,7 @@ const fetchTokenInfoAtAddresses = function(tokenAddresses, artifacts, debug = fa
   return tokenPromises
 }
 
+const globalTokenPromisesFromId = {}
 /**
  * Queries EVM for ERC20 token details by token id
  * and returns a list of detailed token information.
@@ -153,7 +154,6 @@ const fetchTokenInfoAtAddresses = function(tokenAddresses, artifacts, debug = fa
  * @param {integer[]} tokenIds list of *unique* token ids whose data is to be fetch from EVM
  * @return {Promise<TokenObject>[]} list of detailed/relevant token information
  */
-const globalTokenPromisesFromId = {}
 const fetchTokenInfoFromExchange = async function(exchange, tokenIds, artifacts, debug = false) {
   const log = debug ? () => console.log.apply(arguments) : () => {}
 

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -85,7 +85,7 @@ module.exports = async callback => {
 
     let withdrawals = require(argv.withdrawalFile)
     const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))
-    const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved, artifacts, true)
+    const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved, artifacts)
 
     if (argv.allTokens) {
       console.log("Retrieving amount of tokens to withdraw.")

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -112,9 +112,7 @@ module.exports = async callback => {
     const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))
     const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved, artifacts, true)
     for (const withdrawal of withdrawals) {
-      const ERC20 = artifacts.require("ERC20Detailed")
-      const token = await ERC20.at(withdrawal.tokenAddress)
-      const [tokenSymbol, tokenDecimals] = await Promise.all([token.symbol.call(), token.decimals.call()])
+      const {symbol: tokenSymbol, decimals: tokenDecimals} = await tokenInfoPromises[withdrawal.tokenAddress]
 
       const userAmount = fromErc20Units(withdrawal.amount, tokenDecimals)
 

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -1,9 +1,8 @@
-const Contract = require("@truffle/contract")
-const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
-
 const { signAndSend, promptUser } = require("./utils/sign_and_send")
 const { fromErc20Units, shortenedAddress } = require("./utils/printing_tools")
 const {
+  getExchange,
+  getSafe,
   buildRequestWithdraw,
   buildWithdraw,
   buildTransferFundsToMaster,
@@ -79,11 +78,7 @@ const getAmount = async function(bracketAddress, tokenAddress, exchange) {
 
 module.exports = async callback => {
   try {
-    await BatchExchange.setProvider(web3.currentProvider)
-    await BatchExchange.setNetwork(web3.network_id)
-    const exchange = await BatchExchange.deployed()
-    const GnosisSafe = artifacts.require("GnosisSafe")
-    const masterSafe = await GnosisSafe.at(argv.masterSafe)
+    const [ exchange, masterSafe ] = await Promise.all([ getExchange(web3), getSafe(argv.masterSafe, artifacts) ])
 
     let withdrawals = require(argv.withdrawalFile)
 

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -84,6 +84,8 @@ module.exports = async callback => {
     const exchange = await getExchange(web3)
 
     let withdrawals = require(argv.withdrawalFile)
+    const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))
+    const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved, artifacts, true)
 
     if (argv.allTokens) {
       console.log("Retrieving amount of tokens to withdraw.")
@@ -110,8 +112,6 @@ module.exports = async callback => {
       throw new Error("No operation specified")
     }
 
-    const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))
-    const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved, artifacts, true)
     for (const withdrawal of withdrawals) {
       const {symbol: tokenSymbol, decimals: tokenDecimals} = await tokenInfoPromises[withdrawal.tokenAddress]
 

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -1,5 +1,6 @@
 const { signAndSend, promptUser } = require("./utils/sign_and_send")
 const { fromErc20Units, shortenedAddress } = require("./utils/printing_tools")
+const { allElementsOnlyOnce } = require("./utils/js_helpers")
 const {
   getExchange,
   getSafe,
@@ -107,6 +108,7 @@ module.exports = async callback => {
       throw new Error("No operation specified")
     }
 
+    const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))
     for (const withdrawal of withdrawals) {
       const ERC20 = artifacts.require("ERC20Detailed")
       const token = await ERC20.at(withdrawal.tokenAddress)

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -81,7 +81,7 @@ const getAmount = async function(bracketAddress, tokenAddress, exchange) {
 module.exports = async callback => {
   try {
     const masterSafePromise = getSafe(argv.masterSafe, artifacts)
-    const exchange = await getExchange(web3)
+    const exchange = getExchange(web3)
 
     let withdrawals = require(argv.withdrawalFile)
     const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -4,6 +4,7 @@ const { allElementsOnlyOnce } = require("./utils/js_helpers")
 const {
   getExchange,
   getSafe,
+  fetchTokenInfoAtAddresses,
   buildRequestWithdraw,
   buildWithdraw,
   buildTransferFundsToMaster,
@@ -109,6 +110,7 @@ module.exports = async callback => {
     }
 
     const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))
+    const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved, artifacts, true)
     for (const withdrawal of withdrawals) {
       const ERC20 = artifacts.require("ERC20Detailed")
       const token = await ERC20.at(withdrawal.tokenAddress)

--- a/test/dfusionMultiSafes.js
+++ b/test/dfusionMultiSafes.js
@@ -116,18 +116,19 @@ contract("GnosisSafe", function(accounts) {
       await checkTokenInfo(token1, token1Info2)
       await checkTokenInfo(token2, token2Info2)
     })
-    it.only("Fetches tokens from exchange", async function() {
+    it("Fetches tokens from exchange", async function() {
       const owlToken = await TokenOWL.at(await exchange.feeToken())
       await prepareTokenRegistration(accounts[0])
       await exchange.addToken(testToken.address, { from: accounts[0] })
+      const tokenId = await exchange.tokenAddressToIdMap(testToken.address) // TODO: make tests independent and replace tokenId with 1
 
       const tokenInfoPromises1 = fetchTokenInfoFromExchange(exchange, [0], artifacts)
       const token0Info1 = await tokenInfoPromises1[0]
       await checkTokenInfo(owlToken, token0Info1)
 
-      const tokenInfoPromises2 = fetchTokenInfoFromExchange(exchange, [0, 1], artifacts)
+      const tokenInfoPromises2 = fetchTokenInfoFromExchange(exchange, [0, tokenId], artifacts)
       const token0Info2 = await tokenInfoPromises2[0]
-      const token1Info2 = await tokenInfoPromises2[1]
+      const token1Info2 = await tokenInfoPromises2[tokenId]
       await checkTokenInfo(owlToken, token0Info2)
       await checkTokenInfo(testToken, token1Info2)
     })

--- a/test/dfusionMultiSafes.js
+++ b/test/dfusionMultiSafes.js
@@ -116,16 +116,16 @@ contract("GnosisSafe", function(accounts) {
       await checkTokenInfo(token1, token1Info2)
       await checkTokenInfo(token2, token2Info2)
     })
-    it("Fetches tokens from exchange", async function() {
+    it.only("Fetches tokens from exchange", async function() {
       const owlToken = await TokenOWL.at(await exchange.feeToken())
       await prepareTokenRegistration(accounts[0])
       await exchange.addToken(testToken.address, { from: accounts[0] })
 
-      const tokenInfoPromises1 = await fetchTokenInfoFromExchange(exchange, [0], artifacts)
+      const tokenInfoPromises1 = fetchTokenInfoFromExchange(exchange, [0], artifacts)
       const token0Info1 = await tokenInfoPromises1[0]
       await checkTokenInfo(owlToken, token0Info1)
 
-      const tokenInfoPromises2 = await fetchTokenInfoFromExchange(exchange, [0, 1], artifacts)
+      const tokenInfoPromises2 = fetchTokenInfoFromExchange(exchange, [0, 1], artifacts)
       const token0Info2 = await tokenInfoPromises2[0]
       const token1Info2 = await tokenInfoPromises2[1]
       await checkTokenInfo(owlToken, token0Info2)


### PR DESCRIPTION
Drastically reduce the running time of the withdrawal scripts by heavily relying on Javascript's asynchronous features.

This PR is a test bench for using the same techniques everywhere else in this repo, so changes and recommendations are very welcome before we start working on the other scripts.

Notable breaking change is the function `fetchTokenInfo`, which is now split in `fetchTokenInfoAtAddresses` and `fetchTokenInfoFromExchange`, both of which return a promise.

Running times of withdraw.js
1. with two safes
  - before: 28±1s
  - after: 12±1s

2. with 20 safes
  - before: 3min 6s (no ±, I ran it only once)
  - after: 14.7±0.1s


Related issue: #57 
Thanks @nlordell for the discussion.