### PR TITLE
View scripts

### DIFF
--- a/scripts/find_bracket_traders.js
+++ b/scripts/find_bracket_traders.js
@@ -1,0 +1,34 @@
+const { isOnlySafeOwner } = require("./utils/trading_strategy_helpers")
+
+const argv = require("yargs")
+  .option("masterSafe", {
+    type: "string",
+    describe: "Address of Gnosis Safe owning every bracket",
+  })
+  .demand(["masterSafe"])
+  .help(
+    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
+  )
+  .version(false).argv
+
+module.exports = async callback => {
+  try {
+    // Init params
+    const ProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
+
+    const proxyFactory = await ProxyFactory.deployed()
+    const eventData = await proxyFactory.getPastEvents("ProxyCreation", { fromBlock: 0, toBlock: "latest" })
+    const safeDeployments = eventData.map(event => event.args[0]).slice(-100)
+    console.log("In total we have ", safeDeployments.length, " safe deployments")
+    const isDeployedByMaster = await Promise.all(
+      safeDeployments.map(async bracketTrader => await isOnlySafeOwner(argv.masterSafe, bracketTrader, artifacts))
+    )
+    const bracketTraderAddresses = safeDeployments.filter((bracketTrader, index) => isDeployedByMaster[index])
+    console.log("And ", bracketTraderAddresses.length, " safes are used for the bracket strategy of your master safe")
+    console.log("All brackets are: ", bracketTraderAddresses.join(","))
+
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/scripts/get_bracket_data.js
+++ b/scripts/get_bracket_data.js
@@ -1,17 +1,6 @@
-const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")
 const Contract = require("@truffle/contract")
-const {getOrdersPaginated, printOrder} = require("./utils/to_be_imported_from_dex_contracts.js")
-const {
-  buildTransferApproveDepositFromOrders,
-  buildOrders,
-  checkSufficiencyOfBalance,
-  isOnlySafeOwner,
-} = require("./utils/trading_strategy_helpers")
-const BN = require("bn.js")
-
-const { signAndSend, promptUser } = require("./utils/sign_and_send")
-const { toErc20Units } = require("./utils/printing_tools")
-const assert = require("assert")
+const { getOrdersPaginated, printOrder } = require("./utils/to_be_imported_from_dex_contracts.js")
+const { isOnlySafeOwner } = require("./utils/trading_strategy_helpers")
 
 const argv = require("yargs")
   .option("masterSafe", {
@@ -27,20 +16,20 @@ const argv = require("yargs")
 module.exports = async callback => {
   try {
     // Init params
-    const GnosisSafe = artifacts.require("GnosisSafe")
     const ERC20Detailed = artifacts.require("ERC20Detailed")
     const ProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
 
-    const masterSafe = await GnosisSafe.at(argv.masterSafe)
     const proxyFactory = await ProxyFactory.deployed()
-    const eventData = await proxyFactory.getPastEvents( 'ProxyCreation', { fromBlock: 0, toBlock: 'latest' } )
+    const eventData = await proxyFactory.getPastEvents("ProxyCreation", { fromBlock: 0, toBlock: "latest" })
     const safeDeployments = eventData.map(event => event.args[0]).slice(-100)
     //For easy rinkeby testing use:
     //bracketTraderAddresses = ['0xc867f926392a4e55b8800afbbbad8c99efd70e49']
     console.log("In total we have ", safeDeployments.length, " safe deployments")
-    const isDeployedByMaster = await Promise.all(safeDeployments.map(async bracketTrader =>  await isOnlySafeOwner(argv.masterSafe, bracketTrader, artifacts)))
-    bracketTraderAddresses = safeDeployments.filter( (bracketTrader, index) => isDeployedByMaster[index] )
-    console.log("And ", bracketTraderAddresses.length, " safes are used for the bracket strategy of your mastersafe")
+    const isDeployedByMaster = await Promise.all(
+      safeDeployments.map(async bracketTrader => await isOnlySafeOwner(argv.masterSafe, bracketTrader, artifacts))
+    )
+    let bracketTraderAddresses = safeDeployments.filter((bracketTrader, index) => isDeployedByMaster[index])
+    console.log("And ", bracketTraderAddresses.length, " safes are used for the bracket strategy of your master safe")
 
     const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
     BatchExchange.setProvider(web3.currentProvider)
@@ -48,30 +37,34 @@ module.exports = async callback => {
     const exchange = await BatchExchange.deployed()
     const batchId = (await exchange.getCurrentBatchId()).toNumber()
 
-    let auctionElementsDecoded = await getOrdersPaginated(exchange, 100)
-   
-    bracketTraderAddresses = bracketTraderAddresses.map(address => address.toLowerCase())
-    await Promise.all(bracketTraderAddresses.map(async (bracketTrader) => {
-      relevantOrders = auctionElementsDecoded.filter(order => order.user.toLowerCase() == bracketTrader)
+    const auctionElementsDecoded = await getOrdersPaginated(exchange, 100)
 
-      if (relevantOrders.length>0){
-        console.log(`The orders of the bracket trader ${bracketTrader} are:`)
-        relevantOrders.forEach(order => printOrder(order, batchId))
-        let tokenset = new Set()
-        relevantOrders.forEach(order => {
-          tokenset.add(order.buyToken)
-          tokenset.add(order.sellToken)
-        })
-        tokenset = Array.from(tokenset)
-        await Promise.all(tokenset.map(async (tokenId)=> {
-          const tokenAddress = await exchange.tokenIdToAddressMap.call(tokenId)
-          const tokenBalance = await exchange.getBalance.call(bracketTrader, tokenAddress)
-          const erc20 = await ERC20Detailed.at(tokenAddress)
-          const symbol = await erc20.symbol.call()
-          console.log(`And the balance of the trader ${bracketTrader} is ${tokenBalance} ${symbol}`)
-        }))
-      }
-    }))
+    bracketTraderAddresses = bracketTraderAddresses.map(address => address.toLowerCase())
+    await Promise.all(
+      bracketTraderAddresses.map(async bracketTrader => {
+        const relevantOrders = auctionElementsDecoded.filter(order => order.user.toLowerCase() == bracketTrader)
+
+        if (relevantOrders.length > 0) {
+          console.log(`The orders of the bracket trader ${bracketTrader} are:`)
+          relevantOrders.forEach(order => printOrder(order, batchId))
+          let tokenSet = new Set()
+          relevantOrders.forEach(order => {
+            tokenSet.add(order.buyToken)
+            tokenSet.add(order.sellToken)
+          })
+          tokenSet = Array.from(tokenSet)
+          await Promise.all(
+            tokenSet.map(async tokenId => {
+              const tokenAddress = await exchange.tokenIdToAddressMap.call(tokenId)
+              const tokenBalance = await exchange.getBalance.call(bracketTrader, tokenAddress)
+              const erc20 = await ERC20Detailed.at(tokenAddress)
+              const symbol = await erc20.symbol.call()
+              console.log(`And the balance of the trader ${bracketTrader} is ${tokenBalance} ${symbol}`)
+            })
+          )
+        }
+      })
+    )
     callback()
   } catch (error) {
     callback(error)

--- a/scripts/get_bracket_data.js
+++ b/scripts/get_bracket_data.js
@@ -1,13 +1,16 @@
 const Contract = require("@truffle/contract")
 const { getOrdersPaginated, printOrder } = require("./utils/to_be_imported_from_dex_contracts.js")
-const { isOnlySafeOwner } = require("./utils/trading_strategy_helpers")
 
 const argv = require("yargs")
-  .option("masterSafe", {
+  .option("brackets", {
     type: "string",
-    describe: "Address of Gnosis Safe owning every bracket",
+    describe:
+      "Trader account addresses for displaying their information, they can be obtained via the script find_bracket_traders",
+    coerce: str => {
+      return str.split(",")
+    },
   })
-  .demand(["masterSafe"])
+  .demand(["brackets"])
   .help(
     "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
   )
@@ -15,38 +18,21 @@ const argv = require("yargs")
 
 module.exports = async callback => {
   try {
-    // Init params
     const ERC20Detailed = artifacts.require("ERC20Detailed")
-    const ProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
-
-    const proxyFactory = await ProxyFactory.deployed()
-    const eventData = await proxyFactory.getPastEvents("ProxyCreation", { fromBlock: 0, toBlock: "latest" })
-    const safeDeployments = eventData.map(event => event.args[0]).slice(-100)
-    //For easy rinkeby testing use:
-    //bracketTraderAddresses = ['0xc867f926392a4e55b8800afbbbad8c99efd70e49']
-    console.log("In total we have ", safeDeployments.length, " safe deployments")
-    const isDeployedByMaster = await Promise.all(
-      safeDeployments.map(async bracketTrader => await isOnlySafeOwner(argv.masterSafe, bracketTrader, artifacts))
-    )
-    let bracketTraderAddresses = safeDeployments.filter((bracketTrader, index) => isDeployedByMaster[index])
-    console.log("And ", bracketTraderAddresses.length, " safes are used for the bracket strategy of your master safe")
-
     const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
     BatchExchange.setProvider(web3.currentProvider)
     BatchExchange.setNetwork(web3.network_id)
+
+    const bracketTraderAddresses = argv.brackets.map(address => address.toLowerCase())
     const exchange = await BatchExchange.deployed()
     const batchId = (await exchange.getCurrentBatchId()).toNumber()
-
     const auctionElementsDecoded = await getOrdersPaginated(exchange, 100)
 
-    bracketTraderAddresses = bracketTraderAddresses.map(address => address.toLowerCase())
     await Promise.all(
       bracketTraderAddresses.map(async bracketTrader => {
         const relevantOrders = auctionElementsDecoded.filter(order => order.user.toLowerCase() == bracketTrader)
 
         if (relevantOrders.length > 0) {
-          console.log(`The orders of the bracket trader ${bracketTrader} are:`)
-          relevantOrders.forEach(order => printOrder(order, batchId))
           let tokenSet = new Set()
           relevantOrders.forEach(order => {
             tokenSet.add(order.buyToken)
@@ -59,7 +45,9 @@ module.exports = async callback => {
               const tokenBalance = await exchange.getBalance.call(bracketTrader, tokenAddress)
               const erc20 = await ERC20Detailed.at(tokenAddress)
               const symbol = await erc20.symbol.call()
-              console.log(`And the balance of the trader ${bracketTrader} is ${tokenBalance} ${symbol}`)
+              console.log(`The balance of the trader ${bracketTrader} is ${tokenBalance} ${symbol}`)
+              const ordersWithSameSellToken = relevantOrders.filter(order => order.sellToken == tokenId)
+              ordersWithSameSellToken.forEach(order => printOrder(order, batchId))
             })
           )
         }

--- a/scripts/get_bracket_data.js
+++ b/scripts/get_bracket_data.js
@@ -1,0 +1,79 @@
+const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")
+const Contract = require("@truffle/contract")
+const {getOrdersPaginated, printOrder} = require("./utils/to_be_imported_from_dex_contracts.js")
+const {
+  buildTransferApproveDepositFromOrders,
+  buildOrders,
+  checkSufficiencyOfBalance,
+  isOnlySafeOwner,
+} = require("./utils/trading_strategy_helpers")
+const BN = require("bn.js")
+
+const { signAndSend, promptUser } = require("./utils/sign_and_send")
+const { toErc20Units } = require("./utils/printing_tools")
+const assert = require("assert")
+
+const argv = require("yargs")
+  .option("masterSafe", {
+    type: "string",
+    describe: "Address of Gnosis Safe owning every bracket",
+  })
+  .demand(["masterSafe"])
+  .help(
+    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
+  )
+  .version(false).argv
+
+module.exports = async callback => {
+  try {
+    // Init params
+    const GnosisSafe = artifacts.require("GnosisSafe")
+    const ERC20Detailed = artifacts.require("ERC20Detailed")
+    const ProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
+
+    const masterSafe = await GnosisSafe.at(argv.masterSafe)
+    const proxyFactory = await ProxyFactory.deployed()
+    const eventData = await proxyFactory.getPastEvents( 'ProxyCreation', { fromBlock: 0, toBlock: 'latest' } )
+    const safeDeployments = eventData.map(event => event.args[0]).slice(-100)
+    //For easy rinkeby testing use:
+    //bracketTraderAddresses = ['0xc867f926392a4e55b8800afbbbad8c99efd70e49']
+    console.log("In total we have ", safeDeployments.length, " safe deployments")
+    const isDeployedByMaster = await Promise.all(safeDeployments.map(async bracketTrader =>  await isOnlySafeOwner(argv.masterSafe, bracketTrader, artifacts)))
+    bracketTraderAddresses = safeDeployments.filter( (bracketTrader, index) => isDeployedByMaster[index] )
+    console.log("And ", bracketTraderAddresses.length, " safes are used for the bracket strategy of your mastersafe")
+
+    const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
+    BatchExchange.setProvider(web3.currentProvider)
+    BatchExchange.setNetwork(web3.network_id)
+    const exchange = await BatchExchange.deployed()
+    const batchId = (await exchange.getCurrentBatchId()).toNumber()
+
+    let auctionElementsDecoded = await getOrdersPaginated(exchange, 100)
+   
+    bracketTraderAddresses = bracketTraderAddresses.map(address => address.toLowerCase())
+    await Promise.all(bracketTraderAddresses.map(async (bracketTrader) => {
+      relevantOrders = auctionElementsDecoded.filter(order => order.user.toLowerCase() == bracketTrader)
+
+      if (relevantOrders.length>0){
+        console.log(`The orders of the bracket trader ${bracketTrader} are:`)
+        relevantOrders.forEach(order => printOrder(order, batchId))
+        let tokenset = new Set()
+        relevantOrders.forEach(order => {
+          tokenset.add(order.buyToken)
+          tokenset.add(order.sellToken)
+        })
+        tokenset = Array.from(tokenset)
+        await Promise.all(tokenset.map(async (tokenId)=> {
+          const tokenAddress = await exchange.tokenIdToAddressMap.call(tokenId)
+          const tokenBalance = await exchange.getBalance.call(bracketTrader, tokenAddress)
+          const erc20 = await ERC20Detailed.at(tokenAddress)
+          const symbol = await erc20.symbol.call()
+          console.log(`And the balance of the trader ${bracketTrader} is ${tokenBalance} ${symbol}`)
+        }))
+      }
+    }))
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/scripts/utils/to_be_imported_from_dex_contracts.js
+++ b/scripts/utils/to_be_imported_from_dex_contracts.js
@@ -1,0 +1,94 @@
+const getOrdersPaginated = async (instance, pageSize) => {
+  const exchangeUtils = require("@gnosis.pm/dex-contracts")
+  let orders = []
+  let currentUser = "0x0000000000000000000000000000000000000000"
+  let currentOffSet = 0
+  let lastPageSize = pageSize
+  while (lastPageSize == pageSize) {
+    const page = exchangeUtils.decodeOrdersBN(await instance.getEncodedUsersPaginated(currentUser, currentOffSet, pageSize))
+    orders = orders.concat(page)
+    for (const index in page) {
+      if (page[index].user != currentUser) {
+        currentUser = page[index].user
+        currentOffSet = 0
+      }
+      currentOffSet += 1
+    }
+    lastPageSize = page.length
+  }
+  return orders
+}
+
+const BN = require("bn.js")
+
+
+const COLORS = {
+  NONE: "\x1b[0m",
+  RED: "\x1b[31m",
+  YELLOW: "\x1b[33m",
+}
+
+const formatAmount = function(amount) {
+  const string = amount.toString()
+  if (string.length > 4) {
+    return `${string.substring(0, 2)} * 10^${string.length - 2}`
+  } else {
+    return string
+  }
+}
+
+const colorForValidFrom = function(order, currentBatchId) {
+  let color = COLORS.NONE
+  if (order.validFrom >= currentBatchId) {
+    color = COLORS.RED
+    if (order.validFrom - 5 <= currentBatchId) {
+      color = COLORS.YELLOW
+    }
+  }
+  return color
+}
+
+const colorForValidUntil = function(order, currentBatchId) {
+  let color = COLORS.NONE
+  if (order.validUntil - 5 <= currentBatchId) {
+    color = COLORS.YELLOW
+    if (order.validUntil <= currentBatchId) {
+      color = COLORS.RED
+    }
+  }
+  return color
+}
+
+const colorForRemainingAmount = function(order) {
+  if (
+    order.priceDenominator > 0 &&
+    order.remainingAmount
+      .mul(new BN(100))
+      .div(order.priceDenominator)
+      .toNumber() < 1
+  ) {
+    return COLORS.YELLOW
+  } else {
+    return COLORS.NONE
+  }
+}
+
+const printOrder = function(order, currentBatchId) {
+  console.log("{")
+  console.log(`  user: ${order.user}`)
+  console.log(`  sellTokenBalance: ${formatAmount(order.sellTokenBalance)}`)
+  console.log(`  buyToken: ${order.buyToken}`)
+  console.log(`  sellToken: ${order.sellToken}`)
+  console.log(`  ${colorForValidFrom(order, currentBatchId)}validFrom: ${new Date(order.validFrom * 300 * 1000)}${COLORS.NONE}`)
+  console.log(
+    `  ${colorForValidUntil(order, currentBatchId)}validUntil: ${new Date(order.validUntil * 300 * 1000)}${COLORS.NONE}`
+  )
+  console.log(`  price: Sell ${formatAmount(order.priceDenominator)} for at least ${formatAmount(order.priceNumerator)}`)
+  console.log(`  ${colorForRemainingAmount(order)}remaining: ${formatAmount(order.remainingAmount)}${COLORS.NONE}`)
+  console.log("}")
+}
+
+module.exports ={
+  getOrdersPaginated,
+  printOrder
+}


### PR DESCRIPTION
closes #31 

This PR adds two scripts:
- find_bracket-traders, which investigates all deployed safes and checks whether the masterSafe is the only owner.
- get_bracket_data that plots the orders and balances of the bracket-trader

Actually, I do not find these scripts too helpful, especially since they are both soo slow. I will investigate whether we can get the current data from the graph quicker.

testplan:
```
npx truffle exec scripts/get_bracket_data.js --brackets 0x1E800A7E4b103cA2C270e162E66d1B099eC8C1A7,0x65539d12c28946831D65Bb32eEc3A33CaBFB9249  --network mainnet
```
