### PR TITLE
Optimize order creation

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -1,6 +1,8 @@
-const Contract = require("@truffle/contract")
-const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
-const { buildOrders } = require("./utils/trading_strategy_helpers")
+const {
+  getExchange,
+  getSafe,
+  buildOrders
+} = require("./utils/trading_strategy_helpers")
 const { isPriceReasonable } = require("./utils/price-utils.js")
 const { proceedAnyways } = require("./utils/user-interface-helpers")
 const { signAndSend, promptUser } = require("./utils/sign_and_send")
@@ -51,11 +53,8 @@ const argv = require("yargs")
 
 module.exports = async callback => {
   try {
-    await BatchExchange.setProvider(web3.currentProvider)
-    await BatchExchange.setNetwork(web3.network_id)
-    const exchange = await BatchExchange.deployed()
-    const GnosisSafe = artifacts.require("GnosisSafe")
-    const masterSafe = await GnosisSafe.at(argv.masterSafe)
+    const masterSafePromise = getSafe(argv.masterSafe, artifacts)
+    const exchange = await getExchange(web3)
 
     // check price against dex.ag's API
     const targetTokenId = argv.targetToken
@@ -80,7 +79,7 @@ module.exports = async callback => {
 
       const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
       if (answer == "y" || answer.toLowerCase() == "yes") {
-        await signAndSend(masterSafe, transaction, web3, argv.network)
+        await signAndSend(await masterSafePromise(), transaction, web3, argv.network)
       }
     }
 

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -140,8 +140,8 @@ function signTransaction(lw, signers, transactionHash) {
   return signatureBytes
 }
 
-const encodeMultiSend = async function(multiSend, txs, web3 = web3) {
-  return await multiSend.contract.methods
+const encodeMultiSend = function(multiSend, txs, web3 = web3) {
+  return multiSend.contract.methods
     .multiSend(
       `0x${txs
         .map(tx =>
@@ -166,7 +166,7 @@ const encodeMultiSend = async function(multiSend, txs, web3 = web3) {
 const buildBundledTransaction = async function(transactions, web3 = web3, artifacts = artifacts) {
   const MultiSend = artifacts.require("MultiSend")
   const multiSend = await MultiSend.deployed()
-  const transactionData = await encodeMultiSend(multiSend, transactions, web3)
+  const transactionData = encodeMultiSend(multiSend, transactions, web3)
   const bundledTransaction = {
     operation: DELEGATECALL,
     to: multiSend.address,
@@ -176,14 +176,14 @@ const buildBundledTransaction = async function(transactions, web3 = web3, artifa
   return bundledTransaction
 }
 
-const execTransactionData = async function(gnosisSafeMasterCopy, owner, transaction) {
+const execTransactionData = function(gnosisSafeMasterCopy, owner, transaction) {
   const sigs =
     "0x" +
     "000000000000000000000000" +
     owner.replace("0x", "") +
     "0000000000000000000000000000000000000000000000000000000000000000" +
     "01"
-  return await gnosisSafeMasterCopy.contract.methods
+  return gnosisSafeMasterCopy.contract.methods
     .execTransaction(
       transaction.to,
       transaction.value,


### PR DESCRIPTION
This applies the techniques from PR #72 to order creation.

We could prepare the orders while the user is deciding what to answer in the price check failed prompt. The reason I decided not to do it is logging: if I directly did that with the current code, the user would see the prompts and then information for each order being printed on top of the prompt.
Possible solutions are:
1. Separate order generation and order printing. With this solution we risk that the printed output doesn't match the real order.
2. Isolate the creation of order parameters is a single function and use this function directly to print order information. But this looked messy and redundant.
3. Return log as part of the output. This is very inconsistent with the rest of the code and should be done in case in a different PR.
4. Have a global "log" object that is retrieved when needed. This would create a new global object to keep track of, and would probably become confusing to use very quickly.

How do we want to tackle this?