### PR TITLE
Clean up artifacts and web3

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -3,7 +3,7 @@ const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts
 const { buildOrders } = require("./utils/trading_strategy_helpers")
 const { isPriceReasonable } = require("./utils/price-utils.js")(web3, artifacts)
 const { proceedAnyways } = require("./utils/user-interface-helpers")
-const { signAndSend, promptUser } = require("./utils/sign_and_send")
+const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 
 const argv = require("yargs")
   .option("targetToken", {

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -1,7 +1,7 @@
 const Contract = require("@truffle/contract")
 const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
 const { buildOrders } = require("./utils/trading_strategy_helpers")
-const { isPriceReasonable } = require("./utils/price-utils.js")
+const { isPriceReasonable } = require("./utils/price-utils.js")(web3, artifacts)
 const { proceedAnyways } = require("./utils/user-interface-helpers")
 const { signAndSend, promptUser } = require("./utils/sign_and_send")
 
@@ -60,7 +60,7 @@ module.exports = async callback => {
     // check price against dex.ag's API
     const targetTokenId = argv.targetToken
     const stableTokenId = argv.stableToken
-    const priceCheck = await isPriceReasonable(exchange, targetTokenId, stableTokenId, argv.targetPrice, artifacts)
+    const priceCheck = await isPriceReasonable(exchange, targetTokenId, stableTokenId, argv.targetPrice)
 
     if (priceCheck || (await proceedAnyways("Price check failed!"))) {
       console.log("Preparing order transaction data")

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -1,6 +1,6 @@
 const Contract = require("@truffle/contract")
 const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
-const { buildOrders } = require("./utils/trading_strategy_helpers")
+const { buildOrders } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { isPriceReasonable } = require("./utils/price-utils.js")(web3, artifacts)
 const { proceedAnyways } = require("./utils/user-interface-helpers")
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
@@ -70,8 +70,6 @@ module.exports = async callback => {
         argv.targetToken,
         argv.stableToken,
         argv.targetPrice,
-        web3,
-        artifacts,
         true,
         argv.priceRange,
         argv.validFrom,

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -1,4 +1,4 @@
-const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")
+const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { isPriceReasonable } = require("./utils/price-utils")(web3, artifacts)
 const Contract = require("@truffle/contract")
 const {
@@ -86,7 +86,7 @@ module.exports = async callback => {
     }
 
     console.log(`2. Deploying ${argv.fleetSize} trading brackets`)
-    const bracketAddresses = await deployFleetOfSafes(masterSafe.address, argv.fleetSize, artifacts, true)
+    const bracketAddresses = await deployFleetOfSafes(masterSafe.address, argv.fleetSize, true)
     console.log("Following bracket-traders have been deployed", bracketAddresses.join())
 
     console.log("3. Building orders and deposits")
@@ -96,8 +96,6 @@ module.exports = async callback => {
       argv.targetToken,
       argv.stableToken,
       argv.targetPrice,
-      web3,
-      artifacts,
       true,
       argv.priceRangePercentage
     )
@@ -108,8 +106,6 @@ module.exports = async callback => {
       investmentStableToken,
       targetToken.address,
       investmentTargetToken,
-      artifacts,
-      web3,
       true
     )
 

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -6,7 +6,7 @@ const {
   buildOrders,
   checkSufficiencyOfBalance,
 } = require("./utils/trading_strategy_helpers")
-const { signAndSend, promptUser } = require("./utils/sign_and_send")
+const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 const { proceedAnyways } = require("./utils/user-interface-helpers")
 
 const { toErc20Units } = require("./utils/printing_tools")

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -1,5 +1,5 @@
 const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")
-const { isPriceReasonable } = require("./utils/price-utils")
+const { isPriceReasonable } = require("./utils/price-utils")(web3, artifacts)
 const Contract = require("@truffle/contract")
 const {
   buildTransferApproveDepositFromOrders,
@@ -77,7 +77,7 @@ module.exports = async callback => {
     // check price against dex.ag's API
     const targetTokenId = argv.targetToken
     const stableTokenId = argv.stableToken
-    const priceCheck = await isPriceReasonable(exchange, targetTokenId, stableTokenId, argv.targetPrice, artifacts)
+    const priceCheck = await isPriceReasonable(exchange, targetTokenId, stableTokenId, argv.targetPrice)
 
     if (!priceCheck) {
       if (!(await proceedAnyways("Price check failed!"))) {

--- a/scripts/deploy_safes.js
+++ b/scripts/deploy_safes.js
@@ -1,4 +1,4 @@
-const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")
+const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 
 const argv = require("yargs")
   .option("masterSafe", {
@@ -19,7 +19,7 @@ module.exports = async callback => {
   try {
     console.log("Master Safe:", argv.masterSafe)
     console.log(`Deploying a fleet of Safes of size ${argv.fleetSize}`)
-    const fleet = await deployFleetOfSafes(argv.masterSafe, argv.fleetSize, artifacts, true)
+    const fleet = await deployFleetOfSafes(argv.masterSafe, argv.fleetSize, true)
     console.log(" Addresses", fleet.join())
     callback()
   } catch (error) {

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -1,5 +1,5 @@
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
-const { buildTransferApproveDepositFromList } = require("./utils/trading_strategy_helpers")
+const { buildTransferApproveDepositFromList } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 
 const argv = require("yargs")
   .option("masterSafe", {
@@ -24,7 +24,7 @@ module.exports = async callback => {
     const deposits = require(argv.depositFile)
     // TODO - make a simpler to construct deposit file style
     console.log("Preparing transaction data...")
-    const transaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits, web3, artifacts, true)
+    const transaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits, true)
 
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -1,4 +1,4 @@
-const { signAndSend, promptUser } = require("./utils/sign_and_send")
+const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 const { buildTransferApproveDepositFromList } = require("./utils/trading_strategy_helpers")
 
 const argv = require("yargs")

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -1,190 +1,66 @@
-const util = require("util")
-const lightwallet = require("eth-lightwallet")
-const assert = require("assert")
-const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
-const CALL = 0
-const DELEGATECALL = 1
+module.exports = function(web3 = web3, artifacts = artifacts) {
+  const util = require("util")
+  const lightwallet = require("eth-lightwallet")
+  const assert = require("assert")
+  const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
+  const CALL = 0
+  const DELEGATECALL = 1
 
-/**
- * @typedef Transaction
- *  * Example:
- *  {
- *    operation: CALL,
- *    to: "0x0000..000",
- *    value: "10",
- *    data: "0x00",
- *  }
- * @type {object}
- * @property {int} operation Either CALL or DELEGATECALL
- * @property {EthereumAddress} to Ethereum address receiving the transaction
- * @property {string} value Amount of ETH transferred
- * @property {string} data Data sent along with the transaction
- */
+  /**
+   * @typedef Transaction
+   *  * Example:
+   *  {
+   *    operation: CALL,
+   *    to: "0x0000..000",
+   *    value: "10",
+   *    data: "0x00",
+   *  }
+   * @type {object}
+   * @property {int} operation Either CALL or DELEGATECALL
+   * @property {EthereumAddress} to Ethereum address receiving the transaction
+   * @property {string} value Amount of ETH transferred
+   * @property {string} data Data sent along with the transaction
+   */
 
-const jsonrpc = "2.0"
-const id = 0
-const send = function(method, params, web3Provider) {
-  return new Promise(function(resolve, reject) {
-    web3Provider.currentProvider.send({ id, jsonrpc, method, params }, (error, result) => {
-      if (error) {
-        reject(error)
-      } else {
-        resolve(result)
-      }
+  const jsonrpc = "2.0"
+  const id = 0
+  const send = function(method, params, web3Provider) {
+    return new Promise(function(resolve, reject) {
+      web3Provider.currentProvider.send({ id, jsonrpc, method, params }, (error, result) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve(result)
+        }
+      })
     })
-  })
-}
-
-/**
- * Wait for n (evm) seconds to pass
- * @param seconds: int
- * @param web3Provider: potentially different in contract tests and system end-to-end testing.
- */
-const waitForNSeconds = async function(seconds, web3Provider = web3) {
-  await send("evm_increaseTime", [seconds], web3Provider)
-  await send("evm_mine", [], web3Provider)
-}
-
-const execTransaction = async function(safe, lightWallet, transaction) {
-  const nonce = await safe.nonce()
-  const transactionHash = await safe.getTransactionHash(
-    transaction.to,
-    transaction.value,
-    transaction.data,
-    transaction.operation,
-    0,
-    0,
-    0,
-    ADDRESS_0,
-    ADDRESS_0,
-    nonce
-  )
-  const sigs = signTransaction(lightWallet, [lightWallet.accounts[0], lightWallet.accounts[1]], transactionHash)
-  await safe.execTransaction(
-    transaction.to,
-    transaction.value,
-    transaction.data,
-    transaction.operation,
-    0,
-    0,
-    0,
-    ADDRESS_0,
-    ADDRESS_0,
-    sigs
-  )
-}
-
-const deploySafe = async function(gnosisSafeMasterCopy, proxyFactory, owners, threshold, artifacts = artifacts) {
-  const GnosisSafe = artifacts.require("GnosisSafe.sol")
-
-  const initData = await gnosisSafeMasterCopy.contract.methods
-    .setup(owners, threshold, ADDRESS_0, "0x", ADDRESS_0, ADDRESS_0, 0, ADDRESS_0)
-    .encodeABI()
-  const transaction = await proxyFactory.createProxy(gnosisSafeMasterCopy.address, initData)
-  // waiting two second to make sure infura can catch up
-  await sleep(1000)
-  return await getParamFromTxEvent(transaction, "ProxyCreation", "proxy", proxyFactory.address, GnosisSafe, null)
-}
-
-const sleep = function(milliseconds) {
-  return new Promise(r => setTimeout(r, milliseconds))
-}
-
-// Need some small adjustments to default implementation for web3js 1.x
-async function getParamFromTxEvent(transaction, eventName, paramName, contract, contractFactory, subject) {
-  // assert.isObject(transaction)
-  if (subject != null) {
-    logGasUsage(subject, transaction)
   }
-  let logs = transaction.logs
-  if (eventName != null) {
-    logs = logs.filter(l => l.event === eventName && l.address === contract)
-  }
-  assert.equal(logs.length, 1, "too many logs found!")
-  const param = logs[0].args[paramName]
-  if (contractFactory != null) {
-    // Adjustment: add await
-    const contract = await contractFactory.at(param)
-    // assert.isObject(contract, `getting ${paramName} failed for ${param}`)
-    return contract
-  } else {
-    return param
-  }
-}
 
-async function createLightwallet() {
-  // Create lightwallet accounts
-  const createVault = util.promisify(lightwallet.keystore.createVault).bind(lightwallet.keystore)
-  const keystore = await createVault({
-    hdPathString: "m/44'/60'/0'/0",
-    seedPhrase: "myth like bonus scare over problem client lizard pioneer submit female collect",
-    password: "test",
-    salt: "testsalt",
-  })
-  const keyFromPassword = await util.promisify(keystore.keyFromPassword).bind(keystore)("test")
-  keystore.generateNewAddress(keyFromPassword, 20)
-  return {
-    keystore: keystore,
-    accounts: keystore.getAddresses(),
-    passwords: keyFromPassword,
+  /**
+   * Wait for n (evm) seconds to pass
+   * @param seconds: int
+   */
+  const waitForNSeconds = async function(seconds) {
+    await send("evm_increaseTime", [seconds], web3)
+    await send("evm_mine", [], web3)
   }
-}
 
-function signTransaction(lw, signers, transactionHash) {
-  let signatureBytes = "0x"
-  signers.sort()
-  for (let i = 0; i < signers.length; i++) {
-    const sig = lightwallet.signing.signMsgHash(lw.keystore, lw.passwords, transactionHash, signers[i])
-    signatureBytes += sig.r.toString("hex") + sig.s.toString("hex") + sig.v.toString(16)
-  }
-  return signatureBytes
-}
-
-const encodeMultiSend = async function(multiSend, txs, web3 = web3) {
-  return await multiSend.contract.methods
-    .multiSend(
-      `0x${txs
-        .map(tx =>
-          [
-            web3.eth.abi.encodeParameter("uint8", tx.operation).slice(-2),
-            web3.eth.abi.encodeParameter("address", tx.to).slice(-40),
-            web3.eth.abi.encodeParameter("uint256", tx.value).slice(-64),
-            web3.eth.abi.encodeParameter("uint256", web3.utils.hexToBytes(tx.data).length).slice(-64),
-            tx.data.replace(/^0x/, ""),
-          ].join("")
-        )
-        .join("")}`
+  const execTransaction = async function(safe, lightWallet, transaction) {
+    const nonce = await safe.nonce()
+    const transactionHash = await safe.getTransactionHash(
+      transaction.to,
+      transaction.value,
+      transaction.data,
+      transaction.operation,
+      0,
+      0,
+      0,
+      ADDRESS_0,
+      ADDRESS_0,
+      nonce
     )
-    .encodeABI()
-}
-
-/**
- * Given a collection of transactions, creates a single transaction that bundles all of them
- * @param {Transaction[]} transactions List of {@link Transaction} that are to be bundled together
- * @return {Transaction} Multisend transaction bundling all input transactions
- */
-const buildBundledTransaction = async function(transactions, web3 = web3, artifacts = artifacts) {
-  const MultiSend = artifacts.require("MultiSend")
-  const multiSend = await MultiSend.deployed()
-  const transactionData = await encodeMultiSend(multiSend, transactions, web3)
-  const bundledTransaction = {
-    operation: DELEGATECALL,
-    to: multiSend.address,
-    value: 0,
-    data: transactionData,
-  }
-  return bundledTransaction
-}
-
-const execTransactionData = async function(gnosisSafeMasterCopy, owner, transaction) {
-  const sigs =
-    "0x" +
-    "000000000000000000000000" +
-    owner.replace("0x", "") +
-    "0000000000000000000000000000000000000000000000000000000000000000" +
-    "01"
-  return await gnosisSafeMasterCopy.contract.methods
-    .execTransaction(
+    const sigs = signTransaction(lightWallet, [lightWallet.accounts[0], lightWallet.accounts[1]], transactionHash)
+    await safe.execTransaction(
       transaction.to,
       transaction.value,
       transaction.data,
@@ -196,44 +72,169 @@ const execTransactionData = async function(gnosisSafeMasterCopy, owner, transact
       ADDRESS_0,
       sigs
     )
-    .encodeABI()
-}
-
-/**
- * Creates a transaction that makes a master Safe execute a transaction on behalf of a (single-owner) owned trader using execTransaction
- * @param {EthereumAddress} masterAddress Address of a controlled Safe
- * @param {EthereumAddress} bracketAddress Address of a Safe, owned only by master, target of execTransaction
- * @param {Transaction} transaction The transaction to be executed by execTransaction
- * @return {Transaction} Transaction calling execTransaction; should be executed by master
- */
-const buildExecTransaction = async function(masterAddress, bracketAddress, transaction, artifacts) {
-  const GnosisSafe = artifacts.require("GnosisSafe")
-  const gnosisSafeMasterCopy = await GnosisSafe.deployed()
-
-  const execData = await execTransactionData(gnosisSafeMasterCopy, masterAddress, transaction)
-  const execTransaction = {
-    operation: CALL,
-    to: bracketAddress,
-    value: 0,
-    data: execData,
   }
-  return execTransaction
-}
 
-function logGasUsage(subject, transactionOrReceipt) {
-  const receipt = transactionOrReceipt.receipt || transactionOrReceipt
-  console.log("    Gas costs for " + subject + ": " + receipt.gasUsed)
-}
+  const deploySafe = async function(gnosisSafeMasterCopy, proxyFactory, owners, threshold) {
+    const GnosisSafe = artifacts.require("GnosisSafe.sol")
 
-module.exports = {
-  waitForNSeconds,
-  execTransaction,
-  deploySafe,
-  encodeMultiSend,
-  createLightwallet,
-  signTransaction,
-  buildBundledTransaction,
-  buildExecTransaction,
-  CALL,
-  ADDRESS_0,
+    const initData = await gnosisSafeMasterCopy.contract.methods
+      .setup(owners, threshold, ADDRESS_0, "0x", ADDRESS_0, ADDRESS_0, 0, ADDRESS_0)
+      .encodeABI()
+    const transaction = await proxyFactory.createProxy(gnosisSafeMasterCopy.address, initData)
+    // waiting two second to make sure infura can catch up
+    await sleep(1000)
+    return await getParamFromTxEvent(transaction, "ProxyCreation", "proxy", proxyFactory.address, GnosisSafe, null)
+  }
+
+  const sleep = function(milliseconds) {
+    return new Promise(r => setTimeout(r, milliseconds))
+  }
+
+  // Need some small adjustments to default implementation for web3js 1.x
+  async function getParamFromTxEvent(transaction, eventName, paramName, contract, contractFactory, subject) {
+    // assert.isObject(transaction)
+    if (subject != null) {
+      logGasUsage(subject, transaction)
+    }
+    let logs = transaction.logs
+    if (eventName != null) {
+      logs = logs.filter(l => l.event === eventName && l.address === contract)
+    }
+    assert.equal(logs.length, 1, "too many logs found!")
+    const param = logs[0].args[paramName]
+    if (contractFactory != null) {
+      // Adjustment: add await
+      const contract = await contractFactory.at(param)
+      // assert.isObject(contract, `getting ${paramName} failed for ${param}`)
+      return contract
+    } else {
+      return param
+    }
+  }
+
+  async function createLightwallet() {
+    // Create lightwallet accounts
+    const createVault = util.promisify(lightwallet.keystore.createVault).bind(lightwallet.keystore)
+    const keystore = await createVault({
+      hdPathString: "m/44'/60'/0'/0",
+      seedPhrase: "myth like bonus scare over problem client lizard pioneer submit female collect",
+      password: "test",
+      salt: "testsalt",
+    })
+    const keyFromPassword = await util.promisify(keystore.keyFromPassword).bind(keystore)("test")
+    keystore.generateNewAddress(keyFromPassword, 20)
+    return {
+      keystore: keystore,
+      accounts: keystore.getAddresses(),
+      passwords: keyFromPassword,
+    }
+  }
+
+  function signTransaction(lw, signers, transactionHash) {
+    let signatureBytes = "0x"
+    signers.sort()
+    for (let i = 0; i < signers.length; i++) {
+      const sig = lightwallet.signing.signMsgHash(lw.keystore, lw.passwords, transactionHash, signers[i])
+      signatureBytes += sig.r.toString("hex") + sig.s.toString("hex") + sig.v.toString(16)
+    }
+    return signatureBytes
+  }
+
+  const encodeMultiSend = async function(multiSend, txs, web3 = web3) {
+    return await multiSend.contract.methods
+      .multiSend(
+        `0x${txs
+          .map(tx =>
+            [
+              web3.eth.abi.encodeParameter("uint8", tx.operation).slice(-2),
+              web3.eth.abi.encodeParameter("address", tx.to).slice(-40),
+              web3.eth.abi.encodeParameter("uint256", tx.value).slice(-64),
+              web3.eth.abi.encodeParameter("uint256", web3.utils.hexToBytes(tx.data).length).slice(-64),
+              tx.data.replace(/^0x/, ""),
+            ].join("")
+          )
+          .join("")}`
+      )
+      .encodeABI()
+  }
+
+  /**
+   * Given a collection of transactions, creates a single transaction that bundles all of them
+   * @param {Transaction[]} transactions List of {@link Transaction} that are to be bundled together
+   * @return {Transaction} Multisend transaction bundling all input transactions
+   */
+  const buildBundledTransaction = async function(transactions) {
+    const MultiSend = artifacts.require("MultiSend")
+    const multiSend = await MultiSend.deployed()
+    const transactionData = await encodeMultiSend(multiSend, transactions, web3)
+    const bundledTransaction = {
+      operation: DELEGATECALL,
+      to: multiSend.address,
+      value: 0,
+      data: transactionData,
+    }
+    return bundledTransaction
+  }
+
+  const execTransactionData = async function(gnosisSafeMasterCopy, owner, transaction) {
+    const sigs =
+      "0x" +
+      "000000000000000000000000" +
+      owner.replace("0x", "") +
+      "0000000000000000000000000000000000000000000000000000000000000000" +
+      "01"
+    return await gnosisSafeMasterCopy.contract.methods
+      .execTransaction(
+        transaction.to,
+        transaction.value,
+        transaction.data,
+        transaction.operation,
+        0,
+        0,
+        0,
+        ADDRESS_0,
+        ADDRESS_0,
+        sigs
+      )
+      .encodeABI()
+  }
+
+  /**
+   * Creates a transaction that makes a master Safe execute a transaction on behalf of a (single-owner) owned trader using execTransaction
+   * @param {EthereumAddress} masterAddress Address of a controlled Safe
+   * @param {EthereumAddress} bracketAddress Address of a Safe, owned only by master, target of execTransaction
+   * @param {Transaction} transaction The transaction to be executed by execTransaction
+   * @return {Transaction} Transaction calling execTransaction; should be executed by master
+   */
+  const buildExecTransaction = async function(masterAddress, bracketAddress, transaction) {
+    const GnosisSafe = artifacts.require("GnosisSafe")
+    const gnosisSafeMasterCopy = await GnosisSafe.deployed()
+
+    const execData = await execTransactionData(gnosisSafeMasterCopy, masterAddress, transaction)
+    const execTransaction = {
+      operation: CALL,
+      to: bracketAddress,
+      value: 0,
+      data: execData,
+    }
+    return execTransaction
+  }
+
+  function logGasUsage(subject, transactionOrReceipt) {
+    const receipt = transactionOrReceipt.receipt || transactionOrReceipt
+    console.log("    Gas costs for " + subject + ": " + receipt.gasUsed)
+  }
+
+  return {
+    waitForNSeconds,
+    execTransaction,
+    deploySafe,
+    encodeMultiSend,
+    createLightwallet,
+    signTransaction,
+    buildBundledTransaction,
+    buildExecTransaction,
+    CALL,
+    ADDRESS_0,
+  }
 }

--- a/scripts/utils/price-utils.js
+++ b/scripts/utils/price-utils.js
@@ -1,6 +1,6 @@
 module.exports = function(web3 = web3, artifacts = artifacts) {
   const axios = require("axios")
-  const { fetchTokenInfoFromExchange } = require("./trading_strategy_helpers")
+  const { fetchTokenInfoFromExchange } = require("./trading_strategy_helpers")(web3, artifacts)
 
   // returns undefined if the price was not available
   const getDexagPrice = async function(tokenBought, tokenSold) {
@@ -27,7 +27,7 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
     price,
     acceptedPriceDeviationInPercentage = 2
   ) => {
-    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId], artifacts)
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId])
     const targetToken = await tokenInfoPromises[targetTokenId]
     const stableToken = await tokenInfoPromises[stableTokenId]
     const dexagPrice = await getDexagPrice(stableToken.symbol, targetToken.symbol)

--- a/scripts/utils/price-utils.js
+++ b/scripts/utils/price-utils.js
@@ -1,52 +1,53 @@
-const axios = require("axios")
-const { fetchTokenInfoFromExchange } = require("./trading_strategy_helpers")
+module.exports = function(web3 = web3, artifacts = artifacts) {
+  const axios = require("axios")
+  const { fetchTokenInfoFromExchange } = require("./trading_strategy_helpers")
 
-// returns undefined if the price was not available
-const getDexagPrice = async function(tokenBought, tokenSold) {
-  // dex.ag considers WETH to be the same as ETH and fails when using WETH as token
-  tokenBought = tokenBought == "WETH" ? "ETH" : tokenBought
-  tokenSold = tokenSold == "WETH" ? "ETH" : tokenSold
-  // see https://docs.dex.ag/ for API documentation
-  const url = "https://api-v2.dex.ag/price?from=" + tokenSold + "&to=" + tokenBought + "&fromAmount=1&dex=ag"
-  let price
-  try {
-    const requestResult = await axios.get(url)
-    price = requestResult.data.price
-  } catch (error) {
-    console.log("Warning: unable to retrieve price information on dex.ag. The server returns:")
-    console.log(">", error.response.data.error)
+  // returns undefined if the price was not available
+  const getDexagPrice = async function(tokenBought, tokenSold) {
+    // dex.ag considers WETH to be the same as ETH and fails when using WETH as token
+    tokenBought = tokenBought == "WETH" ? "ETH" : tokenBought
+    tokenSold = tokenSold == "WETH" ? "ETH" : tokenSold
+    // see https://docs.dex.ag/ for API documentation
+    const url = "https://api-v2.dex.ag/price?from=" + tokenSold + "&to=" + tokenBought + "&fromAmount=1&dex=ag"
+    let price
+    try {
+      const requestResult = await axios.get(url)
+      price = requestResult.data.price
+    } catch (error) {
+      console.log("Warning: unable to retrieve price information on dex.ag. The server returns:")
+      console.log(">", error.response.data.error)
+    }
+    return price
   }
-  return price
-}
 
-const isPriceReasonable = async (
-  exchange,
-  targetTokenId,
-  stableTokenId,
-  price,
-  artifacts = artifacts,
-  acceptedPriceDeviationInPercentage = 2
-) => {
-  const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId], artifacts)
-  const targetToken = await tokenInfoPromises[targetTokenId]
-  const stableToken = await tokenInfoPromises[stableTokenId]
-  const dexagPrice = await getDexagPrice(stableToken.symbol, targetToken.symbol)
-  if (dexagPrice === undefined) {
-    console.log("Warning: could not perform price check against dex.ag.")
-    return false
-  } else if (Math.abs(dexagPrice - price) / price >= acceptedPriceDeviationInPercentage / 100) {
-    console.log(
-      "Warning: the chosen price differs by more than",
-      acceptedPriceDeviationInPercentage,
-      "percent from the price found on dex.ag."
-    )
-    console.log("         chosen price:", price, stableToken.symbol, "bought for 1", targetToken.symbol)
-    console.log("         dex.ag price:", dexagPrice, stableToken.symbol, "bought for 1", targetToken.symbol)
-    return false
+  const isPriceReasonable = async (
+    exchange,
+    targetTokenId,
+    stableTokenId,
+    price,
+    acceptedPriceDeviationInPercentage = 2
+  ) => {
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId], artifacts)
+    const targetToken = await tokenInfoPromises[targetTokenId]
+    const stableToken = await tokenInfoPromises[stableTokenId]
+    const dexagPrice = await getDexagPrice(stableToken.symbol, targetToken.symbol)
+    if (dexagPrice === undefined) {
+      console.log("Warning: could not perform price check against dex.ag.")
+      return false
+    } else if (Math.abs(dexagPrice - price) / price >= acceptedPriceDeviationInPercentage / 100) {
+      console.log(
+        "Warning: the chosen price differs by more than",
+        acceptedPriceDeviationInPercentage,
+        "percent from the price found on dex.ag."
+      )
+      console.log("         chosen price:", price, stableToken.symbol, "bought for 1", targetToken.symbol)
+      console.log("         dex.ag price:", dexagPrice, stableToken.symbol, "bought for 1", targetToken.symbol)
+      return false
+    }
+    return true
   }
-  return true
-}
 
-module.exports = {
-  isPriceReasonable,
+  return {
+    isPriceReasonable,
+  }
 }

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -1,73 +1,75 @@
-const axios = require("axios")
-const { ADDRESS_0 } = require("./trading_strategy_helpers")
-const { signTransaction, createLightwallet } = require("../utils/internals")
+module.exports =  function(web3 = web3, artifacts = artifacts) {
+  const axios = require("axios")
+  const { ADDRESS_0 } = require("./trading_strategy_helpers")(web3, artifacts)
+  const { signTransaction, createLightwallet } = require("../utils/internals")(web3, artifacts)
 
-const readline = require("readline")
+  const readline = require("readline")
 
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-})
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
 
-const linkPrefix = {
-  rinkeby: "rinkeby.",
-  mainnet: "",
-}
-
-const promptUser = function(message) {
-  return new Promise(resolve => rl.question(message, answer => resolve(answer)))
-}
-
-/**
- * Signs and sends the transaction to the gnosis-safe UI
- * @param {Address} masterAddress Address of the master safe owning the brackets
- * @param {Transaction} transaction The transaction to be signed and sent
- */
-const signAndSend = async function(masterSafe, transaction, web3, network) {
-  const nonce = await masterSafe.nonce()
-  console.log("Aquiring Transaction Hash")
-  const transactionHash = await masterSafe.getTransactionHash(
-    transaction.to,
-    transaction.value,
-    transaction.data,
-    transaction.operation,
-    0,
-    0,
-    0,
-    ADDRESS_0,
-    ADDRESS_0,
-    nonce
-  )
-  const lightWallet = await createLightwallet()
-  const account = lightWallet.accounts[0]
-  console.log(`Signing and posting multi-send transaction request from proposer account ${account}`)
-  const sigs = signTransaction(lightWallet, [account], transactionHash)
-
-  const endpoint = `https://safe-transaction.${network}.gnosis.io/api/v1/safes/${masterSafe.address}/transactions/`
-  const postData = {
-    to: transaction.to,
-    value: transaction.value,
-    data: transaction.data,
-    operation: transaction.operation,
-    safeTxGas: 0, // TODO: magic later
-    baseGas: 0,
-    gasPrice: 0, // important that this is zero
-    gasToken: ADDRESS_0,
-    refundReceiver: ADDRESS_0,
-    nonce: nonce.toNumber(),
-    contractTransactionHash: transactionHash,
-    sender: web3.utils.toChecksumAddress(account),
-    signature: sigs,
+  const linkPrefix = {
+    rinkeby: "rinkeby.",
+    mainnet: "",
   }
-  await axios.post(endpoint, postData)
 
-  const interfaceLink = `https://${linkPrefix[network]}gnosis-safe.io/app/#/safes/${masterSafe.address}/transactions`
-  console.log(
-    "Transaction awaiting execution in the interface", interfaceLink
-  )
-}
+  const promptUser = function(message) {
+    return new Promise(resolve => rl.question(message, answer => resolve(answer)))
+  }
 
-module.exports = {
-  signAndSend,
-  promptUser,
+  /**
+   * Signs and sends the transaction to the gnosis-safe UI
+   * @param {Address} masterAddress Address of the master safe owning the brackets
+   * @param {Transaction} transaction The transaction to be signed and sent
+   */
+  const signAndSend = async function(masterSafe, transaction, network) {
+    const nonce = await masterSafe.nonce()
+    console.log("Aquiring Transaction Hash")
+    const transactionHash = await masterSafe.getTransactionHash(
+      transaction.to,
+      transaction.value,
+      transaction.data,
+      transaction.operation,
+      0,
+      0,
+      0,
+      ADDRESS_0,
+      ADDRESS_0,
+      nonce
+    )
+    const lightWallet = await createLightwallet()
+    const account = lightWallet.accounts[0]
+    console.log(`Signing and posting multi-send transaction request from proposer account ${account}`)
+    const sigs = signTransaction(lightWallet, [account], transactionHash)
+
+    const endpoint = `https://safe-transaction.${network}.gnosis.io/api/v1/safes/${masterSafe.address}/transactions/`
+    const postData = {
+      to: transaction.to,
+      value: transaction.value,
+      data: transaction.data,
+      operation: transaction.operation,
+      safeTxGas: 0, // TODO: magic later
+      baseGas: 0,
+      gasPrice: 0, // important that this is zero
+      gasToken: ADDRESS_0,
+      refundReceiver: ADDRESS_0,
+      nonce: nonce.toNumber(),
+      contractTransactionHash: transactionHash,
+      sender: web3.utils.toChecksumAddress(account),
+      signature: sigs,
+    }
+    await axios.post(endpoint, postData)
+
+    const interfaceLink = `https://${linkPrefix[network]}gnosis-safe.io/app/#/safes/${masterSafe.address}/transactions`
+    console.log(
+      "Transaction awaiting execution in the interface", interfaceLink
+    )
+  }
+
+  return {
+    signAndSend,
+    promptUser,
+  }
 }

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -1,77 +1,77 @@
-//module.exports = function(web3 = web3, artifacts = artifacts) {
-const Contract = require("@truffle/contract")
-const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
+module.exports = function(web3 = web3, artifacts = artifacts) {
+  const Contract = require("@truffle/contract")
+  const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
 
-const assert = require("assert")
-const BN = require("bn.js")
-const fs = require("fs")
-const { deploySafe, buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")(web3, artifacts)
-const { shortenedAddress, fromErc20Units, toErc20Units } = require("./printing_tools")
-const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
-const maxU32 = 2 ** 32 - 1
-const max128 = new BN(2).pow(new BN(128)).subn(1)
-const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))
+  const assert = require("assert")
+  const BN = require("bn.js")
+  const fs = require("fs")
+  const { deploySafe, buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")(web3, artifacts)
+  const { shortenedAddress, fromErc20Units, toErc20Units } = require("./printing_tools")
+  const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
+  const maxU32 = 2 ** 32 - 1
+  const max128 = new BN(2).pow(new BN(128)).subn(1)
+  const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))
 
-/**
- * Ethereum addresses are composed of the prefix "0x", a common identifier for hexadecimal,
- * concatenated with the rightmost 20 bytes of the Keccak-256 hash (big endian) of the ECDSA public key
- * (cf. https://en.wikipedia.org/wiki/Ethereum#Addresses)
- * @typedef Address
- */
+  /**
+   * Ethereum addresses are composed of the prefix "0x", a common identifier for hexadecimal,
+   * concatenated with the rightmost 20 bytes of the Keccak-256 hash (big endian) of the ECDSA public key
+   * (cf. https://en.wikipedia.org/wiki/Ethereum#Addresses)
+   * @typedef Address
+   */
 
-/**
- * Smart contracts are high-level programming abstractions that are compiled down
- * to EVM bytecode and deployed to the Ethereum blockchain for execution.
- * This particular type is that of a JS object representing the Smart contract ABI.
- * (cf. https://en.wikipedia.org/wiki/Ethereum#Smart_contracts)
- * @typedef SmartContract
- */
+  /**
+   * Smart contracts are high-level programming abstractions that are compiled down
+   * to EVM bytecode and deployed to the Ethereum blockchain for execution.
+   * This particular type is that of a JS object representing the Smart contract ABI.
+   * (cf. https://en.wikipedia.org/wiki/Ethereum#Smart_contracts)
+   * @typedef SmartContract
+   */
 
-/**
- * @typedef TokenObject
- *  * Example:
- * {
- *   id: 0,
- *   address: 0x0000000000000000000000000000000000000000,
- *   symbol: "OWL",
- *   decimals: 18,
- * }
- * @type {object}
- * @property {integer} id integer denoting the id of the token on BatchExchange
- * @property {Address} address Hex string denoting the ethereum address of token
- * @property {string} symbol short, usually abbreviated, token name
- * @property {integer} decimals number of decmial places token uses for a Unit
- */
+  /**
+   * @typedef TokenObject
+   *  * Example:
+   * {
+   *   id: 0,
+   *   address: 0x0000000000000000000000000000000000000000,
+   *   symbol: "OWL",
+   *   decimals: 18,
+   * }
+   * @type {object}
+   * @property {integer} id integer denoting the id of the token on BatchExchange
+   * @property {Address} address Hex string denoting the ethereum address of token
+   * @property {string} symbol short, usually abbreviated, token name
+   * @property {integer} decimals number of decmial places token uses for a Unit
+   */
 
-/**
- * Example:
- * {
- *   amount: 100,
- *   tokenAddress: 0x0000000000000000000000000000000000000000,
- *   bracketAddress: 0x0000000000000000000000000000000000000001
- * }
- * @typedef Deposit
- * @type {object}
- * @property {integer} amount integer denoting amount to be deposited
- * @property {Address} tokenAddress {@link Address} of token to be deposited
- * @property {Address} bracketAddress address of bracket into which to deposit
- */
+  /**
+   * Example:
+   * {
+   *   amount: 100,
+   *   tokenAddress: 0x0000000000000000000000000000000000000000,
+   *   bracketAddress: 0x0000000000000000000000000000000000000001
+   * }
+   * @typedef Deposit
+   * @type {object}
+   * @property {integer} amount integer denoting amount to be deposited
+   * @property {Address} tokenAddress {@link Address} of token to be deposited
+   * @property {Address} bracketAddress address of bracket into which to deposit
+   */
 
-/**
- * @typedef Withdrawal
- *  * Example:
- * {
- *   amount: "100",
- *   bracketAddress: "0x0000000000000000000000000000000000000000",
- *   tokenAddress: "0x0000000000000000000000000000000000000000",
- * }
- * @type {object}
- * @property {integer} amount Integer denoting amount to be deposited
- * @property {Address} bracketAddress Ethereum address of the bracket from which to withdraw
- * @property {Address} tokenAddresses List of tokens that the traded wishes to withdraw
- */
+  /**
+   * @typedef Withdrawal
+   *  * Example:
+   * {
+   *   amount: "100",
+   *   bracketAddress: "0x0000000000000000000000000000000000000000",
+   *   tokenAddress: "0x0000000000000000000000000000000000000000",
+   * }
+   * @type {object}
+   * @property {integer} amount Integer denoting amount to be deposited
+   * @property {Address} bracketAddress Ethereum address of the bracket from which to withdraw
+   * @property {Address} tokenAddresses List of tokens that the traded wishes to withdraw
+   */
 
-/**
+  /**
  * @typedef TokenObject
  *  * Example:
  * {
@@ -86,243 +86,238 @@ const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))
 
  */
 
-/**
- * Returns an instance of the exchange contract
- */
-const getExchange = function(web3) {
-  BatchExchange.setNetwork(web3.network_id)
-  BatchExchange.setProvider(web3.currentProvider)
-  return BatchExchange.deployed()
-}
+  /**
+   * Returns an instance of the exchange contract
+   */
+  const getExchange = function(web3) {
+    BatchExchange.setNetwork(web3.network_id)
+    BatchExchange.setProvider(web3.currentProvider)
+    return BatchExchange.deployed()
+  }
 
-/**
- * Returns an instance of the safe contract at the given address
- * @param {Address} safeAddress address of the safe of which to create an instance
- */
-const getSafe = function(safeAddress, artifacts) {
-  return artifacts.require("GnosisSafe").at(safeAddress)
-}
+  /**
+   * Returns an instance of the safe contract at the given address
+   * @param {Address} safeAddress address of the safe of which to create an instance
+   */
+  const getSafe = function(safeAddress) {
+    return artifacts.require("GnosisSafe").at(safeAddress)
+  }
 
-/**
- * Checks that the first input address is the only owner of the first input address
- * @param {Address} masterAddress address that should be the only owner
- * @param {Address} ownedAddress address that is owned
- * @return {bool} whether ownedAddress is indeed owned only by masterAddress
- */
-const isOnlySafeOwner = async function(masterAddress, ownedAddress, artifacts) {
-  const GnosisSafe = artifacts.require("GnosisSafe")
-  const owned = await GnosisSafe.at(ownedAddress)
-  const ownerAddresses = await owned.getOwners()
-  return ownerAddresses.length == 1 && ownerAddresses[0] == masterAddress
-}
+  /**
+   * Checks that the first input address is the only owner of the first input address
+   * @param {Address} masterAddress address that should be the only owner
+   * @param {Address} ownedAddress address that is owned
+   * @return {bool} whether ownedAddress is indeed owned only by masterAddress
+   */
+  const isOnlySafeOwner = async function(masterAddress, ownedAddress) {
+    const GnosisSafe = artifacts.require("GnosisSafe")
+    const owned = await GnosisSafe.at(ownedAddress)
+    const ownerAddresses = await owned.getOwners()
+    return ownerAddresses.length == 1 && ownerAddresses[0] == masterAddress
+  }
 
-const globalTokenPromisesFromAddress = {}
-/**
- * Queries EVM for ERC20 token details by address
- * and returns a list of promises of detailed token information.
- * @param {Address[]} tokenAddresses list of *unique* token addresses whose data is to be fetch from the EVM
- * @return {Promise<TokenObject>[]} list of detailed/relevant token information
- */
-const fetchTokenInfoAtAddresses = function(tokenAddresses, artifacts, debug = false) {
-  const log = debug ? () => console.log.apply(arguments) : () => {}
-  const ERC20 = artifacts.require("ERC20Detailed")
+  const globalTokenPromisesFromAddress = {}
+  /**
+   * Queries EVM for ERC20 token details by address
+   * and returns a list of promises of detailed token information.
+   * @param {Address[]} tokenAddresses list of *unique* token addresses whose data is to be fetch from the EVM
+   * @return {Promise<TokenObject>[]} list of detailed/relevant token information
+   */
+  const fetchTokenInfoAtAddresses = function(tokenAddresses, debug = false) {
+    const log = debug ? () => console.log.apply(arguments) : () => {}
+    const ERC20 = artifacts.require("ERC20Detailed")
 
-  log("Fetching token data from EVM")
-  const tokenPromises = {}
-  for (const tokenAddress of tokenAddresses) {
-    if (!(tokenAddress in globalTokenPromisesFromAddress)) {
-      globalTokenPromisesFromAddress[tokenAddress] = (async () => {
-        const tokenInstance = await ERC20.at(tokenAddress)
-        const [tokenSymbol, tokenDecimals] = await Promise.all([tokenInstance.symbol.call(), tokenInstance.decimals.call()])
-        const tokenInfo = {
-          address: tokenAddress,
-          symbol: tokenSymbol,
-          decimals: tokenDecimals.toNumber(),
-        }
-        log(`Found token ${tokenInfo.symbol} at address ${tokenInfo.address} with ${tokenInfo.decimals} decimals`)
-        return tokenInfo
-      }).call()
+    log("Fetching token data from EVM")
+    const tokenPromises = {}
+    for (const tokenAddress of tokenAddresses) {
+      if (!(tokenAddress in globalTokenPromisesFromAddress)) {
+        globalTokenPromisesFromAddress[tokenAddress] = (async () => {
+          const tokenInstance = await ERC20.at(tokenAddress)
+          const [tokenSymbol, tokenDecimals] = await Promise.all([tokenInstance.symbol.call(), tokenInstance.decimals.call()])
+          const tokenInfo = {
+            address: tokenAddress,
+            symbol: tokenSymbol,
+            decimals: tokenDecimals.toNumber(),
+          }
+          log(`Found token ${tokenInfo.symbol} at address ${tokenInfo.address} with ${tokenInfo.decimals} decimals`)
+          return tokenInfo
+        }).call()
+      }
+      tokenPromises[tokenAddress] = globalTokenPromisesFromAddress[tokenAddress]
     }
-    tokenPromises[tokenAddress] = globalTokenPromisesFromAddress[tokenAddress]
+    return tokenPromises
   }
-  return tokenPromises
-}
 
-const globalTokenPromisesFromId = {}
-/**
- * Queries EVM for ERC20 token details by token id
- * and returns a list of detailed token information.
- * @param {SmartContract} exchange BatchExchange, contract, or any contract implementing `tokenIdToAddressMap`
- * @param {integer[]} tokenIds list of *unique* token ids whose data is to be fetch from EVM
- * @return {Promise<TokenObject>[]} list of detailed/relevant token information
- */
-const fetchTokenInfoFromExchange = function(exchange, tokenIds, artifacts, debug = false) {
-  const log = debug ? () => console.log.apply(arguments) : () => {}
+  const globalTokenPromisesFromId = {}
+  /**
+   * Queries EVM for ERC20 token details by token id
+   * and returns a list of detailed token information.
+   * @param {SmartContract} exchange BatchExchange, contract, or any contract implementing `tokenIdToAddressMap`
+   * @param {integer[]} tokenIds list of *unique* token ids whose data is to be fetch from EVM
+   * @return {Promise<TokenObject>[]} list of detailed/relevant token information
+   */
+  const fetchTokenInfoFromExchange = function(exchange, tokenIds, debug = false) {
+    const log = debug ? () => console.log.apply(arguments) : () => {}
 
-  log("Fetching token data from EVM")
-  const tokenPromises = {}
-  for (const id of tokenIds) {
-    if (!(id in globalTokenPromisesFromId)) {
-      globalTokenPromisesFromId[id] = (async () => {
-        const tokenAddress = await exchange.tokenIdToAddressMap(id)
-        log(`Token id ${id} corresponds to token at address ${tokenAddress}`)
-        return fetchTokenInfoAtAddresses([tokenAddress], artifacts, debug)[tokenAddress]
-      }).call()
+    log("Fetching token data from EVM")
+    const tokenPromises = {}
+    for (const id of tokenIds) {
+      if (!(id in globalTokenPromisesFromId)) {
+        globalTokenPromisesFromId[id] = (async () => {
+          const tokenAddress = await exchange.tokenIdToAddressMap(id)
+          log(`Token id ${id} corresponds to token at address ${tokenAddress}`)
+          return fetchTokenInfoAtAddresses([tokenAddress], debug)[tokenAddress]
+        }).call()
+      }
+      tokenPromises[id] = globalTokenPromisesFromId[id]
     }
-    tokenPromises[id] = globalTokenPromisesFromId[id]
+    return tokenPromises
   }
-  return tokenPromises
-}
 
-/**
- * Deploys specified number singler-owner Gnosis Safes having specified ownership
- * @param {Address} masterAddress address of Gnosis Safe (Multi-Sig) owning the newly created Safes
- * @param {integer} fleetSize number of safes to be created with masterAddress as owner
- * @return {Address[]} list of Ethereum Addresses for the brackets that were deployed
- */
-const deployFleetOfSafes = async function(masterAddress, fleetSize, artifacts, debug = false) {
-  const log = debug ? (...a) => console.log(...a) : () => {}
-  const GnosisSafe = artifacts.require("GnosisSafe")
-  const ProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
+  /**
+   * Deploys specified number singler-owner Gnosis Safes having specified ownership
+   * @param {Address} masterAddress address of Gnosis Safe (Multi-Sig) owning the newly created Safes
+   * @param {integer} fleetSize number of safes to be created with masterAddress as owner
+   * @return {Address[]} list of Ethereum Addresses for the brackets that were deployed
+   */
+  const deployFleetOfSafes = async function(masterAddress, fleetSize, debug = false) {
+    const log = debug ? (...a) => console.log(...a) : () => {}
+    const GnosisSafe = artifacts.require("GnosisSafe")
+    const ProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
 
-  const proxyFactory = await ProxyFactory.deployed()
-  const gnosisSafeMasterCopy = await GnosisSafe.deployed()
+    const proxyFactory = await ProxyFactory.deployed()
+    const gnosisSafeMasterCopy = await GnosisSafe.deployed()
 
-  // TODO - Batch all of this in a single transaction
-  const createdSafes = []
-  for (let i = 0; i < fleetSize; i++) {
-    const newSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [masterAddress], 1)
-    log("New Safe Created", newSafe.address)
-    createdSafes.push(newSafe.address)
+    // TODO - Batch all of this in a single transaction
+    const createdSafes = []
+    for (let i = 0; i < fleetSize; i++) {
+      const newSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [masterAddress], 1)
+      log("New Safe Created", newSafe.address)
+      createdSafes.push(newSafe.address)
+    }
+    return createdSafes
   }
-  return createdSafes
-}
 
-/**
- * Batches together a collection of order placements on BatchExchange
- * on behalf of a fleet of brackets owned by a single "Master Safe"
- * @param {Address} masterAddress Ethereum address of Master Gnosis Safe (Multi-Sig) owning all brackets
- * @param {Address[]} bracketAddresses List of addresses with the brackets sending the orders
- * @param {integer} targetTokenId ID of token (on BatchExchange) whose target price is to be specified (i.e. ETH)
- * @param {integer} stableTokenId ID of "Stable Token" for which trade with target token (i.e. DAI)
- * @param {number} targetPrice Price at which the order brackets will be centered (e.g. current price of ETH in USD)
- * @param {number} [priceRangePercentage=20] Percentage above and below the target price for which orders are to be placed
- * @param {integer} [validFrom=3] Number of batches (from current) until orders become valid
- * @param {integer} [expiry=maxU32] Maximum auction batch for which these orders are valid (e.g. maxU32)
- * @return {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
- */
-const buildOrders = async function(
-  masterAddress,
-  bracketAddresses,
-  targetTokenId,
-  stableTokenId,
-  targetPrice,
-  web3,
-  artifacts,
-  debug = false,
-  priceRangePercentage = 20,
-  validFrom = 3,
-  expiry = maxU32
-) {
-  const log = debug ? (...a) => console.log(...a) : () => {}
+  /**
+   * Batches together a collection of order placements on BatchExchange
+   * on behalf of a fleet of brackets owned by a single "Master Safe"
+   * @param {Address} masterAddress Ethereum address of Master Gnosis Safe (Multi-Sig) owning all brackets
+   * @param {Address[]} bracketAddresses List of addresses with the brackets sending the orders
+   * @param {integer} targetTokenId ID of token (on BatchExchange) whose target price is to be specified (i.e. ETH)
+   * @param {integer} stableTokenId ID of "Stable Token" for which trade with target token (i.e. DAI)
+   * @param {number} targetPrice Price at which the order brackets will be centered (e.g. current price of ETH in USD)
+   * @param {number} [priceRangePercentage=20] Percentage above and below the target price for which orders are to be placed
+   * @param {integer} [validFrom=3] Number of batches (from current) until orders become valid
+   * @param {integer} [expiry=maxU32] Maximum auction batch for which these orders are valid (e.g. maxU32)
+   * @return {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
+   */
+  const buildOrders = async function(
+    masterAddress,
+    bracketAddresses,
+    targetTokenId,
+    stableTokenId,
+    targetPrice,
+    debug = false,
+    priceRangePercentage = 20,
+    validFrom = 3,
+    expiry = maxU32
+  ) {
+    const log = debug ? (...a) => console.log(...a) : () => {}
 
-  await BatchExchange.setProvider(web3.currentProvider)
-  await BatchExchange.setNetwork(web3.network_id)
-  const exchange = await BatchExchange.deployed()
-  log("Batch Exchange", exchange.address)
+    await BatchExchange.setProvider(web3.currentProvider)
+    await BatchExchange.setNetwork(web3.network_id)
+    const exchange = await BatchExchange.deployed()
+    log("Batch Exchange", exchange.address)
 
-  const batch_index = (await exchange.getCurrentBatchId.call()).toNumber()
-  const tokenInfoPromises = await fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId], artifacts)
+    const batch_index = (await exchange.getCurrentBatchId.call()).toNumber()
+    const tokenInfoPromises = await fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId])
 
-  const targetToken = await tokenInfoPromises[targetTokenId]
-  const stableToken = await tokenInfoPromises[stableTokenId]
-  // TODO - handle other cases later.
-  assert(stableToken.decimals === 18, "Target token must have 18 decimals")
-  assert(targetToken.decimals === 18, "Stable tokens must have 18 decimals")
+    const targetToken = await tokenInfoPromises[targetTokenId]
+    const stableToken = await tokenInfoPromises[stableTokenId]
+    // TODO - handle other cases later.
+    assert(stableToken.decimals === 18, "Target token must have 18 decimals")
+    assert(targetToken.decimals === 18, "Stable tokens must have 18 decimals")
 
-  // Number of brackets is determined by bracketAddresses.length
-  const lowestLimit = targetPrice * (1 - priceRangePercentage / 100)
-  const highestLimit = targetPrice * (1 + priceRangePercentage / 100)
-  log(`Lowest-Highest Limit ${lowestLimit}-${highestLimit}`)
+    // Number of brackets is determined by bracketAddresses.length
+    const lowestLimit = targetPrice * (1 - priceRangePercentage / 100)
+    const highestLimit = targetPrice * (1 + priceRangePercentage / 100)
+    log(`Lowest-Highest Limit ${lowestLimit}-${highestLimit}`)
 
-  const stepSize = (highestLimit - lowestLimit) / bracketAddresses.length
+    const stepSize = (highestLimit - lowestLimit) / bracketAddresses.length
 
-  const transactions = []
-  log(
-    `Constructing bracket trading strategy order data based on valuation ${targetPrice} ${stableToken.symbol} per ${targetToken.symbol}`
-  )
-  for (let bracketIndex = 0; bracketIndex < bracketAddresses.length; bracketIndex++) {
-    const bracketAddress = bracketAddresses[bracketIndex]
-    assert(
-      await isOnlySafeOwner(masterAddress, bracketAddress, artifacts),
-      "each bracket should be owned only by the master Safe"
+    const transactions = []
+    log(
+      `Constructing bracket trading strategy order data based on valuation ${targetPrice} ${stableToken.symbol} per ${targetToken.symbol}`
     )
+    for (let bracketIndex = 0; bracketIndex < bracketAddresses.length; bracketIndex++) {
+      const bracketAddress = bracketAddresses[bracketIndex]
+      assert(await isOnlySafeOwner(masterAddress, bracketAddress), "each bracket should be owned only by the master Safe")
 
-    const lowerLimit = lowestLimit + bracketIndex * stepSize
-    const upperLimit = lowestLimit + (bracketIndex + 1) * stepSize
+      const lowerLimit = lowestLimit + bracketIndex * stepSize
+      const upperLimit = lowestLimit + (bracketIndex + 1) * stepSize
 
-    const [upperSellAmount, upperBuyAmount] = calculateBuyAndSellAmountsFromPrice(upperLimit, targetToken)
-    // While the first bracket-order trades standard_token against target_token, the second bracket-order trades
-    // target_token against standard_token. Hence the buyAmounts and sellAmounts are switched in the next line.
-    const [lowerBuyAmount, lowerSellAmount] = calculateBuyAndSellAmountsFromPrice(lowerLimit, targetToken)
+      const [upperSellAmount, upperBuyAmount] = calculateBuyAndSellAmountsFromPrice(upperLimit, targetToken)
+      // While the first bracket-order trades standard_token against target_token, the second bracket-order trades
+      // target_token against standard_token. Hence the buyAmounts and sellAmounts are switched in the next line.
+      const [lowerBuyAmount, lowerSellAmount] = calculateBuyAndSellAmountsFromPrice(lowerLimit, targetToken)
 
-    log(`Safe ${bracketIndex} - ${bracketAddress}:\n  Buy  ${targetToken.symbol} with ${stableToken.symbol} at ${lowerLimit}`)
-    log(`  Sell ${targetToken.symbol} for  ${stableToken.symbol} at ${upperLimit}`)
-    const buyTokens = [targetTokenId, stableTokenId]
-    const sellTokens = [stableTokenId, targetTokenId]
-    const validFroms = [batch_index + validFrom, batch_index + validFrom]
-    const validTos = [expiry, expiry]
-    const buyAmounts = [lowerBuyAmount, upperBuyAmount]
-    const sellAmounts = [lowerSellAmount, upperSellAmount]
+      log(`Safe ${bracketIndex} - ${bracketAddress}:\n  Buy  ${targetToken.symbol} with ${stableToken.symbol} at ${lowerLimit}`)
+      log(`  Sell ${targetToken.symbol} for  ${stableToken.symbol} at ${upperLimit}`)
+      const buyTokens = [targetTokenId, stableTokenId]
+      const sellTokens = [stableTokenId, targetTokenId]
+      const validFroms = [batch_index + validFrom, batch_index + validFrom]
+      const validTos = [expiry, expiry]
+      const buyAmounts = [lowerBuyAmount, upperBuyAmount]
+      const sellAmounts = [lowerSellAmount, upperSellAmount]
 
-    const orderData = await exchange.contract.methods
-      .placeValidFromOrders(buyTokens, sellTokens, validFroms, validTos, buyAmounts, sellAmounts)
-      .encodeABI()
-    const orderTransaction = {
-      operation: CALL,
-      to: exchange.address,
-      value: 0,
-      data: orderData,
+      const orderData = await exchange.contract.methods
+        .placeValidFromOrders(buyTokens, sellTokens, validFroms, validTos, buyAmounts, sellAmounts)
+        .encodeABI()
+      const orderTransaction = {
+        operation: CALL,
+        to: exchange.address,
+        value: 0,
+        data: orderData,
+      }
+
+      transactions.push(await buildExecTransaction(masterAddress, bracketAddress, orderTransaction))
     }
-
-    transactions.push(await buildExecTransaction(masterAddress, bracketAddress, orderTransaction))
+    log("Transaction bundle size", transactions.length)
+    return await buildBundledTransaction(transactions)
   }
-  log("Transaction bundle size", transactions.length)
-  return await buildBundledTransaction(transactions)
-}
 
-const calculateBuyAndSellAmountsFromPrice = function(price, targetToken) {
-  // Sell targetToken for stableToken at price with unlimited orders
-  // Example:
-  // Sell 1 ETH at for 102 DAI (unlimited)
-  // Sell x ETH for max256 DAI
-  // x = max256 / 102
-  // priceFormatted = 102000000000000000000
-  price = price.toFixed(18)
-  const priceFormatted = toErc20Units(price, targetToken.decimals)
-  let sellAmount
-  let buyAmount
-  if (priceFormatted.gt(toErc20Units(1, 18))) {
-    sellAmount = max128
-      .mul(toErc20Units(1, 18))
-      .div(priceFormatted)
-      .toString()
-    buyAmount = max128.toString()
-  } else {
-    buyAmount = max128
-      .mul(priceFormatted)
-      .div(toErc20Units(1, 18))
-      .toString()
-    sellAmount = max128.toString()
+  const calculateBuyAndSellAmountsFromPrice = function(price, targetToken) {
+    // Sell targetToken for stableToken at price with unlimited orders
+    // Example:
+    // Sell 1 ETH at for 102 DAI (unlimited)
+    // Sell x ETH for max256 DAI
+    // x = max256 / 102
+    // priceFormatted = 102000000000000000000
+    price = price.toFixed(18)
+    const priceFormatted = toErc20Units(price, targetToken.decimals)
+    let sellAmount
+    let buyAmount
+    if (priceFormatted.gt(toErc20Units(1, 18))) {
+      sellAmount = max128
+        .mul(toErc20Units(1, 18))
+        .div(priceFormatted)
+        .toString()
+      buyAmount = max128.toString()
+    } else {
+      buyAmount = max128
+        .mul(priceFormatted)
+        .div(toErc20Units(1, 18))
+        .toString()
+      sellAmount = max128.toString()
+    }
+    return [sellAmount, buyAmount]
   }
-  return [sellAmount, buyAmount]
-}
-const checkSufficiencyOfBalance = async function(token, owner, amount) {
-  const depositor_balance = await token.balanceOf.call(owner)
-  return depositor_balance.gte(amount)
-}
+  const checkSufficiencyOfBalance = async function(token, owner, amount) {
+    const depositor_balance = await token.balanceOf.call(owner)
+    return depositor_balance.gte(amount)
+  }
 
-/**
+  /**
  * Batches together a collection of operations (either withdraw or requestWithdraw) on BatchExchange
  * on behalf of a fleet of brackets owned by a single "Master Safe"
  * @param {Address} masterAddress Ethereum address of Master Gnosis Safe (Multi-Sig)
@@ -331,208 +326,197 @@ const checkSufficiencyOfBalance = async function(token, owner, amount) {
  * @return {Transaction} Multisend transaction that has to be sent from the master address to either request
 withdrawal of or to withdraw the desired funds
 */
-const buildGenericFundMovement = async function(masterAddress, withdrawals, functionName, web3 = web3, artifacts = artifacts) {
-  // TODO: do we need artifacts here?
-  const exchange = await getExchange(web3)
+  const buildGenericFundMovement = async function(masterAddress, withdrawals, functionName) {
+    // TODO: do we need artifacts here?
+    const exchange = await getExchange(web3)
 
-  // it's not necessary to avoid overlapping withdraws, since the full amount is withdrawn for each entry
-  const masterTransactionsPromises = withdrawals.map(withdrawal => {
-    // create transaction for the token
-    let transactionData
-    switch (functionName) {
-      case "requestWithdraw":
-        transactionData = exchange.contract.methods["requestWithdraw"](
-          withdrawal.tokenAddress,
-          withdrawal.amount.toString()
-        ).encodeABI()
-        break
-      case "withdraw":
-        transactionData = exchange.contract.methods["withdraw"](withdrawal.bracketAddress, withdrawal.tokenAddress).encodeABI()
-        break
-      default:
-        assert(false, "Function " + functionName + "is not implemented")
-    }
-
-    // prepare bracket transaction
-    const transactionToExecute = {
-      operation: CALL,
-      to: exchange.address,
-      value: 0,
-      data: transactionData,
-    }
-    // build transaction to execute previous transaction through master
-    return buildExecTransaction(masterAddress, withdrawal.bracketAddress, transactionToExecute)
-  })
-
-  // safe pushing to array
-  const masterTransactions = []
-  for (const transactionPromise of masterTransactionsPromises) masterTransactions.push(await transactionPromise)
-  return buildBundledTransaction(masterTransactions)
-}
-
-/**
- * Batches together a collection of transfer-related transaction information.
- * Particularily, the resulting transaction is that of transfering all sufficient funds from master
- * to its brackets, then approving and depositing those same tokens into BatchExchange on behalf of each bracket.
- * @param {string} masterAddress Ethereum address of Master Gnosis Safe (Multi-Sig)
- * @param {Deposit[]} depositList List of {@link Deposit} that are to be bundled together
- * @return {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
- */
-const buildTransferApproveDepositFromList = async function(masterAddress, depositList, web3, artifacts, debug = false) {
-  const log = debug ? (...a) => console.log(...a) : () => {}
-  const ERC20 = artifacts.require("ERC20Detailed")
-
-  let transactions = []
-  // TODO - make cumulative sum of deposits by token and assert that masterSafe has enough for the tranfer
-  // TODO - make deposit list easier so that we dont' have to query the token every time.
-  for (const deposit of depositList) {
-    assert(
-      await isOnlySafeOwner(masterAddress, deposit.bracketAddress, artifacts),
-      "All depositors must be owned only by the master Safe"
-    )
-    const depositToken = await ERC20.at(deposit.tokenAddress)
-    const tokenSymbol = await depositToken.symbol.call()
-    const tokenDecimals = await depositToken.decimals.call()
-    const unitAmount = fromErc20Units(deposit.amount, tokenDecimals)
-    log(
-      `Safe ${deposit.bracketAddress} receiving (from ${shortenedAddress(
-        masterAddress
-      )}) and depositing ${unitAmount} ${tokenSymbol} into BatchExchange`
-    )
-
-    transactions = transactions.concat(
-      await buildBracketTransactionForTransferApproveDeposit(
-        masterAddress,
-        deposit.tokenAddress,
-        deposit.bracketAddress,
-        deposit.amount,
-        artifacts,
-        web3
-      )
-    )
-  }
-  return await buildBundledTransaction(transactions)
-}
-
-const formatDepositString = function(depositsAsJsonString) {
-  let result
-  result = depositsAsJsonString.replace(/{"/g, '{\n    "')
-  result = result.replace(/,"/g, ',\n    "')
-  result = result.replace(/{/g, "\n  {")
-  result = result.replace(/},/g, "\n  },")
-  result = result.replace(/"}/g, '"\n  }')
-  result = result.replace(/]/g, "\n]")
-  return result
-}
-
-/**
- * Batches together a collection of transfer-related transaction information.
- * Particularly, the resulting transaction is that of transfering all sufficient funds from master
- * to its brackets, then approving and depositing those same tokens into BatchExchange on behalf of each bracket.
- * @param {Address} masterAddress Address of the master safe owning the brackets
- * @param {Address[]} bracketAddresses list of bracket addresses that need the deposit
- * @param {Address} stableTokenAddress one token to be traded in bracket strategy
- * @param {number} investmentStableToken Amount of stable tokens to be invested (in total)
- * @param {Address} targetTokenAddress second token to be traded in bracket strategy
- * @param {number} investmentStableToken Amount of target tokens to be invested (in total)
- * @param {bool} storeDepositsAsFile whether to write the executed deposits to a file (defaults to false)
- * @return {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
- */
-const buildTransferApproveDepositFromOrders = async function(
-  masterAddress,
-  bracketAddresses,
-  stableTokenAddress,
-  investmentStableToken,
-  targetTokenAddress,
-  investmentTargetToken,
-  artifacts,
-  web3,
-  storeDepositsAsFile = false
-) {
-  const fleetSize = bracketAddresses.length
-  assert(fleetSize % 2 == 0, "Fleet size must be a even number")
-  const deposits = []
-
-  const fleetSizeDiv2 = fleetSize / 2
-  for (const i of Array(fleetSizeDiv2).keys()) {
-    const deposit = {
-      amount: investmentStableToken.div(new BN(fleetSizeDiv2)).toString(),
-      tokenAddress: stableTokenAddress,
-      bracketAddress: bracketAddresses[i],
-    }
-    deposits.push(deposit)
-  }
-  for (const i of Array(fleetSizeDiv2).keys()) {
-    const deposit = {
-      amount: investmentTargetToken.div(new BN(fleetSizeDiv2)).toString(),
-      tokenAddress: targetTokenAddress,
-      bracketAddress: bracketAddresses[fleetSizeDiv2 + i],
-    }
-    deposits.push(deposit)
-  }
-  if (storeDepositsAsFile) {
-    const depositsAsJsonString = formatDepositString(JSON.stringify(deposits))
-    fs.writeFile("./automaticallyGeneratedDeposits.json", depositsAsJsonString, function(err) {
-      if (err) {
-        console.log("Warning: deposits could not be stored as a file.")
-        console.log(err)
+    // it's not necessary to avoid overlapping withdraws, since the full amount is withdrawn for each entry
+    const masterTransactionsPromises = withdrawals.map(withdrawal => {
+      // create transaction for the token
+      let transactionData
+      switch (functionName) {
+        case "requestWithdraw":
+          transactionData = exchange.contract.methods["requestWithdraw"](
+            withdrawal.tokenAddress,
+            withdrawal.amount.toString()
+          ).encodeABI()
+          break
+        case "withdraw":
+          transactionData = exchange.contract.methods["withdraw"](withdrawal.bracketAddress, withdrawal.tokenAddress).encodeABI()
+          break
+        default:
+          assert(false, "Function " + functionName + "is not implemented")
       }
+
+      // prepare bracket transaction
+      const transactionToExecute = {
+        operation: CALL,
+        to: exchange.address,
+        value: 0,
+        data: transactionData,
+      }
+      // build transaction to execute previous transaction through master
+      return buildExecTransaction(masterAddress, withdrawal.bracketAddress, transactionToExecute)
     })
+
+    // safe pushing to array
+    const masterTransactions = []
+    for (const transactionPromise of masterTransactionsPromises) masterTransactions.push(await transactionPromise)
+    return buildBundledTransaction(masterTransactions)
   }
-  return await buildTransferApproveDepositFromList(masterAddress, deposits, web3, artifacts)
-}
 
-/**
- * Batches together a collection of transfers from each bracket safe to master
- * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
- * @param {Address} tokenAddress for the funds to be deposited
- * @param {Address} bracketAddress The address of the bracket owning the funds in the Exchange
- * @param {BN} amount Amount to be deposited
- * @return {Transaction} Information describing the multisend transaction that has to be sent from the master address to transfer back all funds
- */
-const buildBracketTransactionForTransferApproveDeposit = async (
-  masterAddress,
-  tokenAddress,
-  bracketAddress,
-  amount,
-  artifacts,
-  web3 = web3
-) => {
-  const ERC20 = artifacts.require("ERC20Detailed")
-  const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
+  /**
+   * Batches together a collection of transfer-related transaction information.
+   * Particularily, the resulting transaction is that of transfering all sufficient funds from master
+   * to its brackets, then approving and depositing those same tokens into BatchExchange on behalf of each bracket.
+   * @param {string} masterAddress Ethereum address of Master Gnosis Safe (Multi-Sig)
+   * @param {Deposit[]} depositList List of {@link Deposit} that are to be bundled together
+   * @return {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
+   */
+  const buildTransferApproveDepositFromList = async function(masterAddress, depositList, debug = false) {
+    const log = debug ? (...a) => console.log(...a) : () => {}
+    const ERC20 = artifacts.require("ERC20Detailed")
 
-  BatchExchange.setProvider(web3.currentProvider)
-  BatchExchange.setNetwork(web3.network_id)
-  const exchange = await BatchExchange.deployed()
-  const depositToken = await ERC20.at(tokenAddress)
-  const tokenDecimals = (await depositToken.decimals.call()).toNumber()
-  const transactions = []
+    let transactions = []
+    // TODO - make cumulative sum of deposits by token and assert that masterSafe has enough for the tranfer
+    // TODO - make deposit list easier so that we dont' have to query the token every time.
+    for (const deposit of depositList) {
+      assert(
+        await isOnlySafeOwner(masterAddress, deposit.bracketAddress),
+        "All depositors must be owned only by the master Safe"
+      )
+      const depositToken = await ERC20.at(deposit.tokenAddress)
+      const tokenSymbol = await depositToken.symbol.call()
+      const tokenDecimals = await depositToken.decimals.call()
+      const unitAmount = fromErc20Units(deposit.amount, tokenDecimals)
+      log(
+        `Safe ${deposit.bracketAddress} receiving (from ${shortenedAddress(
+          masterAddress
+        )}) and depositing ${unitAmount} ${tokenSymbol} into BatchExchange`
+      )
 
-  // log(`Deposit Token at ${depositToken.address}: ${tokenSymbol}`)
-  assert.equal(tokenDecimals, 18, "These scripts currently only support tokens with 18 decimals.")
-  // Get data to move funds from master to bracket
-  const transferData = await depositToken.contract.methods.transfer(bracketAddress, amount.toString()).encodeABI()
-  transactions.push({
-    operation: CALL,
-    to: depositToken.address,
-    value: 0,
-    data: transferData,
-  })
-  // Get data to approve funds from bracket to exchange
-  const approveData = await depositToken.contract.methods.approve(exchange.address, amount.toString()).encodeABI()
-  // Get data to deposit funds from bracket to exchange
-  const depositData = await exchange.contract.methods.deposit(tokenAddress, amount.toString()).encodeABI()
-  // Get transaction for approve and deposit multisend on bracket
-  const bracketBundledTransaction = await buildBundledTransaction([
-    { operation: CALL, to: tokenAddress, value: 0, data: approveData },
-    { operation: CALL, to: exchange.address, value: 0, data: depositData },
-  ])
-  // Get transaction executing approve/deposit multisend via bracket
-  const execTransaction = await buildExecTransaction(masterAddress, bracketAddress, bracketBundledTransaction)
-  transactions.push(execTransaction)
-  return transactions
-}
-/**
+      transactions = transactions.concat(
+        await buildBracketTransactionForTransferApproveDeposit(
+          masterAddress,
+          deposit.tokenAddress,
+          deposit.bracketAddress,
+          deposit.amount
+        )
+      )
+    }
+    return await buildBundledTransaction(transactions)
+  }
+
+  const formatDepositString = function(depositsAsJsonString) {
+    let result
+    result = depositsAsJsonString.replace(/{"/g, '{\n    "')
+    result = result.replace(/,"/g, ',\n    "')
+    result = result.replace(/{/g, "\n  {")
+    result = result.replace(/},/g, "\n  },")
+    result = result.replace(/"}/g, '"\n  }')
+    result = result.replace(/]/g, "\n]")
+    return result
+  }
+
+  /**
+   * Batches together a collection of transfer-related transaction information.
+   * Particularly, the resulting transaction is that of transfering all sufficient funds from master
+   * to its brackets, then approving and depositing those same tokens into BatchExchange on behalf of each bracket.
+   * @param {Address} masterAddress Address of the master safe owning the brackets
+   * @param {Address[]} bracketAddresses list of bracket addresses that need the deposit
+   * @param {Address} stableTokenAddress one token to be traded in bracket strategy
+   * @param {number} investmentStableToken Amount of stable tokens to be invested (in total)
+   * @param {Address} targetTokenAddress second token to be traded in bracket strategy
+   * @param {number} investmentStableToken Amount of target tokens to be invested (in total)
+   * @param {bool} storeDepositsAsFile whether to write the executed deposits to a file (defaults to false)
+   * @return {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
+   */
+  const buildTransferApproveDepositFromOrders = async function(
+    masterAddress,
+    bracketAddresses,
+    stableTokenAddress,
+    investmentStableToken,
+    targetTokenAddress,
+    investmentTargetToken,
+    storeDepositsAsFile = false
+  ) {
+    const fleetSize = bracketAddresses.length
+    assert(fleetSize % 2 == 0, "Fleet size must be a even number")
+    const deposits = []
+
+    const fleetSizeDiv2 = fleetSize / 2
+    for (const i of Array(fleetSizeDiv2).keys()) {
+      const deposit = {
+        amount: investmentStableToken.div(new BN(fleetSizeDiv2)).toString(),
+        tokenAddress: stableTokenAddress,
+        bracketAddress: bracketAddresses[i],
+      }
+      deposits.push(deposit)
+    }
+    for (const i of Array(fleetSizeDiv2).keys()) {
+      const deposit = {
+        amount: investmentTargetToken.div(new BN(fleetSizeDiv2)).toString(),
+        tokenAddress: targetTokenAddress,
+        bracketAddress: bracketAddresses[fleetSizeDiv2 + i],
+      }
+      deposits.push(deposit)
+    }
+    if (storeDepositsAsFile) {
+      const depositsAsJsonString = formatDepositString(JSON.stringify(deposits))
+      fs.writeFile("./automaticallyGeneratedDeposits.json", depositsAsJsonString, function(err) {
+        if (err) {
+          console.log("Warning: deposits could not be stored as a file.")
+          console.log(err)
+        }
+      })
+    }
+    return await buildTransferApproveDepositFromList(masterAddress, deposits)
+  }
+
+  /**
+   * Batches together a collection of transfers from each bracket safe to master
+   * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
+   * @param {Address} tokenAddress for the funds to be deposited
+   * @param {Address} bracketAddress The address of the bracket owning the funds in the Exchange
+   * @param {BN} amount Amount to be deposited
+   * @return {Transaction} Information describing the multisend transaction that has to be sent from the master address to transfer back all funds
+   */
+  const buildBracketTransactionForTransferApproveDeposit = async (masterAddress, tokenAddress, bracketAddress, amount) => {
+    const ERC20 = artifacts.require("ERC20Detailed")
+    const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
+
+    BatchExchange.setProvider(web3.currentProvider)
+    BatchExchange.setNetwork(web3.network_id)
+    const exchange = await BatchExchange.deployed()
+    const depositToken = await ERC20.at(tokenAddress)
+    const tokenDecimals = (await depositToken.decimals.call()).toNumber()
+    const transactions = []
+
+    // log(`Deposit Token at ${depositToken.address}: ${tokenSymbol}`)
+    assert.equal(tokenDecimals, 18, "These scripts currently only support tokens with 18 decimals.")
+    // Get data to move funds from master to bracket
+    const transferData = await depositToken.contract.methods.transfer(bracketAddress, amount.toString()).encodeABI()
+    transactions.push({
+      operation: CALL,
+      to: depositToken.address,
+      value: 0,
+      data: transferData,
+    })
+    // Get data to approve funds from bracket to exchange
+    const approveData = await depositToken.contract.methods.approve(exchange.address, amount.toString()).encodeABI()
+    // Get data to deposit funds from bracket to exchange
+    const depositData = await exchange.contract.methods.deposit(tokenAddress, amount.toString()).encodeABI()
+    // Get transaction for approve and deposit multisend on bracket
+    const bracketBundledTransaction = await buildBundledTransaction([
+      { operation: CALL, to: tokenAddress, value: 0, data: approveData },
+      { operation: CALL, to: exchange.address, value: 0, data: depositData },
+    ])
+    // Get transaction executing approve/deposit multisend via bracket
+    const execTransaction = await buildExecTransaction(masterAddress, bracketAddress, bracketBundledTransaction)
+    transactions.push(execTransaction)
+    return transactions
+  }
+  /**
  * Batches together a collection of "requestWithdraw" calls on BatchExchange
  * on behalf of a fleet of brackets owned by a single "Master Safe"
  * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
@@ -540,92 +524,93 @@ const buildBracketTransactionForTransferApproveDeposit = async (
  * @return {Transaction} Multisend transaction that has to be sent from the master address to request
 withdrawal of the desired funds
 */
-const buildRequestWithdraw = function(masterAddress, withdrawals, web3, artifacts) {
-  return buildGenericFundMovement(masterAddress, withdrawals, "requestWithdraw", web3, artifacts)
-}
+  const buildRequestWithdraw = function(masterAddress, withdrawals) {
+    return buildGenericFundMovement(masterAddress, withdrawals, "requestWithdraw")
+  }
 
-/**
- * Batches together a collection of "withdraw" calls on BatchExchange
- * on behalf of a fleet of safes owned by a single "Master Safe"
- * Warning: if any bundled transaction fails, then no funds are withdrawn from the exchange.
- *   Ensure 1. to have executed requestWithdraw for every input before executing
- *          2. no bracket orders have been executed on these tokens (a way to ensure this is to cancel the brackets' standing orders)
- * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
- * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
- * @return {Transaction} Multisend transaction that has to be sent from the master address to withdraw the desired funds
- */
-const buildWithdraw = function(masterAddress, withdrawals, web3, artifacts) {
-  return buildGenericFundMovement(masterAddress, withdrawals, "withdraw", web3, artifacts)
-}
+  /**
+   * Batches together a collection of "withdraw" calls on BatchExchange
+   * on behalf of a fleet of safes owned by a single "Master Safe"
+   * Warning: if any bundled transaction fails, then no funds are withdrawn from the exchange.
+   *   Ensure 1. to have executed requestWithdraw for every input before executing
+   *          2. no bracket orders have been executed on these tokens (a way to ensure this is to cancel the brackets' standing orders)
+   * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
+   * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
+   * @return {Transaction} Multisend transaction that has to be sent from the master address to withdraw the desired funds
+   */
+  const buildWithdraw = function(masterAddress, withdrawals) {
+    return buildGenericFundMovement(masterAddress, withdrawals, "withdraw")
+  }
 
-/**
- * Batches together a collection of transfers from each bracket to master
- * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
- * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
- * @return {Transaction} Multisend transaction that has to be sent from the master address to transfer back all funds
- */
-const buildTransferFundsToMaster = async function(masterAddress, withdrawals, limitToMaxWithdrawableAmount, web3, artifacts) {
-  const ERC20 = artifacts.require("ERC20Mintable")
+  /**
+   * Batches together a collection of transfers from each bracket to master
+   * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
+   * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
+   * @return {Transaction} Multisend transaction that has to be sent from the master address to transfer back all funds
+   */
+  const buildTransferFundsToMaster = async function(masterAddress, withdrawals, limitToMaxWithdrawableAmount) {
+    const ERC20 = artifacts.require("ERC20Mintable")
 
-  // TODO: enforce that there are no overlapping withdrawals
-  const masterTransactions = await Promise.all(
-    withdrawals.map(async withdrawal => {
-      const token = await ERC20.at(withdrawal.tokenAddress)
-      let amount
-      if (limitToMaxWithdrawableAmount) {
-        amount = BN.min(new BN(withdrawal.amount), new BN(await token.balanceOf.call(withdrawal.bracketAddress)))
-      } else {
-        amount = withdrawal.amount
-      }
-      // create transaction for the token
-      const transactionData = await token.contract.methods.transfer(masterAddress, amount.toString()).encodeABI()
+    // TODO: enforce that there are no overlapping withdrawals
+    const masterTransactions = await Promise.all(
+      withdrawals.map(async withdrawal => {
+        const token = await ERC20.at(withdrawal.tokenAddress)
+        let amount
+        if (limitToMaxWithdrawableAmount) {
+          amount = BN.min(new BN(withdrawal.amount), new BN(await token.balanceOf.call(withdrawal.bracketAddress)))
+        } else {
+          amount = withdrawal.amount
+        }
+        // create transaction for the token
+        const transactionData = await token.contract.methods.transfer(masterAddress, amount.toString()).encodeABI()
 
-      // prepare bracket transaction
-      const transactionToExecute = {
-        operation: CALL,
-        to: token.address,
-        value: 0,
-        data: transactionData,
-      }
-      // build transaction to execute previous transaction through master
-      return buildExecTransaction(masterAddress, withdrawal.bracketAddress, transactionToExecute)
-    })
-  )
+        // prepare bracket transaction
+        const transactionToExecute = {
+          operation: CALL,
+          to: token.address,
+          value: 0,
+          data: transactionData,
+        }
+        // build transaction to execute previous transaction through master
+        return buildExecTransaction(masterAddress, withdrawal.bracketAddress, transactionToExecute)
+      })
+    )
 
-  return buildBundledTransaction(masterTransactions)
-}
+    return buildBundledTransaction(masterTransactions)
+  }
 
-/**
- * Batches together a collection of transfers from each bracket to master
- * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
- * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
- * @return {Transaction} Multisend transaction that has to be sent from the master address to transfer back the funds stored in the exchange
- */
-const buildWithdrawAndTransferFundsToMaster = async function(masterAddress, withdrawals, web3 = web3, artifacts = artifacts) {
-  const withdrawalTransaction = await buildWithdraw(masterAddress, withdrawals, web3, artifacts)
-  const transferFundsToMasterTransaction = await buildTransferFundsToMaster(masterAddress, withdrawals, false, web3, artifacts)
-  return buildBundledTransaction([withdrawalTransaction, transferFundsToMasterTransaction])
-}
+  /**
+   * Batches together a collection of transfers from each bracket to master
+   * @param {Address} masterAddress address of Master Gnosis Safe (Multi-Sig)
+   * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
+   * @return {Transaction} Multisend transaction that has to be sent from the master address to transfer back the fubnds stored in the exchange
+   */
+  const buildWithdrawAndTransferFundsToMaster = async function(masterAddress, withdrawals) {
+    const withdrawalTransaction = await buildWithdraw(masterAddress, withdrawals)
+    const transferFundsToMasterTransaction = await buildTransferFundsToMaster(masterAddress, withdrawals, false)
+    return buildBundledTransaction([withdrawalTransaction, transferFundsToMasterTransaction])
+  }
 
-module.exports = {
-  getSafe,
-  getExchange,
-  deployFleetOfSafes,
-  buildOrders,
-  buildBundledTransaction,
-  buildTransferApproveDepositFromList,
-  buildTransferFundsToMaster,
-  buildWithdrawAndTransferFundsToMaster,
-  buildBracketTransactionForTransferApproveDeposit,
-  buildTransferApproveDepositFromOrders,
-  checkSufficiencyOfBalance,
-  buildRequestWithdraw,
-  buildWithdraw,
-  fetchTokenInfoAtAddresses,
-  fetchTokenInfoFromExchange,
-  isOnlySafeOwner,
-  max128,
-  maxU32,
-  maxUINT,
-  ADDRESS_0,
+  return {
+    getSafe,
+    getExchange,
+    deployFleetOfSafes,
+    buildOrders,
+    buildBundledTransaction,
+    buildTransferApproveDepositFromList,
+    buildTransferFundsToMaster,
+    buildWithdrawAndTransferFundsToMaster,
+    buildBracketTransactionForTransferApproveDeposit,
+    buildTransferApproveDepositFromOrders,
+    checkSufficiencyOfBalance,
+    buildRequestWithdraw,
+    buildWithdraw,
+    fetchTokenInfoAtAddresses,
+    fetchTokenInfoFromExchange,
+    isOnlySafeOwner,
+    max128,
+    maxU32,
+    maxUINT,
+    ADDRESS_0,
+  }
 }

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -1,4 +1,4 @@
-const { signAndSend, promptUser } = require("./utils/sign_and_send")
+const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 const { fromErc20Units, shortenedAddress } = require("./utils/printing_tools")
 const { allElementsOnlyOnce } = require("./utils/js_helpers")
 const {

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -9,7 +9,7 @@ const {
   buildWithdraw,
   buildTransferFundsToMaster,
   buildWithdrawAndTransferFundsToMaster,
-} = require("./utils/trading_strategy_helpers")
+} = require("./utils/trading_strategy_helpers")(web3, artifacts)
 
 const argv = require("yargs")
   .option("masterSafe", {
@@ -80,12 +80,12 @@ const getAmount = async function(bracketAddress, tokenAddress, exchange) {
 
 module.exports = async callback => {
   try {
-    const masterSafePromise = getSafe(argv.masterSafe, artifacts)
+    const masterSafePromise = getSafe(argv.masterSafe)
     const exchange = await getExchange(web3)
 
     let withdrawals = require(argv.withdrawalFile)
     const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))
-    const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved, artifacts)
+    const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved)
 
     if (argv.allTokens) {
       console.log("Retrieving amount of tokens to withdraw.")
@@ -101,13 +101,13 @@ module.exports = async callback => {
 
     console.log("Started building withdraw transaction.")
     let transactionPromise
-    if (argv.requestWithdraw) transactionPromise = buildRequestWithdraw(argv.masterSafe, withdrawals, web3, artifacts)
+    if (argv.requestWithdraw) transactionPromise = buildRequestWithdraw(argv.masterSafe, withdrawals)
     else if (argv.withdraw && !argv.transferBackToMaster)
-      transactionPromise = buildWithdraw(argv.masterSafe, withdrawals, web3, artifacts)
+      transactionPromise = buildWithdraw(argv.masterSafe, withdrawals)
     else if (!argv.withdraw && argv.transferBackToMaster)
-      transactionPromise = buildTransferFundsToMaster(argv.masterSafe, withdrawals, true, web3, artifacts)
+      transactionPromise = buildTransferFundsToMaster(argv.masterSafe, withdrawals, true)
     else if (argv.withdraw && argv.transferBackToMaster)
-      transactionPromise = buildWithdrawAndTransferFundsToMaster(argv.masterSafe, withdrawals, web3, artifacts)
+      transactionPromise = buildWithdrawAndTransferFundsToMaster(argv.masterSafe, withdrawals)
     else {
       throw new Error("No operation specified")
     }

--- a/scripts/wrap_eth.js
+++ b/scripts/wrap_eth.js
@@ -1,6 +1,6 @@
 const Contract = require("@truffle/contract")
 
-const { signAndSend, promptUser } = require("./utils/sign_and_send")
+const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 const { CALL } = require("./utils/internals")
 const {  toErc20Units, fromErc20Units } = require("./utils/printing_tools")
 

--- a/scripts/wrap_eth.js
+++ b/scripts/wrap_eth.js
@@ -1,7 +1,7 @@
 const Contract = require("@truffle/contract")
 
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
-const { CALL } = require("./utils/internals")
+const { CALL } = require("./utils/internals")(web3, artifacts)
 const {  toErc20Units, fromErc20Units } = require("./utils/printing_tools")
 
 const argv = require("yargs")

--- a/test/dfusionMultiSafes.js
+++ b/test/dfusionMultiSafes.js
@@ -24,7 +24,7 @@ const {
   max128,
   maxU32,
 } = require("../scripts/utils/trading_strategy_helpers")
-const { waitForNSeconds, execTransaction, deploySafe } = require("../scripts/utils/internals")
+const { waitForNSeconds, execTransaction, deploySafe } = require("../scripts/utils/internals")(web3, artifacts)
 const { toErc20Units } = require("../scripts/utils/printing_tools")
 
 const checkPricesOfBracketStrategy = async function(targetPrice, bracketSafes, exchange) {
@@ -131,7 +131,7 @@ contract("GnosisSafe", function(accounts) {
   })
   describe("Gnosis Safe deployments:", async function() {
     it("Deploys Fleet of Gnosis Safes", async () => {
-      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
+      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const fleet = await deployFleetOfSafes(masterSafe.address, 10, artifacts)
       assert.equal(fleet.length, 10)
       for (const bracketAddress of fleet) assert(await isOnlySafeOwner(masterSafe.address, bracketAddress, artifacts))
@@ -139,7 +139,7 @@ contract("GnosisSafe", function(accounts) {
   })
   describe("transfer tests:", async function() {
     it("transfers tokens from fund account through trader accounts and into exchange via manual deposit logic", async () => {
-      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
+      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2, artifacts)
       const depositAmount = 1000
       await testToken.mint(accounts[0], depositAmount * bracketAddresses.length)
@@ -168,7 +168,7 @@ contract("GnosisSafe", function(accounts) {
     })
 
     it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic", async () => {
-      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
+      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const fleetSize = 2
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, fleetSize, artifacts)
       const depositAmountStableToken = new BN(1000)
@@ -217,7 +217,7 @@ contract("GnosisSafe", function(accounts) {
   })
   describe("bracket order placement test:", async function() {
     it("Places bracket orders on behalf of a fleet of safes and checks for profitability and validity", async () => {
-      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
+      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 6, artifacts)
       const targetToken = 0 // ETH
       const stableToken = 1 // DAI
@@ -254,7 +254,7 @@ contract("GnosisSafe", function(accounts) {
       }
     })
     it("Places bracket orders on behalf of a fleet of safes and checks price for p< 1", async () => {
-      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
+      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6, artifacts)
       const targetToken = 0 // ETH
       const stableToken = 1 // DAI
@@ -284,7 +284,7 @@ contract("GnosisSafe", function(accounts) {
       }
     })
     it("Places bracket orders on behalf of a fleet of safes and checks prices for p>1", async () => {
-      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
+      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6, artifacts)
       const targetToken = 0 // ETH
       const stableToken = 1 // DAI
@@ -384,7 +384,7 @@ contract("GnosisSafe", function(accounts) {
     }
 
     it("Withdraw full amount, three steps", async () => {
-      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
+      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2, artifacts)
       const depositAmount = toErc20Units(200, 18)
       const fullTokenAmount = depositAmount * bracketAddresses.length
@@ -464,7 +464,7 @@ contract("GnosisSafe", function(accounts) {
     })
 
     it("Withdraw full amount, two steps", async () => {
-      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2, artifacts)
+      const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2, artifacts)
       const depositAmount = toErc20Units(200, 18)
       const fullTokenAmount = depositAmount * bracketAddresses.length

--- a/test/dfusionMultiSafes.js
+++ b/test/dfusionMultiSafes.js
@@ -23,7 +23,7 @@ const {
   isOnlySafeOwner,
   max128,
   maxU32,
-} = require("../scripts/utils/trading_strategy_helpers")
+} = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
 const { waitForNSeconds, execTransaction, deploySafe } = require("../scripts/utils/internals")(web3, artifacts)
 const { toErc20Units } = require("../scripts/utils/printing_tools")
 
@@ -132,7 +132,7 @@ contract("GnosisSafe", function(accounts) {
   describe("Gnosis Safe deployments:", async function() {
     it("Deploys Fleet of Gnosis Safes", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
-      const fleet = await deployFleetOfSafes(masterSafe.address, 10, artifacts)
+      const fleet = await deployFleetOfSafes(masterSafe.address, 10)
       assert.equal(fleet.length, 10)
       for (const bracketAddress of fleet) assert(await isOnlySafeOwner(masterSafe.address, bracketAddress, artifacts))
     })
@@ -140,7 +140,7 @@ contract("GnosisSafe", function(accounts) {
   describe("transfer tests:", async function() {
     it("transfers tokens from fund account through trader accounts and into exchange via manual deposit logic", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
-      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2, artifacts)
+      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2)
       const depositAmount = 1000
       await testToken.mint(accounts[0], depositAmount * bracketAddresses.length)
       await testToken.transfer(masterSafe.address, depositAmount * bracketAddresses.length)
@@ -152,7 +152,7 @@ contract("GnosisSafe", function(accounts) {
         bracketAddress: bracketAddress,
       }))
 
-      const batchTransaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits, web3, artifacts)
+      const batchTransaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits)
 
       await execTransaction(masterSafe, lw, batchTransaction)
       // Close auction for deposits to be refelcted in exchange balance
@@ -170,7 +170,7 @@ contract("GnosisSafe", function(accounts) {
     it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       const fleetSize = 2
-      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, fleetSize, artifacts)
+      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, fleetSize)
       const depositAmountStableToken = new BN(1000)
       const stableToken = await TestToken.new("TEST", 18)
       await stableToken.mint(accounts[0], depositAmountStableToken.mul(new BN(bracketAddresses.length)))
@@ -186,9 +186,7 @@ contract("GnosisSafe", function(accounts) {
         stableToken.address,
         depositAmountStableToken,
         targetToken.address,
-        depositAmountTargetToken,
-        artifacts,
-        web3
+        depositAmountTargetToken
       )
 
       await execTransaction(masterSafe, lw, batchTransaction)
@@ -218,7 +216,7 @@ contract("GnosisSafe", function(accounts) {
   describe("bracket order placement test:", async function() {
     it("Places bracket orders on behalf of a fleet of safes and checks for profitability and validity", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
-      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 6, artifacts)
+      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 6)
       const targetToken = 0 // ETH
       const stableToken = 1 // DAI
       const targetPrice = 100
@@ -231,9 +229,7 @@ contract("GnosisSafe", function(accounts) {
         bracketAddresses,
         targetToken,
         stableToken,
-        targetPrice,
-        web3,
-        artifacts
+        targetPrice
       )
       await execTransaction(masterSafe, lw, transaction)
 
@@ -255,7 +251,7 @@ contract("GnosisSafe", function(accounts) {
     })
     it("Places bracket orders on behalf of a fleet of safes and checks price for p< 1", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
-      const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6, artifacts)
+      const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       const targetToken = 0 // ETH
       const stableToken = 1 // DAI
       const targetPrice = 1 / 100
@@ -268,9 +264,7 @@ contract("GnosisSafe", function(accounts) {
         bracketSafes,
         targetToken,
         stableToken,
-        targetPrice,
-        web3,
-        artifacts
+        targetPrice
       )
       await execTransaction(masterSafe, lw, transaction)
 
@@ -285,7 +279,7 @@ contract("GnosisSafe", function(accounts) {
     })
     it("Places bracket orders on behalf of a fleet of safes and checks prices for p>1", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
-      const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6, artifacts)
+      const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       const targetToken = 0 // ETH
       const stableToken = 1 // DAI
       const targetPrice = 100
@@ -297,9 +291,7 @@ contract("GnosisSafe", function(accounts) {
         bracketSafes,
         targetToken,
         stableToken,
-        targetPrice,
-        web3,
-        artifacts
+        targetPrice
       )
       await execTransaction(masterSafe, lw, transaction)
 
@@ -317,7 +309,7 @@ contract("GnosisSafe", function(accounts) {
 
   describe("Test withdrawals", async function() {
     const setupAndRequestWithdraw = async function(masterSafe, bracketAddresses, deposits, withdrawals) {
-      const batchTransaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits, web3, artifacts)
+      const batchTransaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits)
 
       await execTransaction(masterSafe, lw, batchTransaction)
       // Close auction for deposits to be reflected in exchange balance
@@ -349,7 +341,7 @@ contract("GnosisSafe", function(accounts) {
         )
       }
 
-      const requestWithdrawalTransaction = await buildRequestWithdraw(masterSafe.address, withdrawals, web3, artifacts)
+      const requestWithdrawalTransaction = await buildRequestWithdraw(masterSafe.address, withdrawals)
       await execTransaction(masterSafe, lw, requestWithdrawalTransaction, "request withdrawal for all brackets")
       await waitForNSeconds(301)
 
@@ -385,7 +377,7 @@ contract("GnosisSafe", function(accounts) {
 
     it("Withdraw full amount, three steps", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
-      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2, artifacts)
+      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2)
       const depositAmount = toErc20Units(200, 18)
       const fullTokenAmount = depositAmount * bracketAddresses.length
 
@@ -413,7 +405,7 @@ contract("GnosisSafe", function(accounts) {
         withdraw.amount = withdraw.amount.add(toErc20Units(1, 18))
         withdraw
       })
-      const withdrawalTransaction = await buildWithdraw(masterSafe.address, withdrawalsModified, web3, artifacts)
+      const withdrawalTransaction = await buildWithdraw(masterSafe.address, withdrawalsModified)
 
       await execTransaction(masterSafe, lw, withdrawalTransaction, "withdraw for all brackets")
 
@@ -438,9 +430,7 @@ contract("GnosisSafe", function(accounts) {
       const transferFundsToMasterTransaction = await buildTransferFundsToMaster(
         masterSafe.address,
         withdrawalsModified,
-        true,
-        web3,
-        artifacts
+        true
       )
 
       await execTransaction(masterSafe, lw, transferFundsToMasterTransaction, "transfer funds to master for all brackets")
@@ -465,7 +455,7 @@ contract("GnosisSafe", function(accounts) {
 
     it("Withdraw full amount, two steps", async () => {
       const masterSafe = await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
-      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2, artifacts)
+      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 2)
       const depositAmount = toErc20Units(200, 18)
       const fullTokenAmount = depositAmount * bracketAddresses.length
 
@@ -488,9 +478,7 @@ contract("GnosisSafe", function(accounts) {
 
       const withdrawAndTransferFundsToMasterTransaction = await buildWithdrawAndTransferFundsToMaster(
         masterSafe.address,
-        withdrawals,
-        web3,
-        artifacts
+        withdrawals
       )
       await execTransaction(
         masterSafe,

--- a/test/priceUtils.js
+++ b/test/priceUtils.js
@@ -1,7 +1,7 @@
 const assert = require("assert")
 const Contract = require("@truffle/contract")
 const { prepareTokenRegistration } = require("./test-utils")
-const { isPriceReasonable } = require("../scripts/utils/price-utils")
+const { isPriceReasonable } = require("../scripts/utils/price-utils")(web3, artifacts)
 
 contract("PriceOracle", function(accounts) {
   describe("Price oracle sanity check", async () => {
@@ -25,7 +25,7 @@ contract("PriceOracle", function(accounts) {
       const acceptedPriceDeviationInPercentage = 99
       const price = 1000
       assert(
-        await isPriceReasonable(exchange, targetTokenId, stableTokenId, price, artifacts, acceptedPriceDeviationInPercentage)
+        await isPriceReasonable(exchange, targetTokenId, stableTokenId, price, acceptedPriceDeviationInPercentage)
       )
     })
   })


### PR DESCRIPTION
Most functions' input is cluttered with `artifacts` and `web3`s. This PR remove most of them.

Instead of directly returning the functions we need, `require` is transformed into a function taking `web3` and `artifacts` as input. This input is then used by the imported functions without any need to inject it into the functions' arguments.

Not much is happening in this PR, most changes are indentation changes.

Still to do:
1. test that the scripts are working correctly.