### PR TITLE
Safer retrieval of tokens

### DIFF
--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -14,7 +14,7 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
   const fs = require("fs")
   const { deploySafe, buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")(web3, artifacts)
   const { shortenedAddress, fromErc20Units, toErc20Units } = require("./printing_tools")
-  const { allElementsOnlyOnce } = require("./utils/js_helpers")
+  const { allElementsOnlyOnce } = require("./js_helpers")
   const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
   const maxU32 = 2 ** 32 - 1
   const max128 = new BN(2).pow(new BN(128)).subn(1)

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -566,7 +566,7 @@ withdrawal of the desired funds
     // TODO: enforce that there are no overlapping withdrawals
     const masterTransactions = await Promise.all(
       withdrawals.map(async withdrawal => {
-        const tokenInfo = await tokeinInfoPromises[withdrawal.tokenAddresses]
+        const tokenInfo = await tokeinInfoPromises[withdrawal.tokenAddress]
         const token = tokenInfo.instance
         let amount
         if (limitToMaxWithdrawableAmount) {

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -561,10 +561,13 @@ withdrawal of the desired funds
    * @return {Transaction} Multisend transaction that has to be sent from the master address to transfer back all funds
    */
   const buildTransferFundsToMaster = async function(masterAddress, withdrawals, limitToMaxWithdrawableAmount) {
+    const tokeinInfoPromises = fetchTokenInfoFromWithdrawals(withdrawals)
+
     // TODO: enforce that there are no overlapping withdrawals
     const masterTransactions = await Promise.all(
       withdrawals.map(async withdrawal => {
-        const token = await ERC20.at(withdrawal.tokenAddress)
+        const tokenInfo = await tokeinInfoPromises[withdrawal.tokenAddresses]
+        const token = tokenInfo.instance
         let amount
         if (limitToMaxWithdrawableAmount) {
           amount = BN.min(new BN(withdrawal.amount), new BN(await token.balanceOf.call(withdrawal.bracketAddress)))

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -172,7 +172,7 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
    * @param {Deposit[]} depositList List of {@link Deposit}
    * @return {Promise<TokenObject>[]} list of detailed/relevant token information
    */
-  const fetchTokenInfoFromDeposits = function(deposits, debug = false) {
+  const fetchTokenInfoForDeposits = function(deposits, debug = false) {
     const tokensInvolved = allElementsOnlyOnce(deposits.map(deposit => deposit.tokenAddress))
     return fetchTokenInfoAtAddresses(tokensInvolved, debug)
   }
@@ -182,8 +182,8 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
    * @param {Withdrawal[]} depositList List of {@link Withdrawals}
    * @return {Promise<TokenObject>[]} list of detailed/relevant token information
    */
-  const fetchTokenInfoFromWithdrawals = function(withdrawals, debug = false) {
-    return fetchTokenInfoFromDeposits(withdrawals, debug)
+  const fetchTokenInfoForWithdrawals = function(withdrawals, debug = false) {
+    return fetchTokenInfoForDeposits(withdrawals, debug)
   }
 
   /**
@@ -383,7 +383,7 @@ withdrawal of or to withdraw the desired funds
   const buildTransferApproveDepositFromList = async function(masterAddress, depositList, debug = false) {
     const log = debug ? (...a) => console.log(...a) : () => {}
 
-    const tokenInfoPromises = fetchTokenInfoFromDeposits(depositList)
+    const tokenInfoPromises = fetchTokenInfoForDeposits(depositList)
     let transactions = []
     // TODO - make cumulative sum of deposits by token and assert that masterSafe has enough for the tranfer
     for (const deposit of depositList) {
@@ -561,7 +561,7 @@ withdrawal of the desired funds
    * @return {Transaction} Multisend transaction that has to be sent from the master address to transfer back all funds
    */
   const buildTransferFundsToMaster = async function(masterAddress, withdrawals, limitToMaxWithdrawableAmount) {
-    const tokeinInfoPromises = fetchTokenInfoFromWithdrawals(withdrawals)
+    const tokeinInfoPromises = fetchTokenInfoForWithdrawals(withdrawals)
 
     // TODO: enforce that there are no overlapping withdrawals
     const masterTransactions = await Promise.all(
@@ -620,8 +620,8 @@ withdrawal of the desired funds
     buildWithdraw,
     fetchTokenInfoAtAddresses,
     fetchTokenInfoFromExchange,
-    fetchTokenInfoFromDeposits,
-    fetchTokenInfoFromWithdrawals,
+    fetchTokenInfoForDeposits,
+    fetchTokenInfoForWithdrawals,
     isOnlySafeOwner,
     max128,
     maxU32,

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -383,6 +383,7 @@ withdrawal of or to withdraw the desired funds
   const buildTransferApproveDepositFromList = async function(masterAddress, depositList, debug = false) {
     const log = debug ? (...a) => console.log(...a) : () => {}
 
+    const tokenInfoPromises = fetchTokenInfoFromDeposits(depositList)
     let transactions = []
     // TODO - make cumulative sum of deposits by token and assert that masterSafe has enough for the tranfer
     for (const deposit of depositList) {
@@ -390,7 +391,7 @@ withdrawal of or to withdraw the desired funds
         await isOnlySafeOwner(masterAddress, deposit.bracketAddress),
         "All depositors must be owned only by the master Safe"
       )
-      const tokenInfo = await fetchTokenInfoAtAddresses([deposit.tokenAddress], debug)[deposit.tokenAddress]
+      const tokenInfo = await tokenInfoPromises[deposit.tokenAddress]
       const unitAmount = fromErc20Units(deposit.amount, tokenInfo.decimals)
       log(
         `Safe ${deposit.bracketAddress} receiving (from ${shortenedAddress(masterAddress)}) and depositing ${unitAmount} ${

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -1,10 +1,9 @@
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 const { fromErc20Units, shortenedAddress } = require("./utils/printing_tools")
-const { allElementsOnlyOnce } = require("./utils/js_helpers")
 const {
   getExchange,
   getSafe,
-  fetchTokenInfoAtAddresses,
+  fetchTokenInfoFromWithdrawals,
   buildRequestWithdraw,
   buildWithdraw,
   buildTransferFundsToMaster,
@@ -84,8 +83,7 @@ module.exports = async callback => {
     const exchange = await getExchange(web3)
 
     let withdrawals = require(argv.withdrawalFile)
-    const tokensInvolved = allElementsOnlyOnce(withdrawals.map(withdrawal => withdrawal.tokenAddress))
-    const tokenInfoPromises = fetchTokenInfoAtAddresses(tokensInvolved)
+    const tokenInfoPromises = fetchTokenInfoFromWithdrawals(withdrawals)
 
     if (argv.allTokens) {
       console.log("Retrieving amount of tokens to withdraw.")

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -3,7 +3,7 @@ const { fromErc20Units, shortenedAddress } = require("./utils/printing_tools")
 const {
   getExchange,
   getSafe,
-  fetchTokenInfoFromWithdrawals,
+  fetchTokenInfoForWithdrawals,
   buildRequestWithdraw,
   buildWithdraw,
   buildTransferFundsToMaster,
@@ -83,7 +83,7 @@ module.exports = async callback => {
     const exchange = await getExchange(web3)
 
     let withdrawals = require(argv.withdrawalFile)
-    const tokenInfoPromises = fetchTokenInfoFromWithdrawals(withdrawals)
+    const tokenInfoPromises = fetchTokenInfoForWithdrawals(withdrawals)
 
     if (argv.allTokens) {
       console.log("Retrieving amount of tokens to withdraw.")


### PR DESCRIPTION
Change the way tokens are retrieved in deposits and use same strategy to send funds back to master.

Motivation: with the current deposit script we are calling `fetchTokenInfoFromAddresses` once for each deposit. If the token has not been retrieved before, then since all calls are run in parallel we have that each call creates its own promise for the token info at the same time, thus contacting the node multiple times for the same token.