### PR TITLE
BN library as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@gnosis.pm/util-contracts": "^2.0.6",
     "@truffle/contract": "^4.1.13",
     "axios": "^0.19.2",
+    "bn.js": "^5.1.1",
     "canonical-weth": "^1.4.0",
     "dotenv": "^8.0.0",
     "eslint": "^6.8.0",

--- a/test/dfusionMultiSafes.js
+++ b/test/dfusionMultiSafes.js
@@ -211,7 +211,7 @@ contract("GnosisSafe", function(accounts) {
         stableTokenDecimals,
         accounts[0]
       )
-      const depositAmountStableToken = new BN(amountStableToken)
+      const depositAmountStableToken = toErc20Units(amountStableToken, stableTokenDecimals)
       await stableToken.mint(masterSafe.address, depositAmountStableToken, { from: accounts[0] })
 
       //Create  targetToken and add it to the exchange
@@ -221,7 +221,7 @@ contract("GnosisSafe", function(accounts) {
         targetTokenDecimals,
         accounts[0]
       )
-      const depositAmountTargetToken = new BN(amountTargetToken)
+      const depositAmountTargetToken = toErc20Units(amountTargetToken, targetTokenDecimals)
       await targetToken.mint(masterSafe.address, depositAmountTargetToken, { from: accounts[0] })
 
       // Build orders

--- a/test/printingTools.js
+++ b/test/printingTools.js
@@ -429,17 +429,17 @@ describe("fromErc20Units", () => {
   it("fails with bad input", () => {
     const badEntries = [
       {
-        user: "0",
+        machine: "0",
         decimals: -1,
         error: "invalidDecimals",
       },
       {
-        user: "0",
+        machine: "0",
         decimals: 256,
         error: "invalidDecimals",
       },
       {
-        user: "0",
+        machine: "0",
         decimals: 1000,
         error: "invalidDecimals",
       },

--- a/test/printingTools.js
+++ b/test/printingTools.js
@@ -332,9 +332,7 @@ describe("fromErc20Units", () => {
   const allTypesForEntry = function(entry) {
     const entriesToTest = []
     decimalTypesToTest(entry.decimals).map(decimals => {
-      entriesToTest.push(
-        { user: entry.user, error: entry.error, decimals: decimals, machine: entry.machine }
-      )
+      entriesToTest.push({ user: entry.user, error: entry.error, decimals: decimals, machine: entry.machine })
       let machineToBn = null
       try {
         machineToBn = new BN(entry.machine)
@@ -342,9 +340,7 @@ describe("fromErc20Units", () => {
         // if the string cannot be made into a BN, then there is no need to test for this BN input
       } finally {
         if (machineToBn != null) {
-          entriesToTest.push(
-            { user: entry.user, error: entry.error, decimals: decimals, machine: machineToBn }
-          )
+          entriesToTest.push({ user: entry.user, error: entry.error, decimals: decimals, machine: machineToBn })
         }
       }
     })

--- a/test/printingTools.js
+++ b/test/printingTools.js
@@ -330,12 +330,23 @@ describe("toErc20Units", () => {
 describe("fromErc20Units", () => {
   // takes an entry and produces an array containing the same entry expressed in all accepted input types
   const allTypesForEntry = function(entry) {
-    let entriesToTest = []
+    const entriesToTest = []
     decimalTypesToTest(entry.decimals).map(decimals => {
-      entriesToTest = entriesToTest.concat(
-        { user: entry.user, error: entry.error, decimals: decimals, machine: entry.machine },
-        { user: entry.user, error: entry.error, decimals: decimals, machine: new BN(entry.machine) }
+      entriesToTest.push(
+        { user: entry.user, error: entry.error, decimals: decimals, machine: entry.machine }
       )
+      let machineToBn = null
+      try {
+        machineToBn = new BN(entry.machine)
+      } catch (ignored) {
+        // if the string cannot be made into a BN, then there is no need to test for this BN input
+      } finally {
+        if (machineToBn != null) {
+          entriesToTest.push(
+            { user: entry.user, error: entry.error, decimals: decimals, machine: machineToBn }
+          )
+        }
+      }
     })
     return entriesToTest
   }

--- a/test/printingTools.js
+++ b/test/printingTools.js
@@ -102,6 +102,9 @@ const invalidNumber = function(amount) {
 const tooManyDecimals = function() {
   return "Too many decimals for the token in input string"
 }
+const invalidCharacter = function() {
+  return "Invalid character"
+}
 
 // takes an integer and produces an array containing the same value expressed in all types accepted for "decimals"
 const decimalTypesToTest = function(decimals) {
@@ -256,6 +259,21 @@ describe("toErc20Units", () => {
         error: "invalidNumber",
       },
       {
+        user: "1e-1",
+        decimals: 2,
+        error: "invalidNumber",
+      },
+      {
+        user: "1e1",
+        decimals: 2,
+        error: "invalidNumber",
+      },
+      {
+        user: "1e+1",
+        decimals: 2,
+        error: "invalidNumber",
+      },
+      {
         user: "0.333",
         decimals: 2,
         error: "tooManyDecimals",
@@ -343,6 +361,9 @@ describe("fromErc20Units", () => {
           case "tooLargeNumber":
             errorMessage = tooLargeNumber()
             break
+          case "invalidCharacter":
+            errorMessage = invalidCharacter()
+            break
           default:
             throw Error("Invalid error to test")
         }
@@ -425,6 +446,21 @@ describe("fromErc20Units", () => {
         machine: bnMaxUint.add(bnOne).toString(),
         decimals: 255,
         error: "tooLargeNumber",
+      },
+      {
+        machine: "1e+1",
+        decimals: 2,
+        error: "invalidCharacter",
+      },
+      {
+        machine: "1e1",
+        decimals: 2,
+        error: "invalidCharacter",
+      },
+      {
+        machine: "1e-1",
+        decimals: 2,
+        error: "invalidCharacter",
       },
     ]
     testBadEntries(badEntries)


### PR DESCRIPTION
This PR adds the BN library to the dependencies.
Since no version was specified we were using one of the versions provided by another package we are using. This old version accepts any string in the constructor, meaning that garbage would be returned when executing `new BN("1e10")`. With the newest version, the constructor fails on strings that are not well-formatted.
New tests for the printing tools are created to check for invalid strings. In the process I caught a related bug in the tests with automatic deposits and fixed it.