### PR TITLE
Deploy Safe contracts only on development network

### DIFF
--- a/migrations/2_dev_dependencies.js
+++ b/migrations/2_dev_dependencies.js
@@ -1,14 +1,20 @@
 const migrateBatchExchange = require("@gnosis.pm/dex-contracts/src/migration/PoC_dfusion")
+const GnosisSafe = artifacts.require("./GnosisSafe.sol")
+const ProxyFactory = artifacts.require("./GnosisSafeProxyFactory.sol")
+const MultiSend = artifacts.require("./MultiSend.sol")
 
 module.exports = async function(deployer, network, accounts) {
   if (network === "development") {
-    return migrateBatchExchange({
+    await migrateBatchExchange({
       artifacts,
       deployer,
       network,
       account: accounts[0],
       web3,
     })
+    await deployer.deploy(GnosisSafe)
+    await deployer.deploy(ProxyFactory)
+    await deployer.deploy(MultiSend)
   } else {
     // eslint-disable-next-line no-console
     console.log("Not in development, so nothing to do. Current network is %s", network)

--- a/migrations/4_safe_migration.js
+++ b/migrations/4_safe_migration.js
@@ -1,9 +1,0 @@
-const GnosisSafe = artifacts.require("./GnosisSafe.sol")
-const ProxyFactory = artifacts.require("./GnosisSafeProxyFactory.sol")
-const MultiSend = artifacts.require("./MultiSend.sol")
-
-module.exports = async function(deployer) {
-  await deployer.deploy(GnosisSafe)
-  await deployer.deploy(ProxyFactory)
-  await deployer.deploy(MultiSend)
-}


### PR DESCRIPTION
Safe contracts are currently also deployed on mainnet.
This PR moves them in the dev dependencies.