### PR TITLE
Create contract to deploy multiple proxy Safes in the same transaction

### DIFF
--- a/contracts/Dependencies.sol
+++ b/contracts/Dependencies.sol
@@ -14,6 +14,4 @@ import "@gnosis.pm/owl-token/contracts/TokenOWL.sol";
 import "@gnosis.pm/solidity-data-structures/contracts/libraries/IdToAddressBiMap.sol";
 import "@gnosis.pm/solidity-data-structures/contracts/libraries/IterableAppendOnlySet.sol";
 // Gnosis Safe dependencies
-import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
 import "@gnosis.pm/safe-contracts/contracts/libraries/MultiSend.sol";
-import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol";

--- a/contracts/Dependencies.sol
+++ b/contracts/Dependencies.sol
@@ -15,3 +15,4 @@ import "@gnosis.pm/solidity-data-structures/contracts/libraries/IdToAddressBiMap
 import "@gnosis.pm/solidity-data-structures/contracts/libraries/IterableAppendOnlySet.sol";
 // Gnosis Safe dependencies
 import "@gnosis.pm/safe-contracts/contracts/libraries/MultiSend.sol";
+import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxy.sol";

--- a/contracts/FleetFactory.sol
+++ b/contracts/FleetFactory.sol
@@ -1,0 +1,43 @@
+pragma solidity >= 0.5.0 < 0.7.0;
+
+import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol";
+import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxy.sol";
+import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
+
+contract FleetFactory {
+  GnosisSafeProxyFactory public proxyFactory;
+
+  event FleetDeployed(address indexed owner, address[] fleet);
+
+  constructor(GnosisSafeProxyFactory _proxyFactory) public {
+    proxyFactory = _proxyFactory;
+  }
+
+  function deployFleet(address owner, uint256 size) public returns (address[] memory) {
+    IProxy ownerProxyReader = IProxy(owner);
+    return deployFleetFromTemplate(owner, size, ownerProxyReader.masterCopy());
+  }
+
+  function deployFleetFromTemplate(address owner, uint256 size, address template) public returns (address[] memory) {
+    address[] memory fleet = new address[](size);
+    address[] memory ownerList = new address[](1);
+    ownerList[0] = owner;
+    for (uint i = 0; i < size; i++) {
+      address payable proxy = address(proxyFactory.createProxy(template, ""));
+      fleet[i] = proxy;
+      GnosisSafe safe = GnosisSafe(proxy);
+      safe.setup(
+        ownerList,
+        1,
+        address(0),
+        "",
+        address(0),
+        address(0),
+        0,
+        address(0)
+      );
+    }
+    emit FleetDeployed(owner, fleet);
+    return fleet;
+  }
+}

--- a/contracts/FleetFactory.sol
+++ b/contracts/FleetFactory.sol
@@ -1,7 +1,6 @@
 pragma solidity >= 0.5.0 < 0.7.0;
 
 import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol";
-import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxy.sol";
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
 
 contract FleetFactory {
@@ -13,12 +12,7 @@ contract FleetFactory {
     proxyFactory = _proxyFactory;
   }
 
-  function deployFleet(address owner, uint256 size) public returns (address[] memory) {
-    IProxy ownerProxyReader = IProxy(owner);
-    return deployFleetFromTemplate(owner, size, ownerProxyReader.masterCopy());
-  }
-
-  function deployFleetFromTemplate(address owner, uint256 size, address template) public returns (address[] memory) {
+  function deployFleet(address owner, uint256 size, address template) public returns (address[] memory) {
     GnosisSafeProxyFactory _proxyFactory = proxyFactory;
     address[] memory fleet = new address[](size);
     address[] memory ownerList = new address[](1);

--- a/contracts/FleetFactory.sol
+++ b/contracts/FleetFactory.sol
@@ -19,11 +19,12 @@ contract FleetFactory {
   }
 
   function deployFleetFromTemplate(address owner, uint256 size, address template) public returns (address[] memory) {
+    GnosisSafeProxyFactory _proxyFactory = proxyFactory;
     address[] memory fleet = new address[](size);
     address[] memory ownerList = new address[](1);
     ownerList[0] = owner;
     for (uint i = 0; i < size; i++) {
-      address payable proxy = address(proxyFactory.createProxy(template, ""));
+      address payable proxy = address(_proxyFactory.createProxy(template, ""));
       fleet[i] = proxy;
       GnosisSafe safe = GnosisSafe(proxy);
       safe.setup(

--- a/contracts/FleetFactory.sol
+++ b/contracts/FleetFactory.sol
@@ -21,6 +21,7 @@ contract FleetFactory {
       address payable proxy = address(_proxyFactory.createProxy(template, ""));
       fleet[i] = proxy;
       GnosisSafe safe = GnosisSafe(proxy);
+      // safe is set up to have a single owner
       safe.setup(
         ownerList,
         1,

--- a/contracts/FleetFactory.sol
+++ b/contracts/FleetFactory.sol
@@ -12,7 +12,7 @@ contract FleetFactory {
     proxyFactory = _proxyFactory;
   }
 
-  function deployFleet(address owner, uint256 size, address template) public returns (address[] memory) {
+  function deployFleet(address owner, uint256 size, address template) external {
     GnosisSafeProxyFactory _proxyFactory = proxyFactory;
     address[] memory fleet = new address[](size);
     address[] memory ownerList = new address[](1);
@@ -34,6 +34,5 @@ contract FleetFactory {
       );
     }
     emit FleetDeployed(owner, fleet);
-    return fleet;
   }
 }

--- a/migrations/3_fleet_factory.js
+++ b/migrations/3_fleet_factory.js
@@ -1,0 +1,6 @@
+const GnosisSafeProxyFactory = artifacts.require("./GnosisSafeProxyFactory.sol")
+const FleetFactory = artifacts.require("./FleetFactory.sol")
+
+module.exports = async function(deployer) {
+  await deployer.deploy(FleetFactory, GnosisSafeProxyFactory.address)
+}

--- a/test/fleetFactory.js
+++ b/test/fleetFactory.js
@@ -1,0 +1,92 @@
+const GnosisSafe = artifacts.require("GnosisSafe")
+const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
+const IProxy = artifacts.require("IProxy")
+const FleetFactory = artifacts.require("FleetFactory")
+const { deploySafe } = require("../scripts/utils/internals")(web3, artifacts)
+
+/**
+ * Decodes a ProxyCreation raw event from GnosisSafeProxyFactory and tests it for validity.
+ * Returns the address of the newly created proxy.
+ */
+const decodeCreateProxy = function(rawEvent) {
+  const { data, topics } = rawEvent
+  const eventSignature = web3.eth.abi.encodeEventSignature("ProxyCreation(address)")
+  assert.equal(topics[0], eventSignature, "Input raw event is not a CreateProxy event")
+  const decoded = web3.eth.abi.decodeLog(
+    [
+      {
+        type: "address",
+        name: "proxy",
+      },
+    ],
+    data,
+    topics
+  )
+  return decoded.proxy
+}
+
+contract("FleetFactory", function(accounts) {
+  let gnosisSafeMasterCopy
+  let proxyFactory
+  let fleetFactory
+  let master
+  const masterController = accounts[1]
+
+  beforeEach(async function() {
+    gnosisSafeMasterCopy = await GnosisSafe.new()
+    proxyFactory = await ProxyFactory.new()
+    fleetFactory = await FleetFactory.new(proxyFactory.address)
+    master = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [masterController], 1))
+  })
+
+  it("creates and logs new safes", async () => {
+    const numberOfSafes = 20
+    const transcript = await fleetFactory.deployFleet(master.address, numberOfSafes, gnosisSafeMasterCopy.address)
+
+    const fleet = []
+    // the first events are the creation of new proxies with GnosisSafeProxyFactory
+    // these events are not automatically decoded by Truffle because they come from internal transactions to another contract
+    for (let i = 0; i < numberOfSafes; i++) {
+      const rawLog = transcript.receipt.rawLogs[i]
+      fleet.push(decodeCreateProxy(rawLog))
+    }
+    // the last event lists all created proxy, and is the only event decoded by Truffle
+    assert.equal(transcript.receipt.rawLogs.length, numberOfSafes + 1, "More events than expected")
+    assert.equal(transcript.logs.length, 1, "More events than expected")
+
+    const emittedFleet = transcript.logs[0].args.fleet
+    const emittedOwner = transcript.logs[0].args.owner
+    assert.equal(emittedFleet.length, fleet.length, "FleetFactory did not log created Safes correctly")
+    for (let i = 0; i < numberOfSafes; i++)
+      assert.equal(emittedFleet[i], fleet[i], "FleetFactory did not log created Safes correctly")
+    assert.equal(emittedOwner, master.address, "FleetFactory did not log the correct owner")
+  })
+
+  describe("created safes", async function() {
+    it("are owned by master", async () => {
+      const numberOfSafes = 13
+      const transcript = await fleetFactory.deployFleet(master.address, numberOfSafes, gnosisSafeMasterCopy.address)
+      const fleet = transcript.logs[0].args.fleet
+
+      for (const safeAddress of fleet) {
+        const safe = await GnosisSafe.at(safeAddress)
+        const owners = await safe.getOwners()
+        assert.equal(owners.length, 1, "There should be exactly one owner")
+        assert.equal(owners[0], master.address, "There should be exactly one owner")
+      }
+    })
+
+    it("have the right template", async () => {
+      const numberOfSafes = 13
+      const templateAddress = gnosisSafeMasterCopy.address
+      const transcript = await fleetFactory.deployFleet(master.address, numberOfSafes, templateAddress)
+      const fleet = transcript.logs[0].args.fleet
+
+      for (const safeAddress of fleet) {
+        const safe = await IProxy.at(safeAddress)
+        const retrievedTemplate = await safe.masterCopy()
+        assert.equal(retrievedTemplate, templateAddress, "Created Safe uses wrong template")
+      }
+    })
+  })
+})

--- a/test/fleetFactory.js
+++ b/test/fleetFactory.js
@@ -39,6 +39,12 @@ contract("FleetFactory", function(accounts) {
     master = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [masterController], 1))
   })
 
+  it("is deployed with the right factory", async () => {
+    const deployedFleetFactory = await FleetFactory.deployed()
+    const retrievedProxyFactory = await deployedFleetFactory.proxyFactory()
+    assert.equal(retrievedProxyFactory, ProxyFactory.address, "Wrong proxy factory after deployment")
+  })
+
   it("creates and logs new safes", async () => {
     const numberOfSafes = 20
     const transcript = await fleetFactory.deployFleet(master.address, numberOfSafes, gnosisSafeMasterCopy.address)


### PR DESCRIPTION
This PR introduces and tests an Ethereum contract (FleetFactory) for deploying multiple proxy Safes with a single function call in the EVM.

Advantages are:
1. reduced gas cost (a bit more than 21k gas for each Safe deployed)
2. shortened bracket deployment time