### PR TITLE
FleetFactory migration

### DIFF
--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,5 +1,5 @@
 const Migrations = artifacts.require("./Migrations.sol")
 
 module.exports = function(deployer) {
-  deployer.deploy(Migrations)
+  deployer.deploy(Migrations, {gas: 300000})
 }

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,5 +1,5 @@
 const Migrations = artifacts.require("./Migrations.sol")
 
 module.exports = function(deployer) {
-  deployer.deploy(Migrations, {gas: 300000})
+  deployer.deploy(Migrations, { gas: 300000 })
 }

--- a/migrations/3_fleet_factory.js
+++ b/migrations/3_fleet_factory.js
@@ -2,5 +2,5 @@ const GnosisSafeProxyFactory = artifacts.require("./GnosisSafeProxyFactory.sol")
 const FleetFactory = artifacts.require("./FleetFactory.sol")
 
 module.exports = async function(deployer) {
-  await deployer.deploy(FleetFactory, GnosisSafeProxyFactory.address, {gas: 500000})
+  await deployer.deploy(FleetFactory, GnosisSafeProxyFactory.address, { gas: 500000 })
 }

--- a/migrations/3_fleet_factory.js
+++ b/migrations/3_fleet_factory.js
@@ -2,5 +2,5 @@ const GnosisSafeProxyFactory = artifacts.require("./GnosisSafeProxyFactory.sol")
 const FleetFactory = artifacts.require("./FleetFactory.sol")
 
 module.exports = async function(deployer) {
-  await deployer.deploy(FleetFactory, GnosisSafeProxyFactory.address)
+  await deployer.deploy(FleetFactory, GnosisSafeProxyFactory.address, {gas: 500000})
 }

--- a/networks.json
+++ b/networks.json
@@ -20,17 +20,6 @@
       "transactionHash": "0x6b93c236af4d8adf9d9f4aaab07d0158f9ed7dd727141ca117191a3297d6b0e1"
     }
   },
-  "Migrations": {
-    "1": {
-      "links": {},
-      "address": "0x457c89E69850efEb71701aEfd23Eb20f61Fa6cAC"
-    },
-    "4": {
-      "links": {},
-      "address": "0x457c89E69850efEb71701aEfd23Eb20f61Fa6cAC",
-      "transactionHash": "0xa75f39990aed4dbef074363aeeccef45ba73a063cda1c8bce87f0bbf68ff651d"
-    }
-  },
   "MultiSend": {
     "1": {
       "links": {},

--- a/networks.json
+++ b/networks.json
@@ -1,4 +1,11 @@
 {
+  "FleetFactory": {
+    "4": {
+      "links": {},
+      "address": "0x1b94BF378B910e5be70b59e774867a1c919821C7",
+      "transactionHash": "0xf8256a6b6c92a95f9342d0dbb8afee83d1dd6bec8510278893f568ae0114ee3f"
+    }
+  },
   "GnosisSafe": {
     "1": {
       "links": {},
@@ -18,6 +25,13 @@
       "links": {},
       "address": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",
       "transactionHash": "0x6b93c236af4d8adf9d9f4aaab07d0158f9ed7dd727141ca117191a3297d6b0e1"
+    }
+  },
+  "Migrations": {
+    "4": {
+      "links": {},
+      "address": "0xca39A48b3b0C8284bfF8f2299539e2BbaBE714de",
+      "transactionHash": "0x3120664b4b966dc5fa1e13016856d6ef6d39819ed53706a6abee3665f488017b"
     }
   },
   "MultiSend": {

--- a/networks.json
+++ b/networks.json
@@ -1,5 +1,10 @@
 {
   "FleetFactory": {
+    "1": {
+      "links": {},
+      "address": "0xc628FB35ca39705CCD0cBDD5080F1b3d267AdC31",
+      "transactionHash": "0xa2125e6e30056c79569d204197df05a3f9fe09103cfde5569209e9b267518317"
+    },
     "4": {
       "links": {},
       "address": "0x1b94BF378B910e5be70b59e774867a1c919821C7",
@@ -28,6 +33,11 @@
     }
   },
   "Migrations": {
+    "1": {
+      "links": {},
+      "address": "0x094419790e6bfD8071902C7DCa7D59F4c489bF0c",
+      "transactionHash": "0x00358b0338b8fe2cf6d4ee02ecfcf197eb45cb01f56738859a3524b88b154812"
+    },
     "4": {
       "links": {},
       "address": "0xca39A48b3b0C8284bfF8f2299539e2BbaBE714de",

--- a/networks.json
+++ b/networks.json
@@ -1,45 +1,45 @@
 {
-    "GnosisSafe": {
-        "1": {
-            "links": {},
-            "address": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
-        },
-        "4": {
-            "links": {},
-            "address": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
-        }
+  "GnosisSafe": {
+    "1": {
+      "links": {},
+      "address": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
     },
-    "GnosisSafeProxyFactory": {
-        "1": {
-            "links": {},
-            "address": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B"
-        },
-        "4": {
-            "links": {},
-            "address": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",
-            "transactionHash": "0x6b93c236af4d8adf9d9f4aaab07d0158f9ed7dd727141ca117191a3297d6b0e1"
-        }
-    },
-    "MultiSend": {
-        "1": {
-            "links": {},
-            "address": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD"
-        },
-        "4": {
-            "links": {},
-            "address": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD",
-            "transactionHash": "0x6fabaeeba1dba60983da94818965ecbac7b2ed81fc71c08d6582e29dc05745c7"
-        }
-    },
-    "Migrations": {
-        "1": {
-            "links": {},
-            "address": "0x457c89E69850efEb71701aEfd23Eb20f61Fa6cAC"
-        },
-        "4": {
-            "links": {},
-            "address": "0x457c89E69850efEb71701aEfd23Eb20f61Fa6cAC",
-            "transactionHash": "0xa75f39990aed4dbef074363aeeccef45ba73a063cda1c8bce87f0bbf68ff651d"
-        }
+    "4": {
+      "links": {},
+      "address": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
     }
+  },
+  "GnosisSafeProxyFactory": {
+    "1": {
+      "links": {},
+      "address": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B"
+    },
+    "4": {
+      "links": {},
+      "address": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",
+      "transactionHash": "0x6b93c236af4d8adf9d9f4aaab07d0158f9ed7dd727141ca117191a3297d6b0e1"
+    }
+  },
+  "Migrations": {
+    "1": {
+      "links": {},
+      "address": "0x457c89E69850efEb71701aEfd23Eb20f61Fa6cAC"
+    },
+    "4": {
+      "links": {},
+      "address": "0x457c89E69850efEb71701aEfd23Eb20f61Fa6cAC",
+      "transactionHash": "0xa75f39990aed4dbef074363aeeccef45ba73a063cda1c8bce87f0bbf68ff651d"
+    }
+  },
+  "MultiSend": {
+    "1": {
+      "links": {},
+      "address": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD"
+    },
+    "4": {
+      "links": {},
+      "address": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD",
+      "transactionHash": "0x6fabaeeba1dba60983da94818965ecbac7b2ed81fc71c08d6582e29dc05745c7"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "prettier": "prettier --write './**/*.js'",
     "pretty-check": "prettier --check './**/*.js'",
     "test": "truffle test",
-    "networks-inject": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/inject_network_info.js"
+    "compile": "truffle compile",
+    "migrate": "truffle migrate",
+    "verify": "truffle run verify",
+    "networks-inject": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/inject_network_info.js",
+    "networks-extract": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/extract_network_info.js"
   },
   "dependencies": {
     "@gnosis.pm/dex-contracts": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "compile": "truffle compile",
     "migrate": "truffle migrate",
     "verify": "truffle run verify",
+    "flatten": "export FLATTENED_DIR=\"./build/flattenedContracts\" && mkdir -p $FLATTENED_DIR && npx sol-merger \"contracts/*.sol\" $FLATTENED_DIR && echo \"Flattened contracts stored in $FLATTENED_DIR\" && unset FLATTENED_DIR",
     "networks-inject": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/inject_network_info.js",
     "networks-extract": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/extract_network_info.js"
   },
@@ -40,6 +41,7 @@
     "eth-gas-reporter": "^0.2.16",
     "node-fetch": "^2.6.0",
     "openzeppelin-solidity": "^2.4.0",
+    "sol-merger": "^2.0.1",
     "truffle": "^5.1.18",
     "truffle-plugin-verify": "^0.3.10"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5414,7 +5414,7 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-sol-merger@2.0.1:
+sol-merger@2.0.1, sol-merger@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/sol-merger/-/sol-merger-2.0.1.tgz#995338b7bcc7e60cd7c8a8661726e4be82e19884"
   integrity sha512-oab9qSiD+P+xZ0DKgxeYTggKAp+JWaVk849I0tL2oZtl+fEgiefu6wvOdTahwVwCWT+DYR0fiXeQ3Ee87je5Hw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,11 +1139,6 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@=1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.3.tgz#bd47a8986bbb3eec34a56a097a84b8d3e9a2dfcd"
-  integrity sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg==
-
 bignumber.js@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
@@ -3985,7 +3980,7 @@ lodash@=4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@=4.17.15, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -6503,9 +6498,9 @@ web3-provider-engine@^14.0.5:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-"web3-provider-engine@git+https://github.com/trufflesuite/provider-engine.git#web3-one":
+"web3-provider-engine@https://github.com/trufflesuite/provider-engine#web3-one":
   version "14.0.6"
-  resolved "git+https://github.com/trufflesuite/provider-engine.git#3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a"
+  resolved "https://github.com/trufflesuite/provider-engine#3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a"
   dependencies:
     async "^2.5.0"
     backoff "^2.5.0"


### PR DESCRIPTION
Setup tools needed for a clean migration on mainnet, including contract verification on Etherscan.

Migrations are run as follows:
```
export NETWORK_NAME=<insert network name, e.g. rinkeby or mainnet>
export GAS_PRICE_GWEI=<insert gas price in Gwei, e.g. 20>
 export PK=<insert Ethereum private key here>
 export MY_ETHERSCAN_API_KEY=<insert Etherscan API key here>

rm -r build
yarn compile
yarn networks-inject
yarn migrate --network $NETWORK_NAME
yarn networks-extract
yarn verify FleetFactory --network $NETWORK_NAME
```

Contracts deployed on Rinkeby:
Migrations: `0xca39A48b3b0C8284bfF8f2299539e2BbaBE714de`
FleetFactory: `0x1b94BF378B910e5be70b59e774867a1c919821C7`

Contracts deployed on mainnet:
Migrations: `0x094419790e6bfD8071902C7DCa7D59F4c489bF0c`
FleetFactory: `0xc628FB35ca39705CCD0cBDD5080F1b3d267AdC31`