### PR TITLE
Better argument hadling

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -26,7 +26,7 @@ const argv = require("./utils/default_yargs")
   })
   .option("brackets", {
     type: "string",
-    describe: "Trader account addresses to place orders on behalf of.",
+    describe: "Trader account addresses to place orders on behalf of",
     demandOption: true,
     coerce: str => {
       return str.split(",")

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -49,8 +49,7 @@ const argv = require("./utils/default_yargs")
     type: "int",
     describe: "Maximum auction batch for which these orders are valid",
     default: 2 ** 32 - 1,
-  })
-  .argv
+  }).argv
 
 module.exports = async callback => {
   try {

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -3,7 +3,7 @@ const { isPriceReasonable, areBoundsReasonable } = require("./utils/price-utils.
 const { proceedAnyways } = require("./utils/user-interface-helpers")
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 
-const argv = require("yargs")
+const argv = require("./utils/default_yargs")
   .option("targetToken", {
     type: "int",
     describe: "Token whose target price is to be specified (i.e. ETH)",
@@ -45,10 +45,7 @@ const argv = require("yargs")
     default: 2 ** 32 - 1,
   })
   .demand(["targetToken", "stableToken", "currentPrice", "masterSafe", "brackets"])
-  .help(
-    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
-  )
-  .version(false).argv
+  .argv
 
 module.exports = async callback => {
   try {

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -9,6 +9,7 @@ const argv = require("./utils/default_yargs")
     describe: "Token whose target price is to be specified (i.e. ETH)",
   })
   .option("stableToken", {
+    type: "int",
     describe: "Stable Token for which to open orders (i.e. DAI)",
   })
   .option("currentPrice", {

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -7,22 +7,27 @@ const argv = require("./utils/default_yargs")
   .option("targetToken", {
     type: "int",
     describe: "Token whose target price is to be specified (i.e. ETH)",
+    demandOption: true,
   })
   .option("stableToken", {
     type: "int",
     describe: "Stable Token for which to open orders (i.e. DAI)",
+    demandOption: true,
   })
   .option("currentPrice", {
     type: "float",
     describe: "Price at which the brackets will be centered (e.g. current price of ETH in USD)",
+    demandOption: true,
   })
   .option("masterSafe", {
     type: "string",
     describe: "Address of Gnosis Safe owning all brackets",
+    demandOption: true,
   })
   .option("brackets", {
     type: "string",
     describe: "Trader account addresses to place orders on behalf of.",
+    demandOption: true,
     coerce: str => {
       return str.split(",")
     },
@@ -45,7 +50,6 @@ const argv = require("./utils/default_yargs")
     describe: "Maximum auction batch for which these orders are valid",
     default: 2 ** 32 - 1,
   })
-  .demand(["targetToken", "stableToken", "currentPrice", "masterSafe", "brackets"])
   .argv
 
 module.exports = async callback => {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -58,8 +58,7 @@ const argv = require("./utils/default_yargs")
   .option("highestLimit", {
     type: "float",
     describe: "Price for the bracket selling at the highest price",
-  })
-  .argv
+  }).argv
 
 module.exports = async callback => {
   try {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -15,7 +15,7 @@ const { proceedAnyways } = require("./utils/user-interface-helpers")(web3, artif
 const { toErc20Units } = require("./utils/printing_tools")
 const assert = require("assert")
 
-const argv = require("yargs")
+const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
     describe: "Address of Gnosis Safe owning every bracket",
@@ -51,10 +51,7 @@ const argv = require("yargs")
     describe: "Price for the bracket selling at the highest price",
   })
   .demand(["masterSafe", "targetToken", "stableToken", "currentPrice", "investmentTargetToken", "investmentStableToken"])
-  .help(
-    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
-  )
-  .version(false).argv
+  .argv
 
 module.exports = async callback => {
   try {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -19,6 +19,7 @@ const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
     describe: "Address of Gnosis Safe owning every bracket",
+    demandOption: true,
   })
   .option("fleetSize", {
     type: "int",
@@ -28,19 +29,24 @@ const argv = require("./utils/default_yargs")
   .option("targetToken", {
     type: "int",
     describe: "Token whose target price is to be specified (i.e. ETH)",
+    demandOption: true,
   })
   .option("investmentTargetToken", {
     describe: "Amount to be invested into the targetToken",
+    demandOption: true,
   })
   .option("stableToken", {
     describe: "Trusted Stable Token for which to open orders (i.e. DAI)",
+    demandOption: true,
   })
   .option("investmentStableToken", {
     describe: "Amount to be invested into the stableToken",
+    demandOption: true,
   })
   .option("currentPrice", {
     type: "float",
     describe: "Price at which the brackets will be centered (e.g. current price of ETH in USD)",
+    demandOption: true,
   })
   .option("lowestLimit", {
     type: "float",
@@ -50,7 +56,6 @@ const argv = require("./utils/default_yargs")
     type: "float",
     describe: "Price for the bracket selling at the highest price",
   })
-  .demand(["masterSafe", "targetToken", "stableToken", "currentPrice", "investmentTargetToken", "investmentStableToken"])
   .argv
 
 module.exports = async callback => {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -32,14 +32,17 @@ const argv = require("./utils/default_yargs")
     demandOption: true,
   })
   .option("investmentTargetToken", {
+    type: "string",
     describe: "Amount to be invested into the targetToken",
     demandOption: true,
   })
   .option("stableToken", {
+    type: "int",
     describe: "Trusted Stable Token for which to open orders (i.e. DAI)",
     demandOption: true,
   })
   .option("investmentStableToken", {
+    type: "string",
     describe: "Amount to be invested into the stableToken",
     demandOption: true,
   })

--- a/scripts/deploy_safes.js
+++ b/scripts/deploy_safes.js
@@ -10,8 +10,7 @@ const argv = require("./utils/default_yargs")
     type: "int",
     describe: "Number of (sub)safes to be deployed",
     demandOption: true,
-  })
-  .argv
+  }).argv
 
 module.exports = async callback => {
   try {

--- a/scripts/deploy_safes.js
+++ b/scripts/deploy_safes.js
@@ -4,12 +4,13 @@ const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "int",
     describe: "Address of Gnosis Safe that is going to own the new fleet",
+    demandOption: true,
   })
   .option("fleetSize", {
     type: "int",
     describe: "Number of (sub)safes to be deployed",
+    demandOption: true,
   })
-  .demand(["masterSafe", "fleetSize"])
   .argv
 
 module.exports = async callback => {

--- a/scripts/deploy_safes.js
+++ b/scripts/deploy_safes.js
@@ -1,6 +1,6 @@
 const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 
-const argv = require("yargs")
+const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "int",
     describe: "Address of Gnosis Safe that is going to own the new fleet",
@@ -10,10 +10,7 @@ const argv = require("yargs")
     describe: "Number of (sub)safes to be deployed",
   })
   .demand(["masterSafe", "fleetSize"])
-  .help(
-    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
-  )
-  .version(false).argv
+  .argv
 
 module.exports = async callback => {
   try {

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -9,7 +9,7 @@ const argv = require("./utils/default_yargs")
   })
   .option("depositFile", {
     type: "string",
-    describe: "file name (and path) to the list of deposits.",
+    describe: "file name (and path) to the list of deposits",
     demandOption: true,
   }).argv
 

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -1,7 +1,7 @@
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 const { buildTransferApproveDepositFromList } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 
-const argv = require("yargs")
+const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
     describe: "Address of Gnosis Safe owning the brackets",
@@ -11,10 +11,7 @@ const argv = require("yargs")
     describe: "file name (and path) to the list of deposits.",
   })
   .demand(["masterSafe", "depositFile"])
-  .help(
-    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
-  )
-  .version(false).argv
+  .argv
 
 module.exports = async callback => {
   try {

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -11,8 +11,7 @@ const argv = require("./utils/default_yargs")
     type: "string",
     describe: "file name (and path) to the list of deposits.",
     demandOption: true,
-  })
-  .argv
+  }).argv
 
 module.exports = async callback => {
   try {

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -5,12 +5,13 @@ const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
     describe: "Address of Gnosis Safe owning the brackets",
+    demandOption: true,
   })
   .option("depositFile", {
     type: "string",
     describe: "file name (and path) to the list of deposits.",
+    demandOption: true,
   })
-  .demand(["masterSafe", "depositFile"])
   .argv
 
 module.exports = async callback => {

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -1,0 +1,5 @@
+module.exports = require("yargs")
+  .version(false)
+  .help(
+    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
+  )

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -3,3 +3,8 @@ module.exports = require("yargs")
   .epilog(
     "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
   )
+  .option("network", {
+    type: "string",
+    describe: "where the scripts are executed (supported networks: rinkeby, mainnet)",
+    choices: ["rinkeby", "mainnet"],
+  })

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -10,3 +10,4 @@ module.exports = require("yargs")
     describe: "network where the script is executed",
     choices: ["rinkeby", "mainnet"],
   })
+  

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -7,6 +7,6 @@ module.exports = require("yargs")
   )
   .option("network", {
     type: "string",
-    describe: "where the scripts are executed (supported networks: rinkeby, mainnet)",
+    describe: "network where the script is executed",
     choices: ["rinkeby", "mainnet"],
   })

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -10,4 +10,3 @@ module.exports = require("yargs")
     describe: "network where the script is executed",
     choices: ["rinkeby", "mainnet"],
   })
-  

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -1,5 +1,6 @@
 module.exports = require("yargs")
   .version(false)
+  .strict()
   .epilog(
     "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
   )

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -1,5 +1,5 @@
 module.exports = require("yargs")
   .version(false)
-  .help(
+  .epilog(
     "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
   )

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -1,6 +1,7 @@
 module.exports = require("yargs")
   .version(false)
   .strict()
+  .help("help")
   .epilog(
     "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
   )

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -10,7 +10,7 @@ const {
   buildWithdrawAndTransferFundsToMaster,
 } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 
-const argv = require("yargs")
+const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
     describe: "Address of Gnosis Safe owning bracketSafes.",
@@ -40,9 +40,6 @@ const argv = require("yargs")
     describe: "transfer back funds from brackets to master. Funds must be present in the bracket wallets",
   })
   .demand(["masterSafe", "withdrawalFile"])
-  .help(
-    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
-  )
   .check(function(argv) {
     if (!argv.requestWithdraw && !argv.withdraw && !argv.transferFundsToMaster) {
       throw new Error("Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given")
@@ -51,7 +48,7 @@ const argv = require("yargs")
     }
     return true
   })
-  .version(false).argv
+  .argv
 
 const getAmount = async function(bracketAddress, tokenInfo, exchange) {
   let amount

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -13,28 +13,28 @@ const {
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
-    describe: "Address of Gnosis Safe owning bracketSafes.",
+    describe: "Address of Gnosis Safe owning bracketSafes",
     demandOption: true,
   })
   .option("withdrawalFile", {
     type: "string",
-    describe: "file name (and path) to the list of withdrawals.",
+    describe: "file name (and path) to the list of withdrawals",
     demandOption: true,
   })
   .option("allTokens", {
     type: "boolean",
     default: false,
-    describe: "ignore amounts from withdrawalFile and try to withdraw the maximum amount available for each bracket.",
+    describe: "ignore amounts from withdrawalFile and try to withdraw the maximum amount available for each bracket",
   })
   .option("requestWithdraw", {
     type: "boolean",
     default: false,
-    describe: "request withdraw from the exchange.",
+    describe: "request withdraw from the exchange",
   })
   .option("withdraw", {
     type: "boolean",
     default: false,
-    describe: "withdraw from the exchange. A withdraw request must always be made before withdrawing funds from the exchange.",
+    describe: "withdraw from the exchange. A withdraw request must always be made before withdrawing funds from the exchange",
   })
   .option("transferFundsToMaster", {
     type: "boolean",

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -14,10 +14,12 @@ const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
     describe: "Address of Gnosis Safe owning bracketSafes.",
+    demandOption: true,
   })
   .option("withdrawalFile", {
     type: "string",
     describe: "file name (and path) to the list of withdrawals.",
+    demandOption: true,
   })
   .option("allTokens", {
     type: "boolean",
@@ -39,7 +41,6 @@ const argv = require("./utils/default_yargs")
     default: false,
     describe: "transfer back funds from brackets to master. Funds must be present in the bracket wallets",
   })
-  .demand(["masterSafe", "withdrawalFile"])
   .check(function(argv) {
     if (!argv.requestWithdraw && !argv.withdraw && !argv.transferFundsToMaster) {
       throw new Error("Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given")

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -48,8 +48,7 @@ const argv = require("./utils/default_yargs")
       throw new Error("Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster")
     }
     return true
-  })
-  .argv
+  }).argv
 
 const getAmount = async function(bracketAddress, tokenInfo, exchange) {
   let amount

--- a/scripts/wrap_eth.js
+++ b/scripts/wrap_eth.js
@@ -4,7 +4,7 @@ const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artif
 const { CALL } = require("./utils/internals")(web3, artifacts)
 const { toErc20Units, fromErc20Units } = require("./utils/printing_tools")
 
-const argv = require("yargs")
+const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
     describe: "Address of the Gnosis Safe that holds the ETH to be wrapped",
@@ -14,10 +14,7 @@ const argv = require("yargs")
     describe: "Amount of ETH to convert (in ETH, e.g. 3.14159)",
   })
   .demand(["masterSafe", "amount"])
-  .help(
-    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js"
-  )
-  .version(false).argv
+  .argv
 
 module.exports = async callback => {
   try {

--- a/scripts/wrap_eth.js
+++ b/scripts/wrap_eth.js
@@ -14,8 +14,7 @@ const argv = require("./utils/default_yargs")
     type: "string",
     describe: "Amount of ETH to convert (in ETH, e.g. 3.14159)",
     demandOption: true,
-  })
-  .argv
+  }).argv
 
 module.exports = async callback => {
   try {

--- a/scripts/wrap_eth.js
+++ b/scripts/wrap_eth.js
@@ -8,12 +8,13 @@ const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
     describe: "Address of the Gnosis Safe that holds the ETH to be wrapped",
+    demandOption: true,
   })
   .option("amount", {
     type: "string",
     describe: "Amount of ETH to convert (in ETH, e.g. 3.14159)",
+    demandOption: true,
   })
-  .demand(["masterSafe", "amount"])
   .argv
 
 module.exports = async callback => {


### PR DESCRIPTION
Reworks how command-line arguments are handled.

Most important change is that the scripts fail if one of the input arguments is not defined. This helps avoiding misspelling of arguments which would lead to some probably unwanted default behavior. Example: running the withdraw script with `--allToken` now fails (the right name is `--allTokens`).