### PR TITLE
[Travis] Use generic truffle test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ before_install:
 before_script:
   - ganache-cli -l 8e6 > /dev/null &
 script:
-  - yarn run lint
-  - yarn run pretty-check
-  - yarn run test test/dfusionMultiSafes.js
-  - yarn run test test/priceUtils.js
+  - yarn lint
+  - yarn pretty-check
+  - yarn test
   - npx mocha test/printingTools.js

--- a/test/fleetFactory.js
+++ b/test/fleetFactory.js
@@ -2,7 +2,7 @@ const GnosisSafe = artifacts.require("GnosisSafe")
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const IProxy = artifacts.require("IProxy")
 const FleetFactory = artifacts.require("FleetFactory")
-const { deploySafe } = require("../scripts/utils/internals")(web3, artifacts)
+const { deploySafe } = require("./test-utils")
 
 /**
  * Decodes a ProxyCreation raw event from GnosisSafeProxyFactory and tests it for validity.


### PR DESCRIPTION
This PR essentially used `truffle test` so that all test files are run rather than testing individual files. This change already revealed a file `fleetFactory` that was not being run in tests because of it. 

Have a generic test environment will avoid accidentally ignoring new files.