### PR TITLE
[Easy] Bitcore Lib Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "synthetix-js": "^2.21.6",
     "truffle": "^5.1.18",
     "truffle-plugin-verify": "^0.3.10"
+  },
+  "resolutions": {
+    "bitcore-lib": "8.1.1"
   }
 }


### PR DESCRIPTION
Finally a working fix for this dreadful `bitcore-lib` dependency by introducing a "resolution" version.

Test Plan:

Unfortunately I can only describe the test at this point. Worked for me when building a docker image of this project in #129. I recommend checking out that branch and observing that the build works with this, but not without!