### PR TITLE
Remove import from price utils

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -1,4 +1,7 @@
-const { getExchange, getSafe, buildOrders } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { fetchTokenInfoFromExchange, getExchange, getSafe, buildOrders } = require("./utils/trading_strategy_helpers")(
+  web3,
+  artifacts
+)
 const { isPriceReasonable, areBoundsReasonable } = require("./utils/price-utils.js")(web3, artifacts)
 const { proceedAnyways } = require("./utils/user-interface-helpers")
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
@@ -59,7 +62,10 @@ module.exports = async callback => {
     // check price against dex.ag's API
     const targetTokenId = argv.targetToken
     const stableTokenId = argv.stableToken
-    const priceCheck = await isPriceReasonable(exchange, targetTokenId, stableTokenId, argv.currentPrice)
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId])
+    const targetTokenData = await tokenInfoPromises[targetTokenId]
+    const stableTokenData = await tokenInfoPromises[stableTokenId]
+    const priceCheck = await isPriceReasonable(targetTokenData, stableTokenData, argv.currentPrice)
     const boundCheck = areBoundsReasonable(argv.currentPrice, argv.lowestLimit, argv.highestLimit)
 
     if (priceCheck || (await proceedAnyways("Price check failed!"))) {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -73,8 +73,10 @@ module.exports = async callback => {
     const targetTokenId = argv.targetToken
     const stableTokenId = argv.stableToken
     const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId])
-    const { instance: targetToken, decimals: targetTokenDecimals } = await tokenInfoPromises[targetTokenId]
-    const { instance: stableToken, decimals: stableTokenDecimals } = await tokenInfoPromises[stableTokenId]
+    const targetTokenData = await tokenInfoPromises[targetTokenId]
+    const stableTokenData = await tokenInfoPromises[stableTokenId]
+    const { instance: targetToken, decimals: targetTokenDecimals } = targetTokenData
+    const { instance: stableToken, decimals: stableTokenDecimals } = stableTokenData
 
     const investmentTargetToken = toErc20Units(argv.investmentTargetToken, targetTokenDecimals)
     const investmentStableToken = toErc20Units(argv.investmentStableToken, stableTokenDecimals)
@@ -89,7 +91,7 @@ module.exports = async callback => {
       callback(`Error: MasterSafe has insufficient balance for the token ${stableToken.address}.`)
     }
     // check price against dex.ag's API
-    const priceCheck = await isPriceReasonable(exchange, targetTokenId, stableTokenId, argv.currentPrice)
+    const priceCheck = await isPriceReasonable(targetTokenData, stableTokenData, argv.currentPrice)
     if (!priceCheck) {
       if (!(await proceedAnyways("Price check failed!"))) {
         callback("Error: Price checks did not pass")

--- a/scripts/utils/price-utils.js
+++ b/scripts/utils/price-utils.js
@@ -3,8 +3,6 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
   const BN = require("bn.js")
   const exchangeUtils = require("@gnosis.pm/dex-contracts")
 
-  const { fetchTokenInfoFromExchange } = require("./trading_strategy_helpers")(web3, artifacts)
-
   const checkCorrectnessOfDeposits = async (
     currentPrice,
     bracketAddress,
@@ -118,11 +116,8 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
     return price
   }
 
-  const isPriceReasonable = async (exchange, targetTokenId, stableTokenId, price, acceptedPriceDeviationInPercentage = 2) => {
-    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId])
-    const targetToken = await tokenInfoPromises[targetTokenId]
-    const stableToken = await tokenInfoPromises[stableTokenId]
-    const dexagPrice = await getDexagPrice(stableToken.symbol, targetToken.symbol)
+  const isPriceReasonable = async (targetTokenData, stableTokenData, price, acceptedPriceDeviationInPercentage = 2) => {
+    const dexagPrice = await getDexagPrice(stableTokenData.symbol, targetTokenData.symbol)
     if (dexagPrice === undefined) {
       console.log("Warning: could not perform price check against dex.ag.")
       return false
@@ -132,8 +127,8 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
         acceptedPriceDeviationInPercentage,
         "percent from the price found on dex.ag."
       )
-      console.log("         chosen price:", price, stableToken.symbol, "bought for 1", targetToken.symbol)
-      console.log("         dex.ag price:", dexagPrice, stableToken.symbol, "bought for 1", targetToken.symbol)
+      console.log("         chosen price:", price, stableTokenData.symbol, "bought for 1", targetTokenData.symbol)
+      console.log("         dex.ag price:", dexagPrice, stableTokenData.symbol, "bought for 1", targetTokenData.symbol)
       return false
     }
     return true

--- a/test/priceUtils.js
+++ b/test/priceUtils.js
@@ -7,12 +7,8 @@ contract("PriceOracle", function() {
       //the following test especially checks that the price p is not inverted (1/p) and is not below 1
       const acceptedPriceDeviationInPercentage = 99
       const price = 1000
-      const targetTokenData = {
-        symbol: "WETH"
-      }
-      const stableTokenData = {
-        symbol: "DAI"
-      }
+      const targetTokenData = { symbol: "WETH" }
+      const stableTokenData = { symbol: "DAI" }
       assert(await isPriceReasonable(targetTokenData, stableTokenData, price, acceptedPriceDeviationInPercentage))
     })
   })

--- a/test/priceUtils.js
+++ b/test/priceUtils.js
@@ -1,30 +1,19 @@
 const assert = require("assert")
-const Contract = require("@truffle/contract")
-const { prepareTokenRegistration } = require("./test-utils")
 const { isPriceReasonable } = require("../scripts/utils/price-utils")(web3, artifacts)
 
-contract("PriceOracle", function(accounts) {
+contract("PriceOracle", function() {
   describe("Price oracle sanity check", async () => {
     it("checks that price is within reasonable range (10 ≤ price ≤ 1990)", async () => {
       //the following test especially checks that the price p is not inverted (1/p) and is not below 1
-
-      const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
-      BatchExchange.setProvider(web3.currentProvider)
-      BatchExchange.setNetwork(web3.network_id)
-      const exchange = await BatchExchange.deployed()
-
-      const ERC20 = artifacts.require("DetailedMintableToken")
-      const token1 = await ERC20.new("WETH", 18)
-      const token2 = await ERC20.new("DAI", 18)
-      await prepareTokenRegistration(accounts[0], exchange)
-      await exchange.addToken(token1.address, { from: accounts[0] })
-      await prepareTokenRegistration(accounts[0], exchange)
-      await exchange.addToken(token2.address, { from: accounts[0] })
-      const targetTokenId = 1
-      const stableTokenId = 2
       const acceptedPriceDeviationInPercentage = 99
       const price = 1000
-      assert(await isPriceReasonable(exchange, targetTokenId, stableTokenId, price, acceptedPriceDeviationInPercentage))
+      const targetTokenData = {
+        symbol: "WETH"
+      }
+      const stableTokenData = {
+        symbol: "DAI"
+      }
+      assert(await isPriceReasonable(targetTokenData, stableTokenData, price, acceptedPriceDeviationInPercentage))
     })
   })
 })


### PR DESCRIPTION
Motivation: I had an issue with a circular dependency in a PR I'm working on. I want to require price-utils from trading_strategy_helpers but the latter is already requiring the former. Since the only function needing that import is `isPriceReasonable`, and it looked like we could make it simpler, I removed the dependency by simplifying the logic. Is this change ok in your PR?