### PR TITLE
Compute prices without precision issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "networks-extract": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/extract_network_info.js"
   },
   "dependencies": {
-    "@gnosis.pm/dex-contracts": "^0.2.8",
+    "@gnosis.pm/dex-contracts": "github:gnosis/dex-contracts#28a1b654439e755b5475218f4119ea72830b7fb4",
     "@gnosis.pm/owl-token": "^3.1.0",
     "@gnosis.pm/safe-contracts": "github:gnosis/safe-contracts#v1.1.1-dev.1",
     "@gnosis.pm/solidity-data-structures": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "networks-extract": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/extract_network_info.js"
   },
   "dependencies": {
-    "@gnosis.pm/dex-contracts": "github:gnosis/dex-contracts#28a1b654439e755b5475218f4119ea72830b7fb4",
+    "@gnosis.pm/dex-contracts": "^0.2.9",
     "@gnosis.pm/owl-token": "^3.1.0",
     "@gnosis.pm/safe-contracts": "github:gnosis/safe-contracts#v1.1.1-dev.1",
     "@gnosis.pm/solidity-data-structures": "^1.2.2",

--- a/scripts/utils/price-utils.js
+++ b/scripts/utils/price-utils.js
@@ -180,5 +180,6 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
     checkCorrectnessOfDeposits,
     getOutputAmountFromPrice,
     getUnlimitedOrderAmounts,
+    max128,
   }
 }

--- a/scripts/utils/price-utils.js
+++ b/scripts/utils/price-utils.js
@@ -159,11 +159,11 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
   /**
    * Computes the stable and target token amounts needed to set up an unlimited order in the exchange
    * @param {number} price amount of stable tokens in exchange for one target token
-   * @param {integer} stableTokenDecimals number of decimals of the stable token
    * @param {integer} targetTokenDecimals number of decimals of the target token
+   * @param {integer} stableTokenDecimals number of decimals of the stable token
    * @return {BN[2]} amounts of stable token and target token for an unlimited order at the input price
    */
-  const getUnlimitedOrderAmounts = function(price, stableTokenDecimals, targetTokenDecimals) {
+  const getUnlimitedOrderAmounts = function(price, targetTokenDecimals, stableTokenDecimals) {
     let targetTokenAmount = max128.clone()
     let stableTokenAmount = getOutputAmountFromPrice(price, targetTokenAmount, targetTokenDecimals, stableTokenDecimals)
     if (stableTokenAmount.gt(targetTokenAmount)) {
@@ -171,7 +171,7 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
       targetTokenAmount = getOutputAmountFromPrice(1/price, stableTokenAmount, stableTokenDecimals, targetTokenDecimals)
       assert(stableTokenAmount.gte(targetTokenAmount), "Error: unable to create unlimited order")
     }
-    return [stableTokenAmount, targetTokenAmount]
+    return [targetTokenAmount, stableTokenAmount]
   }
 
   return {

--- a/scripts/utils/price-utils.js
+++ b/scripts/utils/price-utils.js
@@ -155,7 +155,6 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
     return stableTokenAmountFraction.toBN()
   }
 
-
   /**
    * Computes the stable and target token amounts needed to set up an unlimited order in the exchange
    * @param {number} price amount of stable tokens in exchange for one target token
@@ -168,7 +167,7 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
     let stableTokenAmount = getOutputAmountFromPrice(price, targetTokenAmount, targetTokenDecimals, stableTokenDecimals)
     if (stableTokenAmount.gt(targetTokenAmount)) {
       stableTokenAmount = max128.clone()
-      targetTokenAmount = getOutputAmountFromPrice(1/price, stableTokenAmount, stableTokenDecimals, targetTokenDecimals)
+      targetTokenAmount = getOutputAmountFromPrice(1 / price, stableTokenAmount, stableTokenDecimals, targetTokenDecimals)
       assert(stableTokenAmount.gte(targetTokenAmount), "Error: unable to create unlimited order")
     }
     return [targetTokenAmount, stableTokenAmount]

--- a/scripts/utils/price-utils.js
+++ b/scripts/utils/price-utils.js
@@ -141,18 +141,18 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
    * Computes the amount of output token units from their price and the amount of input token units
    * Note that the price is expressed in terms of tokens, while the amounts are in terms of token units
    * @param {number} price amount of output token in exchange for one input token
-   * @param {BN} inputTokenAmount amount of token units that are exchanged at price
-   * @param {integer} inputDecimals number of decimals of the input token
-   * @param {integer} outputDecimals number of decimals of the output token
+   * @param {BN} targetTokenAmount amount of token units that are exchanged at price
+   * @param {integer} targetTokenDecimals number of decimals of the input token
+   * @param {integer} stableTokenDecimals number of decimals of the output token
    * @return {BN} amount of output token units obtained
    */
-  const getOutputAmountFromPrice = function(price, inputAmount, inputDecimals, outputDecimals) {
+  const getOutputAmountFromPrice = function(price, targetTokenAmount, targetTokenDecimals, stableTokenDecimals) {
     const priceFraction = Fraction.fromNumber(price)
     const unitPriceFraction = priceFraction.mul(
-      new Fraction(new BN(10).pow(new BN(outputDecimals)), new BN(10).pow(new BN(inputDecimals)))
+      new Fraction(new BN(10).pow(new BN(stableTokenDecimals)), new BN(10).pow(new BN(targetTokenDecimals)))
     )
-    const outputAmountFraction = unitPriceFraction.mul(new Fraction(inputAmount, 1))
-    return outputAmountFraction.toBN()
+    const stableTokenAmountFraction = unitPriceFraction.mul(new Fraction(targetTokenAmount, 1))
+    return stableTokenAmountFraction.toBN()
   }
 
 

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -247,10 +247,10 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
         const lowerLimit = lowestLimit * Math.pow(stepSizeAsMultiplier, bracketIndex)
         const upperLimit = lowerLimit * stepSizeAsMultiplier
 
-        const [upperBuyAmount, upperSellAmount] = getUnlimitedOrderAmounts(upperLimit, stableToken.decimals, targetToken.decimals)
+        const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(upperLimit, targetToken.decimals, stableToken.decimals)
         // While the first bracket-order trades standard_token against target_token, the second bracket-order trades
         // target_token against standard_token. Hence the buyAmounts and sellAmounts are switched in the next line.
-        const [lowerSellAmount, lowerBuyAmount] = getUnlimitedOrderAmounts(lowerLimit, stableToken.decimals, targetToken.decimals)
+        const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(lowerLimit, targetToken.decimals, stableToken.decimals)
 
         log(
           `Safe ${bracketIndex} - ${bracketAddress}:\n  Buy  ${targetToken.symbol} with ${stableToken.symbol} at ${lowerLimit}\n  Sell ${targetToken.symbol} for  ${stableToken.symbol} at ${upperLimit}`

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -246,10 +246,18 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
         const lowerLimit = lowestLimit * Math.pow(stepSizeAsMultiplier, bracketIndex)
         const upperLimit = lowerLimit * stepSizeAsMultiplier
 
-        const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(upperLimit, targetToken.decimals, stableToken.decimals)
+        const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(
+          upperLimit,
+          targetToken.decimals,
+          stableToken.decimals
+        )
         // While the first bracket-order trades standard_token against target_token, the second bracket-order trades
         // target_token against standard_token. Hence the buyAmounts and sellAmounts are switched in the next line.
-        const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(lowerLimit, targetToken.decimals, stableToken.decimals)
+        const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(
+          lowerLimit,
+          targetToken.decimals,
+          stableToken.decimals
+        )
 
         log(
           `Safe ${bracketIndex} - ${bracketAddress}:\n  Buy  ${targetToken.symbol} with ${stableToken.symbol} at ${lowerLimit}\n  Sell ${targetToken.symbol} for  ${stableToken.symbol} at ${upperLimit}`

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -18,7 +18,6 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
   const { allElementsOnlyOnce } = require("./js_helpers")
   const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
   const maxU32 = 2 ** 32 - 1
-  const max128 = new BN(2).pow(new BN(128)).subn(1)
   const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))
 
   /**
@@ -588,7 +587,6 @@ withdrawal of the desired funds
     fetchTokenInfoFromExchange,
     fetchTokenInfoForFlux,
     isOnlySafeOwner,
-    max128,
     maxU32,
     maxUINT,
     ADDRESS_0,

--- a/test/dfusionMultiSafes.js
+++ b/test/dfusionMultiSafes.js
@@ -21,11 +21,10 @@ const {
   buildTransferFundsToMaster,
   buildWithdrawAndTransferFundsToMaster,
   isOnlySafeOwner,
-  max128,
   maxU32,
 } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
 const { waitForNSeconds, execTransaction } = require("../scripts/utils/internals")(web3, artifacts)
-const { checkCorrectnessOfDeposits } = require("../scripts/utils/price-utils")(web3, artifacts)
+const { checkCorrectnessOfDeposits, max128 } = require("../scripts/utils/price-utils")(web3, artifacts)
 
 const { toErc20Units, fromErc20Units } = require("../scripts/utils/printing_tools")
 

--- a/test/priceUtils.js
+++ b/test/priceUtils.js
@@ -113,7 +113,7 @@ describe("getUnlimitedOrderAmounts", () => {
       },
     ]
     for (const { price, stableTokenDecimals, targetTokenDecimals, expectedStableTokenAmount, expectedTargetTokenAmount } of testCases) {
-      const [stableTokenAmount, targetTokenAmount] = getUnlimitedOrderAmounts(price, stableTokenDecimals, targetTokenDecimals)
+      const [targetTokenAmount, stableTokenAmount] = getUnlimitedOrderAmounts(price, targetTokenDecimals, stableTokenDecimals)
       assertEqualUpToFloatPrecision(stableTokenAmount, expectedStableTokenAmount)
       assertEqualUpToFloatPrecision(targetTokenAmount, expectedTargetTokenAmount)
     }

--- a/test/priceUtils.js
+++ b/test/priceUtils.js
@@ -1,12 +1,15 @@
 const BN = require("bn.js")
 const assert = require("assert")
 const { toErc20Units } = require("../scripts/utils/printing_tools")
-const { getOutputAmountFromPrice, getUnlimitedOrderAmounts, isPriceReasonable } = require("../scripts/utils/price-utils")(web3, artifacts)
+const { getOutputAmountFromPrice, getUnlimitedOrderAmounts, isPriceReasonable } = require("../scripts/utils/price-utils")(
+  web3,
+  artifacts
+)
 
 const max128 = new BN(2).pow(new BN(128)).subn(1)
 const floatTolerance = new BN(2).pow(new BN(52)) // same tolerance as float precision
 
-const assertEqualUpToFloatPrecision = function (value, expected) {
+const assertEqualUpToFloatPrecision = function(value, expected) {
   const differenceFromExpected = value.sub(expected).abs()
   assert(differenceFromExpected.mul(floatTolerance).lt(expected))
 }
@@ -22,7 +25,7 @@ describe("getOutputAmountFromPrice", () => {
         expectedOutputAmountString: "160",
       },
       {
-        price: 1/160,
+        price: 1 / 160,
         inputAmountString: "160",
         inputDecimals: 6,
         outputDecimals: 18,
@@ -36,7 +39,7 @@ describe("getOutputAmountFromPrice", () => {
         expectedOutputAmountString: "1",
       },
       {
-        price: 10**30,
+        price: 10 ** 30,
         inputAmountString: "0.000000000000000000000001", // 10**-24
         inputDecimals: 100,
         outputDecimals: 1,
@@ -70,7 +73,7 @@ describe("getUnlimitedOrderAmounts", () => {
         expectedTargetTokenAmount: max128.divn(160),
       },
       {
-        price: 1/160,
+        price: 1 / 160,
         stableTokenDecimals: 18,
         targetTokenDecimals: 18,
         expectedStableTokenAmount: max128.divn(160),
@@ -84,24 +87,24 @@ describe("getUnlimitedOrderAmounts", () => {
         expectedTargetTokenAmount: max128,
       },
       {
-        price: 1+Number.EPSILON,
+        price: 1 + Number.EPSILON,
         stableTokenDecimals: 18,
         targetTokenDecimals: 18,
         expectedStableTokenAmount: max128,
-        expectedTargetTokenAmount: max128.sub(new BN(2).pow(new BN(128-52))),
+        expectedTargetTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
       },
       {
-        price: 1-Number.EPSILON,
+        price: 1 - Number.EPSILON,
         stableTokenDecimals: 18,
         targetTokenDecimals: 18,
-        expectedStableTokenAmount: max128.sub(new BN(2).pow(new BN(128-52))),
+        expectedStableTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
         expectedTargetTokenAmount: max128,
       },
       {
         price: 100,
         stableTokenDecimals: 165,
         targetTokenDecimals: 200,
-        expectedStableTokenAmount: max128.div(new BN(10).pow(new BN(200-165-2))),
+        expectedStableTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 - 2))),
         expectedTargetTokenAmount: max128,
       },
       {
@@ -109,10 +112,16 @@ describe("getUnlimitedOrderAmounts", () => {
         stableTokenDecimals: 200,
         targetTokenDecimals: 165,
         expectedStableTokenAmount: max128,
-        expectedTargetTokenAmount: max128.div(new BN(10).pow(new BN(200-165+2))),
+        expectedTargetTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 + 2))),
       },
     ]
-    for (const { price, stableTokenDecimals, targetTokenDecimals, expectedStableTokenAmount, expectedTargetTokenAmount } of testCases) {
+    for (const {
+      price,
+      stableTokenDecimals,
+      targetTokenDecimals,
+      expectedStableTokenAmount,
+      expectedTargetTokenAmount,
+    } of testCases) {
       const [targetTokenAmount, stableTokenAmount] = getUnlimitedOrderAmounts(price, targetTokenDecimals, stableTokenDecimals)
       assertEqualUpToFloatPrecision(stableTokenAmount, expectedStableTokenAmount)
       assertEqualUpToFloatPrecision(targetTokenAmount, expectedTargetTokenAmount)

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,10 +174,10 @@
     "@ethersproject/constants" ">=5.0.0-beta.128"
     "@ethersproject/logger" ">=5.0.0-beta.129"
 
-"@gnosis.pm/dex-contracts@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.2.8.tgz#c8e76fafe0c79e7385ee08cf1208606af7f8afb0"
-  integrity sha512-NF205eE3bATU6BHcDGwz/2XbO7syRmz0QNvyw59nvDxHHJrrAizr+6PeAPcKn1iQgiR973PTrKxLssAomAj4Tw==
+"@gnosis.pm/dex-contracts@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.2.9.tgz#0f18c96f4d511d0bb9259cc56ee336523292b562"
+  integrity sha512-Fn0Co3QH01a2/sj3EC1U/QsXLv/H4d/2+KMn7r1KmuLajDe5iv+jlnCo6neknpWpes5Gjg/5nwxJJfHE0W/YLw==
   dependencies:
     bn.js "^5.1.1"
 
@@ -1364,20 +1364,19 @@ bitcore-lib@8.1.1:
   resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-8.1.1.tgz#ba9e142a1fdf0b181729658010da2c0784546a80"
   integrity sha512-YyzpyKtwBIeOUu55oqltfk3/Uz8SYi1ayWq3JnaoGSzR4BNpD54sYejv2gZ5TuDe4KwBqvA2C5X1zkPBtlkGhQ==
   dependencies:
-    bech32 "=1.1.3"
     bn.js "=4.11.8"
     bs58 "^4.0.1"
     buffer-compare "=1.1.1"
     elliptic "=6.4.0"
     inherits "=2.0.1"
-    lodash "=4.17.15"
+    lodash "=4.17.11"
 
 bitcore-mnemonic@8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/bitcore-mnemonic/-/bitcore-mnemonic-8.1.1.tgz#f3d970e0e6f20e32708060960806ae630a6bd722"
   integrity sha512-F9R+PKN6m8jDikmNbuD7yp47vdyWcNYGdu9jokiNW46VOm5E+HJM41BiIJdUIVeY9mf+U8T7URq6Knr985NVTg==
   dependencies:
-    bitcore-lib "8.1.1"
+    bitcore-lib "^8.1.1"
     unorm "^1.4.1"
 
 bl@^1.0.0:
@@ -2320,39 +2319,6 @@ dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
   integrity sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==
-
-domelementtype@1, domelementtype@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
-  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
-
-domelementtype@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
-  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
-
-domhandler@^2.3.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
-  integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
-  dependencies:
-    domelementtype "1"
-
-domutils@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
-  integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
 
 domelementtype@1, domelementtype@^1.3.1:
   version "1.3.1"
@@ -6136,13 +6102,6 @@ string.prototype.trimstart@^1.0.0:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
 
 string_decoder@^1.1.1:
   version "1.3.0"


### PR DESCRIPTION
I introduce two new functions:
1. `getOutputAmountFromPrice` computes how much stable token you get from the given price and target token amount.
2. `getUnlimitedOrderAmounts` computes the largest possible order you can make at a given price.

The goal of this PR is to reduce rounding error, especially when the number of decimals of the two traded tokens are significantly different from each other.

The PR is not yet complete: I'm still waiting for version `0.2.9` of `dex-contracts` to be published on npmjs.com. All tests pass on a local install.