### PR TITLE
Reorganize imports

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -3,8 +3,8 @@ const { fetchTokenInfoFromExchange, getExchange, getSafe, buildOrders } = requir
   artifacts
 )
 const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils.js")(web3, artifacts)
-const { proceedAnyways } = require("./utils/user_interface_helpers")
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
+const { proceedAnyways } = require("./utils/user_interface_helpers")
 
 const argv = require("./utils/default_yargs")
   .option("targetToken", {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -1,19 +1,18 @@
-const { deployFleetOfSafes } = require("./utils/trading_strategy_helpers")(web3, artifacts)
-const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils")(web3, artifacts)
-const { sleep } = require("./utils/js_helpers")
-
+const assert = require("assert")
 const Contract = require("@truffle/contract")
+
 const {
+  deployFleetOfSafes,
   fetchTokenInfoFromExchange,
   buildTransferApproveDepositFromOrders,
   buildOrders,
   checkSufficiencyOfBalance,
 } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils")(web3, artifacts)
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 const { proceedAnyways } = require("./utils/user_interface_helpers")(web3, artifacts)
-
 const { toErc20Units } = require("./utils/printing_tools")
-const assert = require("assert")
+const { sleep } = require("./utils/js_helpers")
 
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -1,10 +1,11 @@
 module.exports = function(web3 = web3, artifacts = artifacts) {
   const util = require("util")
   const lightwallet = require("eth-lightwallet")
-  const IProxy = artifacts.require("IProxy")
 
+  const IProxy = artifacts.require("IProxy")
   const GnosisSafe = artifacts.require("GnosisSafe.sol")
   const MultiSend = artifacts.require("MultiSend")
+
   const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const multiSendPromise = MultiSend.deployed()
 

--- a/scripts/utils/printing_tools.js
+++ b/scripts/utils/printing_tools.js
@@ -1,4 +1,5 @@
 const BN = require("bn.js")
+
 const bnZero = new BN(0)
 const bnOne = new BN(1)
 const bnTwo = new BN(2)

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -1,9 +1,9 @@
 module.exports = function(web3 = web3, artifacts = artifacts) {
   const axios = require("axios")
+  const readline = require("readline")
+
   const { ADDRESS_0 } = require("./trading_strategy_helpers")(web3, artifacts)
   const { signTransaction, createLightwallet } = require("../utils/internals")(web3, artifacts)
-
-  const readline = require("readline")
 
   const rl = readline.createInterface({
     input: process.stdin,

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -1,21 +1,24 @@
 module.exports = function(web3 = web3, artifacts = artifacts) {
+  const assert = require("assert")
+  const BN = require("bn.js")
+  const fs = require("fs")
   const Contract = require("@truffle/contract")
+
+  const { buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")(web3, artifacts)
+  const { getUnlimitedOrderAmounts } = require("./price_utils")(web3, artifacts)
+  const { shortenedAddress, fromErc20Units } = require("./printing_tools")
+  const { allElementsOnlyOnce } = require("./js_helpers")
+
   const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
   const GnosisSafe = artifacts.require("GnosisSafe")
   const FleetFactory = artifacts.require("FleetFactory")
+
   BatchExchange.setNetwork(web3.network_id)
   BatchExchange.setProvider(web3.currentProvider)
   const exchangePromise = BatchExchange.deployed()
   const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const fleetFactoryPromise = FleetFactory.deployed()
 
-  const assert = require("assert")
-  const BN = require("bn.js")
-  const fs = require("fs")
-  const { buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")(web3, artifacts)
-  const { getUnlimitedOrderAmounts } = require("./price_utils")(web3, artifacts)
-  const { shortenedAddress, fromErc20Units } = require("./printing_tools")
-  const { allElementsOnlyOnce } = require("./js_helpers")
   const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
   const maxU32 = 2 ** 32 - 1
   const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))

--- a/scripts/utils/verify_scripts.js
+++ b/scripts/utils/verify_scripts.js
@@ -1,18 +1,18 @@
 module.exports = function(web3 = web3, artifacts = artifacts) {
-  const { getOrdersPaginated } = require("@gnosis.pm/dex-contracts/src/onchain_reading")
-  const Contract = require("@truffle/contract")
   const BN = require("bn.js")
+  const assert = require("assert")
+  const Contract = require("@truffle/contract")
+  const { getOrdersPaginated } = require("@gnosis.pm/dex-contracts/src/onchain_reading")
+  const { Fraction } = require("@gnosis.pm/dex-contracts/src")
+
   const { isOnlySafeOwner, fetchTokenInfoFromExchange, assertNoAllowances } = require("./trading_strategy_helpers")(
     web3,
     artifacts
   )
-  const { Fraction } = require("@gnosis.pm/dex-contracts/src")
-
   const { getMasterCopy } = require("./internals")(web3, artifacts)
-  const { getDexagPrice } = require("./price_utils")(web3, artifacts)
-  const { checkNoProfitableOffer } = require("./price_utils")(web3, artifacts)
+  const { getDexagPrice, checkNoProfitableOffer } = require("./price_utils")(web3, artifacts)
+
   const pageSize = 50
-  const assert = require("assert")
 
   const verifyCorrectSetup = async function(
     brackets,

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -2,12 +2,14 @@ const BN = require("bn.js")
 const utils = require("@gnosis.pm/safe-contracts/test/utils/general")
 const exchangeUtils = require("@gnosis.pm/dex-contracts")
 const Contract = require("@truffle/contract")
+
 const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
 const ERC20 = artifacts.require("ERC20Detailed")
 const TokenOWL = artifacts.require("TokenOWL")
 const GnosisSafe = artifacts.require("GnosisSafe")
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const TestToken = artifacts.require("DetailedMintableToken")
+
 const { prepareTokenRegistration, addCustomMintableTokenToExchange, deploySafe } = require("./test_utils")
 const {
   fetchTokenInfoFromExchange,
@@ -25,7 +27,6 @@ const {
 } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
 const { waitForNSeconds, execTransaction } = require("../scripts/utils/internals")(web3, artifacts)
 const { checkCorrectnessOfDeposits, max128 } = require("../scripts/utils/price_utils")(web3, artifacts)
-
 const { toErc20Units, fromErc20Units } = require("../scripts/utils/printing_tools")
 
 const TEN = new BN(10)

--- a/test/price_utils.js
+++ b/test/price_utils.js
@@ -1,6 +1,7 @@
 const BN = require("bn.js")
-const Contract = require("@truffle/contract")
 const assert = require("assert")
+const Contract = require("@truffle/contract")
+
 const { toErc20Units } = require("../scripts/utils/printing_tools")
 const { addCustomMintableTokenToExchange } = require("./test_utils")
 const {

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1,6 +1,8 @@
 const TokenOWL = artifacts.require("TokenOWL")
 const TestToken = artifacts.require("DetailedMintableToken")
+
 const { toErc20Units } = require("../scripts/utils/printing_tools")
+
 const ADDRESS_0 = "0x0000000000000000000000000000000000000000"
 
 const prepareTokenRegistration = async function(account, exchange) {

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -1,20 +1,21 @@
-const { createTokenAndGetData } = require("./test_utils")
-const { getAllowances, assertNoAllowances } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
-const assert = require("assert")
 const BN = require("bn.js")
-const utils = require("@gnosis.pm/safe-contracts/test/utils/general")
+const assert = require("assert")
 const Contract = require("@truffle/contract")
-const { deploySafe } = require("./test_utils")
+const utils = require("@gnosis.pm/safe-contracts/test/utils/general")
+
 const GnosisSafe = artifacts.require("GnosisSafe")
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
+
 const { verifyCorrectSetup } = require("../scripts/utils/verify_scripts")(web3, artifacts)
-const { addCustomMintableTokenToExchange } = require("./test_utils")
+const { addCustomMintableTokenToExchange, createTokenAndGetData, deploySafe } = require("./test_utils")
+const { execTransaction, waitForNSeconds } = require("../scripts/utils/internals")(web3, artifacts)
 const {
+  getAllowances,
+  assertNoAllowances,
   deployFleetOfSafes,
   buildOrders,
   buildTransferApproveDepositFromOrders,
 } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
-const { execTransaction, waitForNSeconds } = require("../scripts/utils/internals")(web3, artifacts)
 
 contract("verification checks - for allowances", async accounts => {
   describe("allowances", async () => {


### PR DESCRIPTION
While working on #137 I noticed that imports were messy.
This PR structures them as follows:
```
\\ external imports

\\ contracts/artifacts import

\\ internal imports, priority to those requiring web3 or artifacts

\\ constants
```