### PR TITLE
Fix check deposits

### DIFF
--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -17,7 +17,7 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
     investmentStableTokenPerBracket,
     investmentTargetTokenPerBracket
   ) => {
-    // all prices are of the form: 1 target token = "price" stable tokens 
+    // all prices are of the form: 1 target token = "price" stable tokens
     const bracketExchangeBalanceStableToken = (await exchange.getBalance(bracketAddress, stableToken.address)).toString()
     const bracketExchangeBalanceTargetToken = (await exchange.getBalance(bracketAddress, targetToken.address)).toString()
     const targetTokenId = await exchange.tokenAddressToIdMap.call(targetToken.address)
@@ -34,7 +34,10 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
     const buyTargetTokenOrder = buyTargetTokenOrders[0]
     assert.equal(buyTargetTokenOrder.sellToken, stableTokenId)
     // price of order is in terms of target tokens per stable token, the inverse is needed
-    const priceBuyingTargetToken = new Fraction(buyTargetTokenOrder.priceNumerator, buyTargetTokenOrder.priceDenominator).inverted()
+    const priceBuyingTargetToken = new Fraction(
+      buyTargetTokenOrder.priceNumerator,
+      buyTargetTokenOrder.priceDenominator
+    ).inverted()
 
     const sellTargetTokenOrders = bracketOrders.filter(order => order.sellToken == targetTokenId)
     assert.equal(sellTargetTokenOrders.length, 1)

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -295,6 +295,23 @@ contract("GnosisSafe", function(accounts) {
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
     })
+    it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p > 1 and wide brackets", async () => {
+      const tradeInfo = {
+        fleetSize: 4,
+        lowestLimit: 25,
+        highestLimit: 400,
+        currentPrice: 100,
+        amountStableToken: "1",
+        amountTargetToken: "2",
+        stableTokenInfo: { decimals: 18, symbol: "DAI" },
+        targetTokenInfo: { decimals: 18, symbol: "WETH" },
+      }
+      const expectedDistribution = {
+        bracketsWithStableTokenDeposit: 2,
+        bracketsWithTargetTokenDeposit: 2,
+      }
+      await testAutomaticDeposits(tradeInfo, expectedDistribution)
+    })
     it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p < 1", async () => {
       const tradeInfo = {
         fleetSize: 4,
@@ -379,6 +396,22 @@ contract("GnosisSafe", function(accounts) {
           lowestLimit: 100,
           highestLimit: 121,
           currentPrice: 110,
+        }
+        const expectedDistribution = {
+          bracketsWithStableTokenDeposit: 2,
+          bracketsWithTargetTokenDeposit: 2,
+        }
+        for (const tokenSetup of tokenSetups) {
+          const tradeInfo = { ...JSON.parse(JSON.stringify(tradeInfoWithoutTokens)), ...JSON.parse(JSON.stringify(tokenSetup)) }
+          await testAutomaticDeposits(tradeInfo, expectedDistribution)
+        }
+      })
+      it("when p is in the middle of the brackets and the steps are wide", async () => {
+        const tradeInfoWithoutTokens = {
+          fleetSize: 4,
+          lowestLimit: 25,
+          highestLimit: 400,
+          currentPrice: 100,
         }
         const expectedDistribution = {
           bracketsWithStableTokenDeposit: 2,

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -144,7 +144,7 @@ contract("GnosisSafe", function(accounts) {
       for (const bracketAddress of fleet) assert(await isOnlySafeOwner(masterSafe.address, bracketAddress))
     })
   })
-  describe.only("transfer tests:", async function() {
+  describe("transfer tests:", async function() {
     const testManualDeposits = async function(tokenDecimals, readableDepositAmount) {
       const masterSafe = await GnosisSafe.at(
         await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
@@ -470,7 +470,7 @@ contract("GnosisSafe", function(accounts) {
           await testAutomaticDeposits(tradeInfo, expectedDistribution)
         }
       })
-      it("with extreme prices and decimals", async () => {
+      /*it("with extreme prices and decimals", async () => {
         const tradeInfo = {
           fleetSize: 4,
           lowestLimit: 20e+194,
@@ -488,7 +488,7 @@ contract("GnosisSafe", function(accounts) {
           bracketsWithTargetTokenDeposit: 2,
         }
         await testAutomaticDeposits(tradeInfo, expectedDistribution)
-      })
+      })*/
     })
   })
 

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -470,11 +470,11 @@ contract("GnosisSafe", function(accounts) {
           await testAutomaticDeposits(tradeInfo, expectedDistribution)
         }
       })
-      /*it("with extreme prices and decimals", async () => {
+      it("with extreme prices and decimals", async () => {
         const tradeInfo = {
           fleetSize: 4,
-          lowestLimit: 20e+194,
-          highestLimit: 5e+194,
+          lowestLimit: 5e+194,
+          highestLimit: 20e+194,
           currentPrice: 10e+194,
           bracketsWithStableTokenDeposit: 2,
           bracketsWithTargetTokenDeposit: 2,
@@ -488,7 +488,7 @@ contract("GnosisSafe", function(accounts) {
           bracketsWithTargetTokenDeposit: 2,
         }
         await testAutomaticDeposits(tradeInfo, expectedDistribution)
-      })*/
+      })
     })
   })
 

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -144,7 +144,7 @@ contract("GnosisSafe", function(accounts) {
       for (const bracketAddress of fleet) assert(await isOnlySafeOwner(masterSafe.address, bracketAddress))
     })
   })
-  describe("transfer tests:", async function() {
+  describe.only("transfer tests:", async function() {
     const testManualDeposits = async function(tokenDecimals, readableDepositAmount) {
       const masterSafe = await GnosisSafe.at(
         await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
@@ -469,6 +469,25 @@ contract("GnosisSafe", function(accounts) {
           const tradeInfo = { ...JSON.parse(JSON.stringify(tradeInfoWithoutTokens)), ...JSON.parse(JSON.stringify(tokenSetup)) }
           await testAutomaticDeposits(tradeInfo, expectedDistribution)
         }
+      })
+      it("with extreme prices and decimals", async () => {
+        const tradeInfo = {
+          fleetSize: 4,
+          lowestLimit: 20e+194,
+          highestLimit: 5e+194,
+          currentPrice: 10e+194,
+          bracketsWithStableTokenDeposit: 2,
+          bracketsWithTargetTokenDeposit: 2,
+          amountStableToken: "10",
+          amountTargetToken: fromErc20Units(new BN("5000000"), 200),
+          stableTokenInfo: { decimals: 3, symbol: "fewdecimals" },
+          targetTokenInfo: { decimals: 200, symbol: "manydecimals" },
+        }
+        const expectedDistribution = {
+          bracketsWithStableTokenDeposit: 2,
+          bracketsWithTargetTokenDeposit: 2,
+        }
+        await testAutomaticDeposits(tradeInfo, expectedDistribution)
       })
     })
   })

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -476,8 +476,6 @@ contract("GnosisSafe", function(accounts) {
           lowestLimit: 5e194,
           highestLimit: 20e194,
           currentPrice: 10e194,
-          bracketsWithStableTokenDeposit: 2,
-          bracketsWithTargetTokenDeposit: 2,
           amountStableToken: "10",
           amountTargetToken: fromErc20Units(new BN("5000000"), 200),
           stableTokenInfo: { decimals: 3, symbol: "fewdecimals" },

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -473,9 +473,9 @@ contract("GnosisSafe", function(accounts) {
       it("with extreme prices and decimals", async () => {
         const tradeInfo = {
           fleetSize: 4,
-          lowestLimit: 5e+194,
-          highestLimit: 20e+194,
-          currentPrice: 10e+194,
+          lowestLimit: 5e194,
+          highestLimit: 20e194,
+          currentPrice: 10e194,
           bracketsWithStableTokenDeposit: 2,
           bracketsWithTargetTokenDeposit: 2,
           amountStableToken: "10",


### PR DESCRIPTION
This PR unearthed two issues in the function `checkCorrectnessOfDeposits`:
1. the function made no sense for tokens with digits!=18, yet no test failed because of that.
2. the function compared two BN using literal `<` and `>` instead of `.lt`, `.gt`.

Point 2. greatly aggravated my debugging of point 1.: when using `<` or `>` for comparison, the BNs are converted to strings and then lexicographically compared. This means that as long as the strings have the same length then the comparison works as expected, but if the length is different then it might yield unwelcomed surprises: for example, `"101"<"11" === true`.

I added a test case which would have failed with the code as it was before this PR and I rewrote the function to be, I hope, more straightforward. I would gladly accept comments to improve readability.

Finally, I created yet another test case to check whether the function works with extreme values for prices and number of decimals. ~~The test fails, even after this PR, so I left it commented out. Rewriting the function helped me to identify that the failure point likely lies somewere else, namely in the order creation: the price at which the brackets buy appears to be higher than the price at which the brackets sell, sometimes. I'll look into this and fix it in another PR, in the best case this issue is limited to the very unrealistic ranges and prices used.~~ i accidentally swapped highest and lowest limit in the test. Issue will be permanently fixed with #141.