### PR TITLE
Fail order construction with bad limits

### DIFF
--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -228,6 +228,8 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
   ) {
     const log = debug ? (...a) => console.log(...a) : () => {}
 
+    assert(lowestLimit < highestLimit, "Lowest limit must be lower than highest limit")
+
     const exchange = await exchangePromise
     log("Batch Exchange", exchange.address)
 

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -1,5 +1,5 @@
 const BN = require("bn.js")
-const assert = require("assert")
+const assertNodejs = require("assert")
 const utils = require("@gnosis.pm/safe-contracts/test/utils/general")
 const exchangeUtils = require("@gnosis.pm/dex-contracts")
 const Contract = require("@truffle/contract")
@@ -637,10 +637,13 @@ contract("GnosisSafe", function(accounts) {
       await prepareTokenRegistration(accounts[0], exchange)
       await exchange.addToken(testToken.address, { from: accounts[0] })
 
-      await assert.rejects(buildOrders(masterSafe.address, bracketSafes, targetToken, stableToken, lowestLimit, highestLimit), {
-        name: "AssertionError [ERR_ASSERTION]",
-        message: "Lowest limit must be lower than highest limit",
-      })
+      await assertNodejs.rejects(
+        buildOrders(masterSafe.address, bracketSafes, targetToken, stableToken, lowestLimit, highestLimit),
+        {
+          name: "AssertionError [ERR_ASSERTION]",
+          message: "Lowest limit must be lower than highest limit",
+        }
+      )
     })
   })
 

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -625,7 +625,7 @@ contract("GnosisSafe", function(accounts) {
 
       await checkPricesOfBracketStrategy(lowestLimit, highestLimit, bracketSafes, exchange)
     })
-    it.only("Failing when lowest limit is higher than highest limit", async () => {
+    it("Failing when lowest limit is higher than highest limit", async () => {
       const masterSafe = await GnosisSafe.at(
         await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
       )

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -1,4 +1,5 @@
 const BN = require("bn.js")
+const assert = require("assert")
 const utils = require("@gnosis.pm/safe-contracts/test/utils/general")
 const exchangeUtils = require("@gnosis.pm/dex-contracts")
 const Contract = require("@truffle/contract")
@@ -623,6 +624,23 @@ contract("GnosisSafe", function(accounts) {
       await execTransaction(masterSafe, lw, transaction)
 
       await checkPricesOfBracketStrategy(lowestLimit, highestLimit, bracketSafes, exchange)
+    })
+    it.only("Failing when lowest limit is higher than highest limit", async () => {
+      const masterSafe = await GnosisSafe.at(
+        await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
+      )
+      const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
+      const targetToken = 0 // ETH
+      const stableToken = 1 // DAI
+      const lowestLimit = 120
+      const highestLimit = 90
+      await prepareTokenRegistration(accounts[0], exchange)
+      await exchange.addToken(testToken.address, { from: accounts[0] })
+
+      await assert.rejects(buildOrders(masterSafe.address, bracketSafes, targetToken, stableToken, lowestLimit, highestLimit), {
+        name: "AssertionError [ERR_ASSERTION]",
+        message: "Lowest limit must be lower than highest limit",
+      })
     })
   })
 


### PR DESCRIPTION
Currently, we can create orders for which the lowest limit is higher than the highest limit. Everything goes through smoothly and all brackets end up unprofitable, losing money from the point they receive funds.
This PR makes `buildOrder` fail in this scenario. 