### PR TITLE
Verify script - better order checks

### DIFF
--- a/scripts/utils/verify_scripts.js
+++ b/scripts/utils/verify_scripts.js
@@ -74,26 +74,24 @@ module.exports = function(web3 = web3, artifacts = artifacts) {
       })
     )
 
-    log("3. Verify that each bracket has only two orders")
-    await Promise.all(
-      bracketTraderAddresses.map(async bracketTrader => {
-        const ownedOrders = relevantOrders.filter(order => order.user.toLowerCase() == bracketTrader)
-        assert(ownedOrders.length == 2, "order length is not correct")
-      })
-    )
+    log("3. Verify that orders are set up correctly")
+    for (const bracketTrader of bracketTraderAddresses) {
+      const ownedOrders = relevantOrders.filter(order => order.user.toLowerCase() == bracketTrader)
+      assert(ownedOrders.length == 2, "order length is not correct")
+
+      assert(
+        ownedOrders[0].buyToken === ownedOrders[1].sellToken && ownedOrders[0].sellToken === ownedOrders[1].buyToken,
+        "The two orders are not set up to trade back and forth on the same token pair"
+      )
+    }
 
     log("4. Verify that each bracket can not lose tokens by selling and buying consecutively via their two orders")
     for (const bracketTrader of bracketTraderAddresses) {
       const ownedOrders = relevantOrders.filter(order => order.user.toLowerCase() == bracketTrader)
-
-      // Checks that selling an initial amount and then re-buying it with the second order is unprofitable.
-      const initialAmount = new Fraction(new BN(10).pow(new BN(50)), new BN("1"))
-      const amountAfterSelling = initialAmount.mul(new Fraction(ownedOrders[0].priceNumerator, ownedOrders[0].priceDenominator))
-      const amountAfterBuying = amountAfterSelling.mul(
-        new Fraction(ownedOrders[1].priceNumerator, ownedOrders[1].priceDenominator)
-      )
-      assert(amountAfterBuying.gt(initialAmount), "Brackets are not profitable")
-      // If the last equation holds, the inverse trade must be profitable as well
+      const sellOrderPrice = new Fraction(ownedOrders[0].priceNumerator, ownedOrders[0].priceDenominator)
+      const buyOrderPrice = new Fraction(ownedOrders[1].priceNumerator, ownedOrders[1].priceDenominator)
+      const one = new Fraction(1, 1)
+      assert(sellOrderPrice.mul(buyOrderPrice).gt(one), "Brackets do not gain money when trading")
     }
 
     log("5. Verify that no bracket-trader offers profitable orders")

--- a/scripts/utils/verify_scripts.js
+++ b/scripts/utils/verify_scripts.js
@@ -1,5 +1,4 @@
 module.exports = function(web3 = web3, artifacts = artifacts) {
-  const BN = require("bn.js")
   const assert = require("assert")
   const Contract = require("@truffle/contract")
   const { getOrdersPaginated } = require("@gnosis.pm/dex-contracts/src/onchain_reading")

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -150,7 +150,7 @@ contract("Verification checks", function(accounts) {
       })
     })
   })
-  describe("3 Check: Each bracket has only two orders", async () => {
+  describe("3 Check: orders are properly set up", async () => {
     it("throws if a bracket does not have two orders", async () => {
       const masterSafe = await GnosisSafe.at(
         await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
@@ -182,6 +182,44 @@ contract("Verification checks", function(accounts) {
       await execTransaction(masterSafe, lw, transaction2)
       await assert.rejects(verifyCorrectSetup([bracketAddresses[0]], masterSafe.address, []), {
         message: "order length is not correct",
+      })
+    })
+    it("throws if orders do not buy and sell the same tokens in a loop", async () => {
+      const masterSafe = await GnosisSafe.at(
+        await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
+      )
+      const bracketAddress = (await deployFleetOfSafes(masterSafe.address, 1))[0]
+      const targetToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
+      const stableToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
+      const lowestLimit = 90
+      const highestLimit = 120
+
+      // create unlimited orders to sell low and buy high
+      const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(highestLimit, 18, 18)
+      const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(lowestLimit, 18, 18)
+
+      const validFrom = (await exchange.getCurrentBatchId.call()).toNumber() + 3
+      const buyTokens = [targetToken.id, targetToken.id]
+      const sellTokens = [stableToken.id, stableToken.id]
+      const validFroms = [validFrom, validFrom]
+      const validTos = [maxU32, maxU32]
+      const buyAmounts = [lowerBuyAmount.toString(), upperBuyAmount.toString()]
+      const sellAmounts = [lowerSellAmount.toString(), upperSellAmount.toString()]
+
+      const orderData = exchange.contract.methods
+        .placeValidFromOrders(buyTokens, sellTokens, validFroms, validTos, buyAmounts, sellAmounts)
+        .encodeABI()
+      const orderTransaction = {
+        operation: CALL,
+        to: exchange.address,
+        value: 0,
+        data: orderData,
+      }
+
+      const transaction = await buildExecTransaction(masterSafe.address, bracketAddress, orderTransaction)
+      await execTransaction(masterSafe, lw, transaction)
+      await assert.rejects(verifyCorrectSetup([bracketAddress], masterSafe.address, []), {
+        message: "The two orders are not set up to trade back and forth on the same token pair",
       })
     })
   })

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -221,7 +221,7 @@ contract("Verification checks", function(accounts) {
       const transaction = await buildExecTransaction(masterSafe.address, bracketAddress, orderTransaction)
       await execTransaction(masterSafe, lw, transaction)
       await assert.rejects(verifyCorrectSetup([bracketAddress], masterSafe.address, []), {
-        message: "Brackets are not profitable",
+        message: "Brackets do not gain money when trading",
       })
     })
   })


### PR DESCRIPTION
Another PR following the comments in issue #142. The logic of profitability checking is simplified, orders' token ids are checked, `Promise.all` is replaced with for loop since there are no asynchronous functions in this part of the code.