### PR TITLE
Reorganize withdraw script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ganache-cli": "6.9.0",
     "prettier": "^1.19.1",
     "run-with-testrpc": "^0.3.0",
+    "tmp-promise": "^2.0.2",
     "truffle-hdwallet-provider": "^1.0.0-web3one.1"
   },
   "scripts": {
@@ -44,7 +45,6 @@
     "openzeppelin-solidity": "^2.4.0",
     "sol-merger": "^2.0.1",
     "synthetix-js": "^2.21.6",
-    "tmp-promise": "^2.0.2",
     "truffle": "^5.1.18",
     "truffle-plugin-verify": "^0.3.10"
   },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "openzeppelin-solidity": "^2.4.0",
     "sol-merger": "^2.0.1",
     "synthetix-js": "^2.21.6",
+    "tmp-promise": "^2.0.2",
     "truffle": "^5.1.18",
     "truffle-plugin-verify": "^0.3.10"
   },

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -13,7 +13,7 @@ const argv = require("./utils/default_yargs")
     describe: "file name (and path) to the list of withdrawals",
     demandOption: true,
   })
-  .option("withdrawAllFrom", {
+  .option("allTokens", {
     type: "boolean",
     describe: "ignore amounts from withdrawalFile and try to withdraw the maximum amount available for each bracket",
   })

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -1,14 +1,6 @@
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
-const { fromErc20Units, shortenedAddress } = require("./utils/printing_tools")
-const {
-  getExchange,
-  getSafe,
-  fetchTokenInfoForFlux,
-  buildRequestWithdraw,
-  buildWithdraw,
-  buildTransferFundsToMaster,
-  buildWithdrawAndTransferFundsToMaster,
-} = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const prepareWithdraw = require("./wrapper/withdraw")(web3, artifacts)
 
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {
@@ -21,9 +13,8 @@ const argv = require("./utils/default_yargs")
     describe: "file name (and path) to the list of withdrawals",
     demandOption: true,
   })
-  .option("allTokens", {
+  .option("withdrawAllFrom", {
     type: "boolean",
-    default: false,
     describe: "ignore amounts from withdrawalFile and try to withdraw the maximum amount available for each bracket",
   })
   .option("requestWithdraw", {
@@ -50,94 +41,14 @@ const argv = require("./utils/default_yargs")
     return true
   }).argv
 
-const getAmount = async function(bracketAddress, tokenInfo, exchange) {
-  let amount
-  const token = tokenInfo.instance
-  if (argv.requestWithdraw) amount = (await exchange.getBalance(bracketAddress, tokenInfo.address)).toString()
-  else if (argv.withdraw) {
-    const currentBatchId = Math.floor(Date.now() / (5 * 60 * 1000)) // definition of BatchID, it avoids making a web3 request for each withdrawal to get BatchID
-    const pendingWithdrawal = await exchange.getPendingWithdraw(bracketAddress, tokenInfo.address)
-    if (pendingWithdrawal[1].toNumber() == 0) {
-      console.log("Warning: no withdrawal was requested for address", bracketAddress, "and token", tokenInfo.symbol)
-      amount = "0"
-    }
-    if (amount != "0" && pendingWithdrawal[1].toNumber() >= currentBatchId) {
-      console.log("Warning: amount cannot be withdrawn from the exchange right now, withdrawing zero")
-      amount = "0"
-    }
-    amount = pendingWithdrawal[0].toString()
-  } else {
-    amount = (await token.balanceOf(bracketAddress)).toString()
-  }
-  if (amount == "0") console.log("Warning: address", bracketAddress, "has no balance to withdraw for token", tokenInfo.symbol)
-  return amount
-}
-
 module.exports = async callback => {
   try {
-    let withdrawals = require(argv.withdrawalFile)
-    const tokenInfoPromises = fetchTokenInfoForFlux(withdrawals)
+    const masterSafe = getSafe(argv.masterSafe)
 
-    const masterSafePromise = getSafe(argv.masterSafe)
-    const exchange = await getExchange(web3)
-
-    if (argv.allTokens) {
-      console.log("Retrieving amount of tokens to withdraw.")
-      // get full amount to withdraw from the blockchain
-      withdrawals = await Promise.all(
-        withdrawals.map(async withdrawal => ({
-          bracketAddress: withdrawal.bracketAddress,
-          tokenAddress: withdrawal.tokenAddress,
-          amount: await getAmount(withdrawal.bracketAddress, await tokenInfoPromises[withdrawal.tokenAddress], exchange),
-        }))
-      )
-    }
-
-    console.log("Started building withdraw transaction.")
-    let transactionPromise
-    if (argv.requestWithdraw) transactionPromise = buildRequestWithdraw(argv.masterSafe, withdrawals)
-    else if (argv.withdraw && !argv.transferFundsToMaster) transactionPromise = buildWithdraw(argv.masterSafe, withdrawals)
-    else if (!argv.withdraw && argv.transferFundsToMaster)
-      transactionPromise = buildTransferFundsToMaster(argv.masterSafe, withdrawals, true)
-    else if (argv.withdraw && argv.transferFundsToMaster)
-      transactionPromise = buildWithdrawAndTransferFundsToMaster(argv.masterSafe, withdrawals)
-    else {
-      throw new Error("No operation specified")
-    }
-
-    for (const withdrawal of withdrawals) {
-      const { symbol: tokenSymbol, decimals: tokenDecimals } = await tokenInfoPromises[withdrawal.tokenAddress]
-
-      const userAmount = fromErc20Units(withdrawal.amount, tokenDecimals)
-
-      if (argv.requestWithdraw)
-        console.log(
-          `Requesting withdrawal of ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`
-        )
-      else if (argv.withdraw && !argv.transferFundsToMaster)
-        console.log(`Withdrawing ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`)
-      else if (!argv.withdraw && argv.transferFundsToMaster)
-        console.log(
-          `Transferring ${userAmount} ${tokenSymbol} from Safe ${withdrawal.bracketAddress} into master Safe ${shortenedAddress(
-            argv.masterSafe
-          )}`
-        )
-      else if (argv.withdraw && argv.transferFundsToMaster)
-        console.log(
-          `Safe ${
-            withdrawal.bracketAddress
-          } withdrawing ${userAmount} ${tokenSymbol} from BatchExchange and forwarding the whole amount into master Safe ${shortenedAddress(
-            argv.masterSafe
-          )})`
-        )
-      else {
-        throw new Error("No operation specified")
-      }
-    }
-
+    const transaction = await prepareWithdraw(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
-      await signAndSend(await masterSafePromise, await transactionPromise, argv.network)
+      await signAndSend(await masterSafe, transaction, argv.network)
     }
 
     callback()

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -15,6 +15,7 @@ const argv = require("./utils/default_yargs")
   })
   .option("allTokens", {
     type: "boolean",
+    default: false,
     describe: "ignore amounts from withdrawalFile and try to withdraw the maximum amount available for each bracket",
   })
   .option("requestWithdraw", {

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -32,14 +32,6 @@ const argv = require("./utils/default_yargs")
     type: "boolean",
     default: false,
     describe: "transfer back funds from brackets to master. Funds must be present in the bracket wallets",
-  })
-  .check(function(argv) {
-    if (!argv.requestWithdraw && !argv.withdraw && !argv.transferFundsToMaster) {
-      throw new Error("Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given")
-    } else if (argv.requestWithdraw && (argv.transferFundsToMaster || argv.withdraw)) {
-      throw new Error("Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster")
-    }
-    return true
   }).argv
 
 module.exports = async callback => {

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -19,7 +19,7 @@ module.exports = function(web3, artifacts) {
     }
   }
 
-  const getAmount = async function(argv, bracketAddress, tokenInfo, exchange, printOutput = false) {
+  const getMaxWithdrawableAmount = async function(argv, bracketAddress, tokenInfo, exchange, printOutput = false) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
     let amount
     const token = tokenInfo.instance
@@ -59,7 +59,7 @@ module.exports = function(web3, artifacts) {
         withdrawals.map(async withdrawal => ({
           bracketAddress: withdrawal.bracketAddress,
           tokenAddress: withdrawal.tokenAddress,
-          amount: await getAmount(
+          amount: await getMaxWithdrawableAmount(
             argv,
             withdrawal.bracketAddress,
             await tokenInfoPromises[withdrawal.tokenAddress],

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -1,0 +1,100 @@
+module.exports = function(web3, artifacts) {
+  const { fromErc20Units, shortenedAddress } = require("./utils/printing_tools")
+  const {
+    getExchange,
+    fetchTokenInfoForFlux,
+    buildRequestWithdraw,
+    buildWithdraw,
+    buildTransferFundsToMaster,
+    buildWithdrawAndTransferFundsToMaster,
+  } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+
+  const getAmount = async function(argv, bracketAddress, tokenInfo, exchange, printOutput = false) {
+    const log = printOutput ? (...a) => console.log(...a) : () => {}
+    let amount
+    const token = tokenInfo.instance
+    if (argv.requestWithdraw) amount = (await exchange.getBalance(bracketAddress, tokenInfo.address)).toString()
+    else if (argv.withdraw) {
+      const currentBatchId = Math.floor(Date.now() / (5 * 60 * 1000)) // definition of BatchID, it avoids making a web3 request for each withdrawal to get BatchID
+      const pendingWithdrawal = await exchange.getPendingWithdraw(bracketAddress, tokenInfo.address)
+      if (pendingWithdrawal[1].toNumber() == 0) {
+        log("Warning: no withdrawal was requested for address", bracketAddress, "and token", tokenInfo.symbol)
+        amount = "0"
+      }
+      if (amount != "0" && pendingWithdrawal[1].toNumber() >= currentBatchId) {
+        log("Warning: amount cannot be withdrawn from the exchange right now, withdrawing zero")
+        amount = "0"
+      }
+      amount = pendingWithdrawal[0].toString()
+    } else {
+      amount = (await token.balanceOf(bracketAddress)).toString()
+    }
+    if (amount == "0") log("Warning: address", bracketAddress, "has no balance to withdraw for token", tokenInfo.symbol)
+    return amount
+  }
+
+  return async function(argv, printOutput = false) {
+    const log = printOutput ? (...a) => console.log(...a) : () => {}
+
+    let withdrawals = require(argv.withdrawalFile)
+    const tokenInfoPromises = fetchTokenInfoForFlux(withdrawals)
+
+    const exchange = await getExchange(web3)
+
+    if (argv.allTokens) {
+      log("Retrieving amount of tokens to withdraw.")
+      // get full amount to withdraw from the blockchain
+      withdrawals = await Promise.all(
+        withdrawals.map(async withdrawal => ({
+          bracketAddress: withdrawal.bracketAddress,
+          tokenAddress: withdrawal.tokenAddress,
+          amount: await getAmount(argv, withdrawal.bracketAddress, await tokenInfoPromises[withdrawal.tokenAddress], exchange),
+        }))
+      )
+    }
+
+    log("Started building withdraw transaction.")
+    let transactionPromise
+    if (argv.requestWithdraw) transactionPromise = buildRequestWithdraw(argv.masterSafe, withdrawals)
+    else if (argv.withdraw && !argv.transferFundsToMaster) transactionPromise = buildWithdraw(argv.masterSafe, withdrawals)
+    else if (!argv.withdraw && argv.transferFundsToMaster)
+      transactionPromise = buildTransferFundsToMaster(argv.masterSafe, withdrawals, true)
+    else if (argv.withdraw && argv.transferFundsToMaster)
+      transactionPromise = buildWithdrawAndTransferFundsToMaster(argv.masterSafe, withdrawals)
+    else {
+      throw new Error("No operation specified")
+    }
+
+    for (const withdrawal of withdrawals) {
+      const { symbol: tokenSymbol, decimals: tokenDecimals } = await tokenInfoPromises[withdrawal.tokenAddress]
+
+      const userAmount = fromErc20Units(withdrawal.amount, tokenDecimals)
+
+      if (argv.requestWithdraw)
+        log(
+          `Requesting withdrawal of ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`
+        )
+      else if (argv.withdraw && !argv.transferFundsToMaster)
+        log(`Withdrawing ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`)
+      else if (!argv.withdraw && argv.transferFundsToMaster)
+        log(
+          `Transferring ${userAmount} ${tokenSymbol} from Safe ${withdrawal.bracketAddress} into master Safe ${shortenedAddress(
+            argv.masterSafe
+          )}`
+        )
+      else if (argv.withdraw && argv.transferFundsToMaster)
+        log(
+          `Safe ${
+            withdrawal.bracketAddress
+          } withdrawing ${userAmount} ${tokenSymbol} from BatchExchange and forwarding the whole amount into master Safe ${shortenedAddress(
+            argv.masterSafe
+          )})`
+        )
+      else {
+        throw new Error("No operation specified")
+      }
+    }
+
+    return transactionPromise
+  }
+}

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -1,4 +1,6 @@
 module.exports = function(web3, artifacts) {
+  const fs = require("fs").promises
+
   const { fromErc20Units, shortenedAddress } = require("../utils/printing_tools")
   const {
     getExchange,
@@ -36,9 +38,8 @@ module.exports = function(web3, artifacts) {
   return async function(argv, printOutput = false) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
 
-    let withdrawals = require(argv.withdrawalFile)
+    let withdrawals = JSON.parse(await fs.readFile(argv.withdrawalFile, "utf8"))
     const tokenInfoPromises = fetchTokenInfoForFlux(withdrawals)
-
     const exchange = await getExchange(web3)
 
     if (argv.allTokens) {
@@ -48,7 +49,12 @@ module.exports = function(web3, artifacts) {
         withdrawals.map(async withdrawal => ({
           bracketAddress: withdrawal.bracketAddress,
           tokenAddress: withdrawal.tokenAddress,
-          amount: await getAmount(argv, withdrawal.bracketAddress, await tokenInfoPromises[withdrawal.tokenAddress], exchange),
+          amount: await getAmount(
+            argv,
+            withdrawal.bracketAddress,
+            await tokenInfoPromises[withdrawal.tokenAddress],
+            await exchange
+          ),
         }))
       )
     }

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -1,5 +1,5 @@
 module.exports = function(web3, artifacts) {
-  const { fromErc20Units, shortenedAddress } = require("./utils/printing_tools")
+  const { fromErc20Units, shortenedAddress } = require("../utils/printing_tools")
   const {
     getExchange,
     fetchTokenInfoForFlux,
@@ -7,7 +7,7 @@ module.exports = function(web3, artifacts) {
     buildWithdraw,
     buildTransferFundsToMaster,
     buildWithdrawAndTransferFundsToMaster,
-  } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+  } = require("../utils/trading_strategy_helpers")(web3, artifacts)
 
   const getAmount = async function(argv, bracketAddress, tokenInfo, exchange, printOutput = false) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -11,6 +11,15 @@ module.exports = function(web3, artifacts) {
     buildWithdrawAndTransferFundsToMaster,
   } = require("../utils/trading_strategy_helpers")(web3, artifacts)
 
+  const assertGoodArguments = function(argv) {
+    if (!argv.requestWithdraw && !argv.withdraw && !argv.transferFundsToMaster) {
+      throw new Error("Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given")
+    } else if (argv.requestWithdraw && (argv.transferFundsToMaster || argv.withdraw)) {
+      throw new Error("Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster")
+    }
+    return true
+  }
+
   const getAmount = async function(argv, bracketAddress, tokenInfo, exchange, printOutput = false) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
     let amount
@@ -37,6 +46,8 @@ module.exports = function(web3, artifacts) {
 
   return async function(argv, printOutput = false) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
+
+    assertGoodArguments(argv)
 
     let withdrawals = JSON.parse(await fs.readFile(argv.withdrawalFile, "utf8"))
     const tokenInfoPromises = fetchTokenInfoForFlux(withdrawals)

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -17,7 +17,6 @@ module.exports = function(web3, artifacts) {
     } else if (argv.requestWithdraw && (argv.transferFundsToMaster || argv.withdraw)) {
       throw new Error("Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster")
     }
-    return true
   }
 
   const getAmount = async function(argv, bracketAddress, tokenInfo, exchange, printOutput = false) {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -241,10 +241,9 @@ contract("Withdraw script", function(accounts) {
       {
         argv: {
           masterSafe: masterSafe.address,
-          withdrawalFile: "/dev/null",
-          requestWithdraw: true,
+          withdrawalFile: "/dev/zero",
         },
-        error: "Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster",
+        error: "Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given",
       },
     ]
     for (const { argv, error } of badInput)

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -1,0 +1,266 @@
+const BN = require("bn.js")
+const fs = require("fs").promises
+const tmp = require("tmp-promise")
+const assertNodejs = require("assert")
+const utils = require("@gnosis.pm/safe-contracts/test/utils/general")
+const Contract = require("@truffle/contract")
+
+const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
+const ERC20 = artifacts.require("ERC20Detailed")
+const GnosisSafe = artifacts.require("GnosisSafe")
+const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
+const TestToken = artifacts.require("DetailedMintableToken")
+
+const { prepareTokenRegistration, addCustomMintableTokenToExchange, deploySafe } = require("../test_utils")
+const {
+  fetchTokenInfoFromExchange,
+  fetchTokenInfoAtAddresses,
+  deployFleetOfSafes,
+  buildOrders,
+  buildTransferApproveDepositFromList,
+  buildTransferApproveDepositFromOrders,
+  buildRequestWithdraw,
+  buildWithdraw,
+  buildTransferFundsToMaster,
+  buildWithdrawAndTransferFundsToMaster,
+  isOnlySafeOwner,
+  maxU32,
+} = require("../../scripts/utils/trading_strategy_helpers")(web3, artifacts)
+const { waitForNSeconds, execTransaction } = require("../../scripts/utils/internals")(web3, artifacts)
+const prepareWithdraw = require("../../scripts/wrapper/withdraw")(web3, artifacts)
+const { toErc20Units, fromErc20Units } = require("../../scripts/utils/printing_tools")
+
+contract("Withdraw script", function(accounts) {
+  let lw
+  let gnosisSafeMasterCopy
+  let proxyFactory
+  let exchange
+
+  beforeEach(async function() {
+    // Create lightwallet
+    // TODO - can we just use accounts provided by ganache?
+    lw = await utils.createLightwallet()
+
+    gnosisSafeMasterCopy = await GnosisSafe.new()
+    proxyFactory = await ProxyFactory.new()
+
+    BatchExchange.setProvider(web3.currentProvider)
+    exchange = await BatchExchange.deployed()
+  })
+
+  const setup = async function(numberOfBrackets, amounts) {
+    const masterSafe = await GnosisSafe.at(
+      await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
+    )
+    const bracketAddresses = await deployFleetOfSafes(masterSafe.address, numberOfBrackets)
+    const tokenInfo = []
+    for (const { tokenData = {}, amount } of amounts) {
+      const symbol = tokenData.symbol || "TEST"
+      const decimals = tokenData.decimals || 18
+      const { id, token } = await addCustomMintableTokenToExchange(exchange, symbol, decimals, accounts[0])
+      tokenInfo.push({ symbol: symbol, decimals: decimals, id: id, token: token, address: token.address })
+      await token.mint(masterSafe.address, toErc20Units(amount, decimals))
+      const masterBalance = await token.balanceOf(masterSafe.address)
+      assert.equal(fromErc20Units(masterBalance, decimals), amount, "Setup failed, did not deposit amount")
+    }
+
+    return [masterSafe, bracketAddresses, tokenInfo]
+  }
+
+  const evenDeposits = function(bracketAddresses, tokenData, amount) {
+    const numberOfBrackets = bracketAddresses.length
+    const amountToEach = toErc20Units(amount, tokenData.decimals)
+      .div(new BN(numberOfBrackets))
+      .toString()
+    return bracketAddresses.map(bracketAddress => ({
+      amount: amountToEach,
+      tokenAddress: tokenData.address,
+      bracketAddress: bracketAddress,
+    }))
+  }
+
+  const deposit = async function(masterSafe, deposits) {
+    const batchTransaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits)
+    await execTransaction(masterSafe, lw, batchTransaction)
+    // Close auction for deposits to be reflected in exchange balance
+    await waitForNSeconds(301)
+
+    const amountsInExchange = {}
+    const depositsOfBrackets = {}
+    for (const { amount, tokenAddress, bracketAddress } of deposits) {
+      amountsInExchange[tokenAddress] = (amountsInExchange[tokenAddress] || new BN(0)).add(new BN(amount))
+      if (!depositsOfBrackets[tokenAddress]) depositsOfBrackets[tokenAddress] = {}
+      depositsOfBrackets[tokenAddress][bracketAddress] = (depositsOfBrackets[tokenAddress][bracketAddress] || new BN(0)).add(
+        new BN(amount)
+      )
+    }
+
+    for (const { tokenAddress } of deposits) {
+      const token = await ERC20.at(tokenAddress)
+      assert.equal(
+        (await token.balanceOf(exchange.address)).toString(),
+        amountsInExchange[tokenAddress].toString(),
+        "Balance setup failed: the exchange does not hold all tokens"
+      )
+      const tokenDepositsOfBrackets = depositsOfBrackets[tokenAddress]
+      for (const bracketAddress in tokenDepositsOfBrackets) {
+        assert.equal(
+          (await exchange.getBalance(bracketAddress, tokenAddress)).toString(),
+          tokenDepositsOfBrackets[bracketAddress].toString(),
+          "Balance setup failed: the bracket is not the owner of the tokens in the exchange"
+        )
+      }
+    }
+  }
+  it("requests withdrawals", async () => {
+    const amounts = [{ token: { decimals: 18, symbol: "DAI" }, amount: "1000" }]
+    const [masterSafe, bracketAddresses, tokenInfo] = await setup(2, amounts)
+    const deposits = evenDeposits(bracketAddresses, tokenInfo[0], "1000")
+    await deposit(masterSafe, deposits)
+    const depositFile = await tmp.file()
+    await fs.writeFile(depositFile.path, JSON.stringify(deposits))
+
+    const argv = {
+      masterSafe: masterSafe.address,
+      withdrawalFile: depositFile.path,
+      requestWithdraw: true,
+    }
+    const transaction = await prepareWithdraw(argv)
+    await execTransaction(masterSafe, lw, transaction)
+
+    for (const { amount, tokenAddress, bracketAddress } of deposits) {
+      const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()
+      assert.notEqual(requestedWithdrawal, "0", "Withdrawal was not requested")
+      assert.equal(requestedWithdrawal, amount, "Bad amount requested to withdraw")
+    }
+
+    depositFile.cleanup()
+  })
+  it("withdraws", async () => {
+    const amounts = [{ token: { decimals: 18, symbol: "DAI" }, amount: "1000" }]
+    const [masterSafe, bracketAddresses, tokenInfo] = await setup(2, amounts)
+    const token = tokenInfo[0].token
+    const deposits = evenDeposits(bracketAddresses, tokenInfo[0], "1000")
+    await deposit(masterSafe, deposits)
+    const depositFile = await tmp.file()
+    await fs.writeFile(depositFile.path, JSON.stringify(deposits))
+
+    const argv1 = {
+      masterSafe: masterSafe.address,
+      withdrawalFile: depositFile.path,
+      requestWithdraw: true,
+    }
+    const transaction1 = await prepareWithdraw(argv1)
+    await execTransaction(masterSafe, lw, transaction1)
+    await waitForNSeconds(301)
+
+    const argv2 = {
+      masterSafe: masterSafe.address,
+      withdrawalFile: depositFile.path,
+      withdraw: true,
+    }
+    const transaction2 = await prepareWithdraw(argv2)
+    await execTransaction(masterSafe, lw, transaction2)
+
+    for (const { amount, tokenAddress, bracketAddress } of deposits) {
+      const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()
+      const bracketBalance = (await token.balanceOf(bracketAddress)).toString()
+      assert.equal(requestedWithdrawal, "0", "A withdrawal request is still pending")
+      assert.equal(bracketBalance, amount, "Bad amount requested to withdraw")
+    }
+
+    depositFile.cleanup()
+  })
+  it("transfer funds to master", async () => {
+    const amounts = [{ token: { decimals: 18, symbol: "DAI" }, amount: "1000" }]
+    const [masterSafe, bracketAddresses, tokenInfo] = await setup(2, amounts)
+    const token = tokenInfo[0].token
+    const deposits = evenDeposits(bracketAddresses, tokenInfo[0], "1000")
+    await deposit(masterSafe, deposits)
+    const depositFile = await tmp.file()
+    await fs.writeFile(depositFile.path, JSON.stringify(deposits))
+
+    const argv1 = {
+      masterSafe: masterSafe.address,
+      withdrawalFile: depositFile.path,
+      requestWithdraw: true,
+    }
+    const transaction1 = await prepareWithdraw(argv1)
+    await execTransaction(masterSafe, lw, transaction1)
+    await waitForNSeconds(301)
+
+    const argv2 = {
+      masterSafe: masterSafe.address,
+      withdrawalFile: depositFile.path,
+      withdraw: true,
+    }
+    const transaction2 = await prepareWithdraw(argv2)
+    await execTransaction(masterSafe, lw, transaction2)
+
+    const argv3 = {
+      masterSafe: masterSafe.address,
+      withdrawalFile: depositFile.path,
+      transferFundsToMaster: true,
+    }
+    const transaction3 = await prepareWithdraw(argv3)
+    await execTransaction(masterSafe, lw, transaction3)
+
+    for (const { tokenAddress, bracketAddress } of deposits) {
+      const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()
+      const bracketBalance = (await token.balanceOf(bracketAddress)).toString()
+      assert.equal(requestedWithdrawal, "0", "A withdrawal request is still pending")
+      assert.equal(bracketBalance, "0", "Bracket balance is nonzero")
+    }
+    const masterBalance = (await token.balanceOf(masterSafe.address)).toString()
+    assert.equal(masterBalance, toErc20Units("1000", 18).toString(), "Master safe did not receive tokens")
+
+    depositFile.cleanup()
+  })
+  it.only("fails on bad input", async () => {
+    const masterSafe = await GnosisSafe.at(
+      await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
+    )
+    const badInput = [
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          withdrawalFile: "/dev/null",
+          requestWithdraw: true,
+          withdraw: true,
+        },
+        error: "Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          withdrawalFile: "/dev/null",
+          requestWithdraw: true,
+          transferFundsToMaster: true,
+        },
+        error: "Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          withdrawalFile: "/dev/null",
+          requestWithdraw: true,
+          withdraw: true,
+          transferFundsToMaster: true,
+        },
+        error: "Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          withdrawalFile: "/dev/null",
+          requestWithdraw: true,
+        },
+        error: "Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster",
+      },
+    ]
+    for (const { argv, error } of badInput)
+      await assertNodejs.rejects(prepareWithdraw(argv), {
+        message: error,
+      })
+  })
+})

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -216,7 +216,7 @@ contract("Withdraw script", function(accounts) {
 
     depositFile.cleanup()
   })
-  it.only("fails on bad input", async () => {
+  it("fails on bad input", async () => {
     const masterSafe = await GnosisSafe.at(
       await deploySafe(gnosisSafeMasterCopy, proxyFactory, [lw.accounts[0], lw.accounts[1]], 2)
     )

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -9,23 +9,12 @@ const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts
 const ERC20 = artifacts.require("ERC20Detailed")
 const GnosisSafe = artifacts.require("GnosisSafe")
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
-const TestToken = artifacts.require("DetailedMintableToken")
 
-const { prepareTokenRegistration, addCustomMintableTokenToExchange, deploySafe } = require("../test_utils")
-const {
-  fetchTokenInfoFromExchange,
-  fetchTokenInfoAtAddresses,
-  deployFleetOfSafes,
-  buildOrders,
-  buildTransferApproveDepositFromList,
-  buildTransferApproveDepositFromOrders,
-  buildRequestWithdraw,
-  buildWithdraw,
-  buildTransferFundsToMaster,
-  buildWithdrawAndTransferFundsToMaster,
-  isOnlySafeOwner,
-  maxU32,
-} = require("../../scripts/utils/trading_strategy_helpers")(web3, artifacts)
+const { addCustomMintableTokenToExchange, deploySafe } = require("../test_utils")
+const { deployFleetOfSafes, buildTransferApproveDepositFromList } = require("../../scripts/utils/trading_strategy_helpers")(
+  web3,
+  artifacts
+)
 const { waitForNSeconds, execTransaction } = require("../../scripts/utils/internals")(web3, artifacts)
 const prepareWithdraw = require("../../scripts/wrapper/withdraw")(web3, artifacts)
 const { toErc20Units, fromErc20Units } = require("../../scripts/utils/printing_tools")

--- a/yarn.lock
+++ b/yarn.lock
@@ -5591,7 +5591,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.2.8:
+rimraf@^2.2.8, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -6373,12 +6373,26 @@ timers-ext@^0.1.5:
     es5-ext "~0.10.46"
     next-tick "1"
 
+tmp-promise@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-2.0.2.tgz#ee605edb10f100954be5dd8b9dbe1bfd56194202"
+  integrity sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==
+  dependencies:
+    tmp "0.1.0"
+
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
 
 to-buffer@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
Move the logic of the withdraw script to its own testable function. Tests are added.

This PR inadvertently fixed issue #78 for the withdraw script. Another PR should fix the issue for all scripts, otherwise we would have an incostistent behavior between scripts when managing filesystem paths.