### PR TITLE
Fix relative paths in deposit script

### DIFF
--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -19,7 +19,7 @@ module.exports = async (callback) => {
     const masterSafe = await GnosisSafe.at(argv.masterSafe)
 
     const deposits = require(argv.depositFile)
-    // TODO - make a simpler to construct deposit file style
+    // TODO - make it simpler to construct deposit file style
     console.log("Preparing transaction data...")
     const transaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits, true)
 

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -21,7 +21,7 @@ module.exports = async (callback) => {
     const masterSafe = await GnosisSafe.at(argv.masterSafe)
 
     const deposits = JSON.parse(await fs.readFile(argv.depositFile, "utf8"))
-    // TODO - make it simpler to construct deposit file style
+
     console.log("Preparing transaction data...")
     const transaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits, true)
 

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -1,3 +1,5 @@
+const fs = require("fs").promises
+
 const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
 const { buildTransferApproveDepositFromList } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 
@@ -18,7 +20,7 @@ module.exports = async (callback) => {
     const GnosisSafe = artifacts.require("GnosisSafe")
     const masterSafe = await GnosisSafe.at(argv.masterSafe)
 
-    const deposits = require(argv.depositFile)
+    const deposits = JSON.parse(await fs.readFile(argv.depositFile, "utf8"))
     // TODO - make it simpler to construct deposit file style
     console.log("Preparing transaction data...")
     const transaction = await buildTransferApproveDepositFromList(masterSafe.address, deposits, true)


### PR DESCRIPTION
Fixes issue #78 and makes the behavior of the deposit script consistent with that of the withdraw script after PR #155. With this change, the command-line examples in the readme become correct.