### PR TITLE
Withdraw without withdrawal file

### DIFF
--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -22,14 +22,14 @@ const argv = require("./utils/default_yargs")
   })
   .option("tokens", {
     type: "string",
-    describe: "comma separated address list of tokens to withdraw, to use in combination with --from",
+    describe: "comma separated address list of tokens to withdraw, to use in combination with --brackets",
     coerce: (str) => {
       return str.split(",")
     },
   })
   .option("tokenIds", {
     type: "string",
-    describe: "comma separated list of exchange ids for the tokens to withdraw, to use in combination with --from",
+    describe: "comma separated list of exchange ids for the tokens to withdraw, to use in combination with --brackets",
     coerce: (str) => {
       return str.split(",")
     },

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -5,18 +5,34 @@ const prepareWithdraw = require("./wrapper/withdraw")(web3, artifacts)
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",
-    describe: "Address of Gnosis Safe owning bracketSafes",
+    describe: "address of Gnosis Safe owning bracketSafes",
     demandOption: true,
   })
   .option("withdrawalFile", {
     type: "string",
     describe: "file name (and path) to the list of withdrawals",
-    demandOption: true,
   })
-  .option("allTokens", {
-    type: "boolean",
-    default: false,
-    describe: "ignore amounts from withdrawalFile and try to withdraw the maximum amount available for each bracket",
+  .option("from", {
+    type: "string",
+    describe:
+      "comma-separated list of brackets from which to withdraw the entire balance. Compatible with all valid combinations of --requestWithdraw, --withdraw, --transferFundsToMaster",
+    coerce: (str) => {
+      return str.split(",")
+    },
+  })
+  .option("tokens", {
+    type: "string",
+    describe: "comma separated address list of tokens to withdraw, to use in combination with --from",
+    coerce: (str) => {
+      return str.split(",")
+    },
+  })
+  .option("tokenIds", {
+    type: "string",
+    describe: "comma separated list of exchange ids for the tokens to withdraw, to use in combination with --from",
+    coerce: (str) => {
+      return str.split(",")
+    },
   })
   .option("requestWithdraw", {
     type: "boolean",

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -49,19 +49,27 @@ module.exports = function (web3, artifacts) {
     else if (argv.withdraw) {
       const currentBatchId = Math.floor(Date.now() / (5 * 60 * 1000)) // definition of BatchID, it avoids making a web3 request for each withdrawal to get BatchID
       const pendingWithdrawal = await exchange.getPendingWithdraw(bracketAddress, tokenData.address)
-      if (pendingWithdrawal[1].toNumber() == 0) {
-        log("Warning: no withdrawal was requested for address", bracketAddress, "and token", tokenData.symbol)
-        amount = "0"
-      }
-      if (amount != "0" && pendingWithdrawal[1].toNumber() >= currentBatchId) {
-        log("Warning: amount cannot be withdrawn from the exchange right now, withdrawing zero")
-        amount = "0"
-      }
       amount = pendingWithdrawal[0].toString()
+      if (pendingWithdrawal[1].toNumber() >= currentBatchId) {
+        const batchIdsLeft = pendingWithdrawal[1].toNumber() - currentBatchId + 1
+        log(
+          "Warning: requested withdrawal of " +
+            amount +
+            " " +
+            tokenData.symbol +
+            " for bracket " +
+            bracketAddress +
+            " cannot be executed until " +
+            batchIdsLeft +
+            " " +
+            (batchIdsLeft == 1 ? "batch" : "batches") +
+            " from now, skipping"
+        )
+        amount = "0"
+      }
     } else {
       amount = (await token.balanceOf(bracketAddress)).toString()
     }
-    if (amount == "0") log("Warning: address", bracketAddress, "has no balance to withdraw for token", tokenData.symbol)
     return amount
   }
 

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -84,13 +84,9 @@ module.exports = function (web3, artifacts) {
       tokenInfoPromises = fetchTokenInfoForFlux(withdrawals)
     } else {
       const exchangePromise = getExchange(web3)
-      if (argv.tokens) tokenInfoPromises = fetchTokenInfoAtAddresses(argv.tokens)
-      else {
-        const tokenAddresses = await Promise.all(
-          argv.tokenIds.map(async (id) => (await exchangePromise).tokenIdToAddressMap(id))
-        )
-        tokenInfoPromises = fetchTokenInfoAtAddresses(tokenAddresses)
-      }
+      const tokenAddresses =
+        argv.tokens || (await Promise.all(argv.tokenIds.map(async (id) => (await exchangePromise).tokenIdToAddressMap(id))))
+      tokenInfoPromises = fetchTokenInfoAtAddresses(tokenAddresses)
       const exchange = await exchangePromise
       const currentBatchId = (await exchange.getCurrentBatchId()).toNumber() // cannot be computed directly from Date() because time of testing blockchain is not consistent with system clock
 

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -21,21 +21,21 @@ module.exports = function (web3, artifacts) {
       throw new Error("Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster")
     }
 
-    if (!argv.withdrawalFile && !argv.from) {
-      throw new Error("Argument error: one of --withdrawalFile, --from must be given")
-    } else if (argv.withdrawalFile && argv.from) {
-      throw new Error("Argument error: --from cannot be used with --withdrawalFile")
+    if (!argv.withdrawalFile && !argv.brackets) {
+      throw new Error("Argument error: one of --withdrawalFile, --brackets must be given")
+    } else if (argv.withdrawalFile && argv.brackets) {
+      throw new Error("Argument error: --brackets cannot be used with --withdrawalFile")
     }
 
-    if (argv.from) {
+    if (argv.brackets) {
       if (!argv.tokens && !argv.tokenIds) {
-        throw new Error("Argument error: one of --tokens, --tokenIds must be given when using --from")
+        throw new Error("Argument error: one of --tokens, --tokenIds must be given when using --brackets")
       } else if (argv.tokens && argv.tokenIds) {
-        throw new Error("Argument error: only one of --tokens, --tokenIds is required when using --from")
+        throw new Error("Argument error: only one of --tokens, --tokenIds is required when using --brackets")
       }
     } else {
       if (argv.tokens || argv.tokenIds) {
-        throw new Error("Argument error: --tokens or --tokenIds can only be used with --from")
+        throw new Error("Argument error: --tokens or --tokenIds can only be used with --brackets")
       }
     }
   }
@@ -99,7 +99,7 @@ module.exports = function (web3, artifacts) {
       withdrawals = []
       const candidateWithdrawalPromises = []
       for (const [, tokenDataPromise] of Object.entries(tokenInfoPromises))
-        for (const bracketAddress of argv.from)
+        for (const bracketAddress of argv.brackets)
           candidateWithdrawalPromises.push(
             (async () => {
               const maxWithdrawableAmount = await getMaxWithdrawableAmount(

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -98,7 +98,7 @@ module.exports = function (web3, artifacts) {
         tokenInfoPromises = fetchTokenInfoAtAddresses(tokenAddresses)
       }
       const exchange = await exchangePromise
-      const currentBatchId = (await exchange.getCurrentBatchId()).toNumber() // cannot be computed directly from Date() because testing would fail
+      const currentBatchId = (await exchange.getCurrentBatchId()).toNumber() // cannot be computed directly from Date() because time of testing blockchain is not consistent with system clock
 
       log("Retrieving amount of tokens to withdraw.")
       // get full amount to withdraw from the blockchain

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -12,10 +12,30 @@ module.exports = function (web3, artifacts) {
   } = require("../utils/trading_strategy_helpers")(web3, artifacts)
 
   const assertGoodArguments = function (argv) {
+    if (!argv.masterSafe) throw new Error("Argument error: --masterSafe is required")
+
     if (!argv.requestWithdraw && !argv.withdraw && !argv.transferFundsToMaster) {
       throw new Error("Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given")
     } else if (argv.requestWithdraw && (argv.transferFundsToMaster || argv.withdraw)) {
       throw new Error("Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster")
+    }
+
+    if (!argv.withdrawalFile && !argv.from) {
+      throw new Error("Argument error: one of --withdrawalFile, --from must be given")
+    } else if (argv.withdrawalFile && argv.from) {
+      throw new Error("Argument error: --from cannot be used with --withdrawalFile")
+    }
+
+    if (argv.from) {
+      if (!argv.tokens && !argv.tokenIds) {
+        throw new Error("Argument error: one of --tokens, --tokenIds must be given when using --from")
+      } else if (argv.tokens && argv.tokenIds) {
+        throw new Error("Argument error: only one of --tokens, --tokenIds is required when using --from")
+      }
+    } else {
+      if (argv.tokens || argv.tokenIds) {
+        throw new Error("Argument error: --tokens or --tokenIds can only be used with --from")
+      }
     }
   }
 

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -58,17 +58,11 @@ module.exports = function (web3, artifacts) {
       if (pendingWithdrawal[1].toNumber() >= currentBatchId) {
         const batchIdsLeft = pendingWithdrawal[1].toNumber() - currentBatchId + 1
         log(
-          "Warning: requested withdrawal of " +
-            amount +
-            " " +
-            tokenData.symbol +
-            " for bracket " +
-            bracketAddress +
-            " cannot be executed until " +
-            batchIdsLeft +
-            " " +
-            (batchIdsLeft == 1 ? "batch" : "batches") +
-            " from now, skipping"
+          `Warning: requested withdrawal of ${amount} ${
+            tokenData.symbol
+          } for bracket ${bracketAddress} cannot be executed until ${batchIdsLeft} ${
+            batchIdsLeft == 1 ? "batch" : "batches"
+          } from now, skipping`
         )
         amount = "0"
       }

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -258,7 +258,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
         requestWithdraw: true,
       }
@@ -287,7 +287,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokenIds: [usdcId, wethId],
         requestWithdraw: true,
       }
@@ -314,7 +314,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv1 = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
         requestWithdraw: true,
       }
@@ -324,7 +324,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv2 = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
         withdraw: true,
       }
@@ -354,7 +354,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv1 = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
         requestWithdraw: true,
       }
@@ -364,7 +364,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv2 = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
         withdraw: true,
       }
@@ -373,7 +373,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv3 = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
         transferFundsToMaster: true,
       }
@@ -407,7 +407,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv1 = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
         requestWithdraw: true,
       }
@@ -417,7 +417,7 @@ contract("Withdraw script", function (accounts) {
 
       const argv2 = {
         masterSafe: masterSafe.address,
-        from: bracketAddresses,
+        brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
         withdraw: true,
         transferFundsToMaster: true,
@@ -486,34 +486,34 @@ contract("Withdraw script", function (accounts) {
           masterSafe: masterSafe.address,
           requestWithdraw: true,
           withdrawalFile: "/dev/zero",
-          from: "0x0,0x1",
+          brackets: "0x0,0x1",
         },
-        error: "Argument error: --from cannot be used with --withdrawalFile",
+        error: "Argument error: --brackets cannot be used with --withdrawalFile",
       },
       {
         argv: {
           masterSafe: masterSafe.address,
           requestWithdraw: true,
         },
-        error: "Argument error: one of --withdrawalFile, --from must be given",
+        error: "Argument error: one of --withdrawalFile, --brackets must be given",
       },
       {
         argv: {
           masterSafe: masterSafe.address,
           requestWithdraw: true,
-          from: "0x0,0x1",
+          brackets: "0x0,0x1",
         },
-        error: "Argument error: one of --tokens, --tokenIds must be given when using --from",
+        error: "Argument error: one of --tokens, --tokenIds must be given when using --brackets",
       },
       {
         argv: {
           masterSafe: masterSafe.address,
           requestWithdraw: true,
-          from: "0x0,0x1",
+          brackets: "0x0,0x1",
           tokens: "0x0,0x1",
           tokenIds: "0,1",
         },
-        error: "Argument error: only one of --tokens, --tokenIds is required when using --from",
+        error: "Argument error: only one of --tokens, --tokenIds is required when using --brackets",
       },
       {
         argv: {
@@ -523,7 +523,7 @@ contract("Withdraw script", function (accounts) {
           tokens: "0x0,0x1",
           tokenIds: "0,1",
         },
-        error: "Argument error: --tokens or --tokenIds can only be used with --from",
+        error: "Argument error: --tokens or --tokenIds can only be used with --brackets",
       },
       {
         argv: {
@@ -532,7 +532,7 @@ contract("Withdraw script", function (accounts) {
           requestWithdraw: true,
           tokens: "0x0,0x1",
         },
-        error: "Argument error: --tokens or --tokenIds can only be used with --from",
+        error: "Argument error: --tokens or --tokenIds can only be used with --brackets",
       },
       {
         argv: {
@@ -541,7 +541,7 @@ contract("Withdraw script", function (accounts) {
           requestWithdraw: true,
           tokenIds: "0,1",
         },
-        error: "Argument error: --tokens or --tokenIds can only be used with --from",
+        error: "Argument error: --tokens or --tokenIds can only be used with --brackets",
       },
     ]
     for (const { argv, error } of badInput)

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -209,6 +209,10 @@ contract("Withdraw script", function (accounts) {
     )
     const badInput = [
       {
+        argv: {},
+        error: "Argument error: --masterSafe is required",
+      },
+      {
         argv: {
           masterSafe: masterSafe.address,
           withdrawalFile: "/dev/null",
@@ -242,6 +246,68 @@ contract("Withdraw script", function (accounts) {
           withdrawalFile: "/dev/zero",
         },
         error: "Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          requestWithdraw: true,
+          withdrawalFile: "/dev/zero",
+          from: "0x0,0x1",
+        },
+        error: "Argument error: --from cannot be used with --withdrawalFile",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          requestWithdraw: true,
+        },
+        error: "Argument error: one of --withdrawalFile, --from must be given",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          requestWithdraw: true,
+          from: "0x0,0x1",
+        },
+        error: "Argument error: one of --tokens, --tokenIds must be given when using --from",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          requestWithdraw: true,
+          from: "0x0,0x1",
+          tokens: "0x0,0x1",
+          tokenIds: "0,1",
+        },
+        error: "Argument error: only one of --tokens, --tokenIds is required when using --from",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          requestWithdraw: true,
+          withdrawalFile: "/dev/zero",
+          tokens: "0x0,0x1",
+          tokenIds: "0,1",
+        },
+        error: "Argument error: --tokens or --tokenIds can only be used with --from",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          withdrawalFile: "/dev/zero",
+          requestWithdraw: true,
+          tokens: "0x0,0x1",
+        },
+        error: "Argument error: --tokens or --tokenIds can only be used with --from",
+      },
+      {
+        argv: {
+          masterSafe: masterSafe.address,
+          withdrawalFile: "/dev/zero",
+          requestWithdraw: true,
+          tokenIds: "0,1",
+        },
+        error: "Argument error: --tokens or --tokenIds can only be used with --from",
       },
     ]
     for (const { argv, error } of badInput)

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -204,6 +204,44 @@ contract("Withdraw script", function (accounts) {
 
       depositFile.cleanup()
     })
+    it("withdraws and transfers simultaneously", async () => {
+      const amounts = [{ tokenData: { decimals: 18, symbol: "DAI" }, amount: "1000" }]
+      const [masterSafe, bracketAddresses, tokenInfo] = await setup(2, amounts)
+      const token = tokenInfo[0].token
+      const deposits = evenDeposits(bracketAddresses, tokenInfo[0], "1000")
+      await deposit(masterSafe, deposits)
+      const depositFile = await tmp.file()
+      await fs.writeFile(depositFile.path, JSON.stringify(deposits))
+
+      const argv1 = {
+        masterSafe: masterSafe.address,
+        withdrawalFile: depositFile.path,
+        requestWithdraw: true,
+      }
+      const transaction1 = await prepareWithdraw(argv1)
+      await execTransaction(masterSafe, lw, transaction1)
+      await waitForNSeconds(301)
+
+      const argv2 = {
+        masterSafe: masterSafe.address,
+        withdrawalFile: depositFile.path,
+        withdraw: true,
+        transferFundsToMaster: true,
+      }
+      const transaction2 = await prepareWithdraw(argv2)
+      await execTransaction(masterSafe, lw, transaction2)
+
+      for (const { tokenAddress, bracketAddress } of deposits) {
+        const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()
+        const bracketBalance = (await token.balanceOf(bracketAddress)).toString()
+        assert.equal(requestedWithdrawal, "0", "A withdrawal request is still pending")
+        assert.equal(bracketBalance, "0", "Bracket balance is nonzero")
+      }
+      const masterBalance = (await token.balanceOf(masterSafe.address)).toString()
+      assert.equal(masterBalance, toErc20Units("1000", 18).toString(), "Master safe did not receive tokens")
+
+      depositFile.cleanup()
+    })
   })
   describe("using explicit from addresses", () => {
     it("requests withdrawals", async () => {
@@ -341,6 +379,51 @@ contract("Withdraw script", function (accounts) {
       }
       const transaction3 = await prepareWithdraw(argv3)
       await execTransaction(masterSafe, lw, transaction3)
+
+      for (const { tokenAddress, bracketAddress } of deposits) {
+        const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()
+        const bracketBalance = (await (await ERC20.at(tokenAddress)).balanceOf(bracketAddress)).toString()
+        assert.equal(requestedWithdrawal, "0", "A withdrawal request is still pending")
+        assert.equal(bracketBalance, "0", "Bracket balance is nonzero")
+      }
+      const usdcMasterBalance = (await usdcToken.balanceOf(masterSafe.address)).toString()
+      const wethMasterBalance = (await wethToken.balanceOf(masterSafe.address)).toString()
+      assert.equal(usdcMasterBalance, toErc20Units("10000", 6).toString(), "Master safe did not receive USDC")
+      assert.equal(wethMasterBalance, toErc20Units("50", 18).toString(), "Master safe did not receive WETH")
+    })
+    it("withdraws and transfers simultaneously", async () => {
+      const amounts = [
+        { tokenData: { decimals: 6, symbol: "USDC" }, amount: "10000" },
+        { tokenData: { decimals: 18, symbol: "WETH" }, amount: "50" },
+      ]
+      const [masterSafe, bracketAddresses, tokenInfo] = await setup(4, amounts)
+      const usdcToken = await ERC20.at(tokenInfo[0].address)
+      const wethToken = await ERC20.at(tokenInfo[1].address)
+      // deposits: brackets 0,1,2 have USDC, brackets 2,3 have ETH
+      const depositsUsdc = evenDeposits(bracketAddresses.slice(0, 3), tokenInfo[0], "8000")
+      const depositsWeth = evenDeposits(bracketAddresses.slice(2, 4), tokenInfo[1], "40")
+      const deposits = depositsUsdc.concat(depositsWeth)
+      await deposit(masterSafe, deposits)
+
+      const argv1 = {
+        masterSafe: masterSafe.address,
+        from: bracketAddresses,
+        tokens: [tokenInfo[0].address, tokenInfo[1].address],
+        requestWithdraw: true,
+      }
+      const transaction1 = await prepareWithdraw(argv1)
+      await execTransaction(masterSafe, lw, transaction1)
+      await waitForNSeconds(301)
+
+      const argv2 = {
+        masterSafe: masterSafe.address,
+        from: bracketAddresses,
+        tokens: [tokenInfo[0].address, tokenInfo[1].address],
+        withdraw: true,
+        transferFundsToMaster: true,
+      }
+      const transaction2 = await prepareWithdraw(argv2)
+      await execTransaction(masterSafe, lw, transaction2)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
         const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()


### PR DESCRIPTION
The command-line options of the withdraw script are changed:
- `--allTokens` is removed;
- `--from` is introduced as an alternative to `--withdrawalFile` and accepts a comma-separated list of bracket addresses. Tokens to be withdrawn must be specified manually with one of two new command-line options: `--tokens` or `--tokenIds`, which take a list of addresses or ids respectively for the tokens to withdraw. Amounts are computed automatically.

Note that using a deposit file is more efficient, especially if only one token is deposited at each address. If there are n brackets and m tokens, then using a deposit file would cost `~n` web3 requests, while using `--from` takes `~nm` requests since it needs to retrieve the balances of each pair (token, bracket). Anyway, if the amount to withdraw is zero the corresponding withdraw transaction is not created. 