### PR TITLE
Rework package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "liquidity-provision-scripts",
   "description": "Scripts to deploy and manage automated traders on the Gnosis Protocol exchange",
+  "keywords": [
+    "Gnosis Protocol",
+    "liquidity",
+    "trading"
+  ],
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.0",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "tmp-promise": "^2.0.2",
     "truffle-plugin-verify": "^0.3.10"
   },
+  "engines": {
+    "node": "^10.0.0"
+  },
   "scripts": {
     "lint": "eslint .",
     "prettier": "prettier --write './**/*.js'",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
     "liquidity",
     "trading"
   ],
+  "repository": {
+    "type": "git",
+    "url": "github:https://github.com/gnosis/dex-liquidity-provision"
+  },
+  "bugs": {
+    "url": "https://github.com/gnosis/dex-liquidity-provision/issues"
+  },
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.0",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liquidity-provision-scripts",
   "version": "0.1.0",
-  "description": "",
+  "description": "Scripts to deploy and manage automated traders on the Gnosis Protocol exchange",
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.0",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,11 @@
     "eslint": "^6.8.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-react": "^7.19.0",
-    "eth-lightwallet": "^4.0.0",
-    "ethereumjs-abi": "^0.6.5",
     "ganache-cli": "6.9.1",
     "prettier": "^2.0.5",
-    "run-with-testrpc": "^0.3.0",
+    "sol-merger": "^2.0.1",
     "tmp-promise": "^2.0.2",
-    "truffle-hdwallet-provider": "^1.0.0-web3one.1"
+    "truffle-plugin-verify": "^0.3.10"
   },
   "scripts": {
     "lint": "eslint .",
@@ -38,15 +36,14 @@
     "bn.js": "^5.1.1",
     "canonical-weth": "^1.4.0",
     "dotenv": "^8.0.0",
-    "eslint": "^6.8.0",
     "eth-gas-reporter": "^0.2.17",
+    "eth-lightwallet": "^4.0.0",
     "ethereumjs-util": "^6.2.0",
     "node-fetch": "^2.6.0",
     "openzeppelin-solidity": "^2.4.0",
-    "sol-merger": "^2.0.1",
     "synthetix-js": "^2.21.9",
     "truffle": "^5.1.23",
-    "truffle-plugin-verify": "^0.3.10"
+    "truffle-hdwallet-provider": "^1.0.0-web3one.1"
   },
   "resolutions": {
     "bitcore-lib": "8.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "liquidity-provision-scripts",
-  "version": "0.1.0",
   "description": "Scripts to deploy and manage automated traders on the Gnosis Protocol exchange",
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "liquidity-provision-scripts",
   "description": "Scripts to deploy and manage automated traders on the Gnosis Protocol exchange",
+  "private": true,
   "keywords": [
     "Gnosis Protocol",
     "liquidity",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3570,7 +3570,7 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-ganache-cli@6.9.1, ganache-cli@^6.4.2:
+ganache-cli@6.9.1:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.9.1.tgz#1e13eee098fb9f19b031a191ec3f62ae926ea8b3"
   integrity sha512-VPBumkNUZzXDRQwVOby5YyQpd5t1clkr06xMgB28lZdEIn5ht1GMwUskOTFOAxdkQ4J12IWP0gdeacVRGowqbA==
@@ -5788,14 +5788,6 @@ run-async@^2.4.0:
   integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
   dependencies:
     is-promise "^2.1.0"
-
-run-with-testrpc@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/run-with-testrpc/-/run-with-testrpc-0.3.1.tgz#93dcaab062ece14fb0c02d28def5f05e4bd8e136"
-  integrity sha512-+G9L7oMhLNXStmXGSjWtWxu7QVTJROJq3P1vruH01FaRtDiKIuvgqs9aZ3eJoTkfjg6UoOPxg/kwgYZlwKIvoQ==
-  dependencies:
-    colors "^1.1.2"
-    ganache-cli "^6.4.2"
 
 rustbn.js@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Clean up of `package.json`.
Dependencies have been correctly sorted into dev and non-dev.
Unused package `run-with-testrpc` has been removed.

A nice addition that could also be included in dex-contracts is `engines`: if you try to run `yarn install` with for example Node version 11 the command fails telling the user the Node version is incompatible. I remember my first experience with `dex-contracts` was to debug a mysteriously failing installation due to the fact that the Node version I used was 12.