### PR TITLE
Fix logging when fetching tokens

### DIFF
--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -120,10 +120,11 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     const log = debug ? (...a) => console.log(...a) : () => {}
     const ERC20 = artifacts.require("ERC20Detailed")
 
-    log("Fetching token data from EVM")
+    let requiresFetching = false
     const tokenPromises = {}
     for (const tokenAddress of tokenAddresses) {
       if (!(tokenAddress in globalTokenPromisesFromAddress)) {
+        requiresFetching = true
         globalTokenPromisesFromAddress[tokenAddress] = (async () => {
           const tokenInstance = await ERC20.at(tokenAddress)
           const [tokenSymbol, tokenDecimals] = await Promise.all([tokenInstance.symbol.call(), tokenInstance.decimals.call()])
@@ -139,6 +140,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
       }
       tokenPromises[tokenAddress] = globalTokenPromisesFromAddress[tokenAddress]
     }
+    if (requiresFetching) log("Fetching token data from EVM")
     return tokenPromises
   }
 
@@ -153,10 +155,11 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const fetchTokenInfoFromExchange = function (exchange, tokenIds, debug = false) {
     const log = debug ? (...a) => console.log(...a) : () => {}
 
-    log("Fetching token data from EVM")
+    let requiresFetching = false
     const tokenPromises = {}
     for (const id of tokenIds) {
       if (!(id in globalTokenPromisesFromId)) {
+        requiresFetching = true
         globalTokenPromisesFromId[id] = (async () => {
           const tokenAddress = await exchange.tokenIdToAddressMap(id)
           const tokenInfo = await fetchTokenInfoAtAddresses([tokenAddress], false)[tokenAddress]
@@ -168,6 +171,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
       }
       tokenPromises[id] = globalTokenPromisesFromId[id]
     }
+    if (requiresFetching) log("Fetching token data from EVM")
     return tokenPromises
   }
 

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -117,7 +117,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @return {Promise<TokenObject>[]} list of detailed/relevant token information
    */
   const fetchTokenInfoAtAddresses = function (tokenAddresses, debug = false) {
-    const log = debug ? () => console.log.apply(arguments) : () => {}
+    const log = debug ? (...a) => console.log(...a) : () => {}
     const ERC20 = artifacts.require("ERC20Detailed")
 
     log("Fetching token data from EVM")
@@ -151,7 +151,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @return {Promise<TokenObject>[]} list of detailed/relevant token information
    */
   const fetchTokenInfoFromExchange = function (exchange, tokenIds, debug = false) {
-    const log = debug ? () => console.log.apply(arguments) : () => {}
+    const log = debug ? (...a) => console.log(...a) : () => {}
 
     log("Fetching token data from EVM")
     const tokenPromises = {}

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -159,8 +159,11 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
       if (!(id in globalTokenPromisesFromId)) {
         globalTokenPromisesFromId[id] = (async () => {
           const tokenAddress = await exchange.tokenIdToAddressMap(id)
-          log(`Token id ${id} corresponds to token at address ${tokenAddress}`)
-          return fetchTokenInfoAtAddresses([tokenAddress], debug)[tokenAddress]
+          const tokenInfo = await fetchTokenInfoAtAddresses([tokenAddress], false)[tokenAddress]
+          log(
+            `Found token ${tokenInfo.symbol} for exchange id ${id} at address ${tokenInfo.address} with ${tokenInfo.decimals} decimals`
+          )
+          return tokenInfo
         }).call()
       }
       tokenPromises[id] = globalTokenPromisesFromId[id]


### PR DESCRIPTION
Partially solves issues #74 and #120, further improvements require a different logging strategy. The logs are now printed if the flag `debug` is set to true, there are no repeating log lines, and the fetching message only appears if token info is actually being fetched from the EVM instead of retrieved locally.