### PR TITLE
Fixed gas limit

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -125,4 +125,4 @@ truffle exec scripts/withdraw.js --transferFundsToMaster --masterSafe=$MASTER_SA
 
 ### Confirming multisig-transactions on gnosis-safe with Metamask
 
-The gas limit for the transactions going through the gnosis-safe interface can not yet be correctly estimated. Hence, the proposed gas limits are very high. Usually, for a liquidity deployment with 20 brackets, not more than 5.8m gas is consumed.
+The gas limit for the transactions going through the gnosis-safe interface can not yet be correctly estimated. Hence, the proposed gas limits are very high. Usually, for a liquidity deployment with 20 brackets, not more than 6m gas is consumed.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,10 +29,6 @@ export MASTER_SAFE=<master safe>
 
 ```
 
-### Confirming multisig-transactions on gnosis-safe with Metamask
-
-For the signing process, note that the gas consumption is underestimated. There is currently no proper way to estimate the gas limit. In order to make sure that the gas limit of your transaction is sufficient, increase it to 5.9 million gas. In practice, this limit suffices to deploy a strategy with 20 brackets.
-
 ### Deploy the bracket-strategy:
 
 In order to deploy new bracket-trader contracts, place orders on behalf of the newly mined contracts and fund their accounts on the exchange, one only has to run the `complete_liquidity_provision` script.
@@ -126,3 +122,7 @@ truffle exec scripts/withdraw.js --withdraw --masterSafe=$MASTER_SAFE --withdraw
 ```js
 truffle exec scripts/withdraw.js --transferFundsToMaster --masterSafe=$MASTER_SAFE --withdrawalsFromDepositFile="./data/depositList.json" --network=$NETWORK_NAME
 ```
+
+### Confirming multisig-transactions on gnosis-safe with Metamask
+
+The gas limit for the transactions going through the gnosis-safe interface can not yet be correctly estimated. Hence, the proposed gas limits are very high. Usually, for a liquidity deployment with 20 brackets, not more than 5.8m gas is consumed.

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -65,12 +65,10 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
       signature: sigs,
     }
     await axios.post(endpoint, postData).catch(function (error) {
-      console.log("Show error notification!")
-      return Promise.reject(error)
+      throw new Error("Error while talking to the gnosis-interface: " + error.response.data)
     })
     const interfaceLink = `https://${linkPrefix[network]}gnosis-safe.io/app/#/safes/${masterSafe.address}/transactions`
     console.log("Transaction awaiting execution in the interface", interfaceLink)
-    console.log("Remember to increase the gas limit!")
   }
 
   return {

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -28,7 +28,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     const nonce = await masterSafe.nonce()
     const safeTxGas = 4000000 // Since the gas can not yet be estimated reliably, we are hard coding it.
     // 4000000 is a magic value: This value ensures that the user gets a gas limit proposal in Metask
-    // of roughly 6m for deployment with 20 bracket
+    // of roughly 6m - MetaMask adds a buffer of roughly 50% here.
     const baseGas = 0
     console.log("Aquiring Transaction Hash")
     const transactionHash = await masterSafe.getTransactionHash(


### PR DESCRIPTION
Closes #154 

This PR fixes in practice the gas limit to a value around 6m.
But we can not set the value straight forward, as Metamask still adds a gas-buffer.


testplan:

```
export PK...
source config/rinkeby.env

npx truffle exec scripts/complete_liquidity_provision.js --targetToken=1 --stableToken=2 --lowestLimit=190 --highestLimit=215 --currentPrice=207 --masterSafe=$MASTER_SAFE --investmentTargetToken=0 --investmentStableToken=0 --fleetSize=<Random even. number < 20 > --network=rinkeby
```
and check in meta mask the proposed gas, which should be around 6 million.