### PR TITLE
Calculating the nonce

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,7 +41,7 @@ It will send one ethereum transaction and send two transactions request to the g
 The ethereum transasction will create the bracket-traders. For this transaction the provided private key will be used to pay for the gas.
 The first request of the script will generate orders on behalf of the bracket-traders.
 Please sign this transaction in the gnosis-safe interface and double check that the prices of the orders are as intended - for example in [telegram-mainnet](https://t.me/gnosis_protocol) or [telegram-rinkeby](https://t.me/gnosis_protocol_dev) channels.
-Then continue the script and send out the second request, which will fund the bracket-traders' accounts on the exchange. Notice: One has to wait until the transaction is mined, as otherwise the nonce for the next request will be incorrect.
+The second request generates a transaction funding the bracket-traders' accounts on the exchange.
 Making the requests to the gnosis-interfaces does not cost any gas. However, signing and executing the transactions in the gnosis-safe interface will incur gas costs.
 
 Here is an example script invocation:

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -9,7 +9,7 @@ const {
   checkSufficiencyOfBalance,
 } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils")(web3, artifacts)
-const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
+const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { proceedAnyways } = require("./utils/user_interface_helpers")(web3, artifacts)
 const { toErc20Units } = require("./utils/printing_tools")
 const { sleep } = require("./utils/js_helpers")
@@ -136,16 +136,12 @@ module.exports = async (callback) => {
       true
     )
 
-    console.log("4. Sending out orders")
-    await signAndSend(masterSafe, orderTransaction, argv.network)
+    console.log("4. Sending the order placing transaction to gnosis-safe interface, please sign this transaction first")
+    const nonce = (await masterSafe.nonce()).toNumber()
+    await signAndSend(masterSafe, orderTransaction, argv.network, nonce)
 
-    console.log("5. Sending out funds")
-    const answer = await promptUser(
-      "Are you sure you that the order placement was correct, did you check the telegram bot? [yN] "
-    )
-    if (answer == "y" || answer.toLowerCase() == "yes") {
-      await signAndSend(masterSafe, bundledFundingTransaction, argv.network)
-    }
+    console.log("5. Sending the funds transferring transaction, please sign this transaction second")
+    await signAndSend(masterSafe, bundledFundingTransaction, argv.network, nonce + 1)
 
     callback()
   } catch (error) {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -136,11 +136,11 @@ module.exports = async (callback) => {
       true
     )
 
-    console.log("4. Sending the order placing transaction to gnosis-safe interface, please sign this transaction first")
+    console.log("4. Sending the order placing transaction to gnosis-safe interface, please execute this transaction first")
     const nonce = (await masterSafe.nonce()).toNumber()
     await signAndSend(masterSafe, orderTransaction, argv.network, nonce)
 
-    console.log("5. Sending the funds transferring transaction, please sign this transaction second")
+    console.log("5. Sending the funds transferring transaction, please execute this transaction second")
     await signAndSend(masterSafe, bundledFundingTransaction, argv.network, nonce + 1)
 
     callback()

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -66,6 +66,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
     const interfaceLink = `https://${linkPrefix[network]}gnosis-safe.io/app/#/safes/${masterSafe.address}/transactions`
     console.log("Transaction awaiting execution in the interface", interfaceLink)
+    console.log("Remember to increase the gas limit!")
   }
 
   return {

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -24,8 +24,10 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {Address} masterAddress Address of the master safe owning the brackets
    * @param {Transaction} transaction The transaction to be signed and sent
    */
-  const signAndSend = async function (masterSafe, transaction, network) {
-    const nonce = await masterSafe.nonce()
+  const signAndSend = async function (masterSafe, transaction, network, nonce = null) {
+    if (nonce === null) {
+      nonce = (await masterSafe.nonce()).toNumber()
+    }
     console.log("Aquiring Transaction Hash")
     const transactionHash = await masterSafe.getTransactionHash(
       transaction.to,
@@ -55,7 +57,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
       gasPrice: 0, // important that this is zero
       gasToken: ADDRESS_0,
       refundReceiver: ADDRESS_0,
-      nonce: nonce.toNumber(),
+      nonce: nonce,
       contractTransactionHash: transactionHash,
       sender: web3.utils.toChecksumAddress(account),
       signature: sigs,
@@ -64,7 +66,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
     const interfaceLink = `https://${linkPrefix[network]}gnosis-safe.io/app/#/safes/${masterSafe.address}/transactions`
     console.log("Transaction awaiting execution in the interface", interfaceLink)
-    console.log("Remember to increase the gas limit!")
   }
 
   return {


### PR DESCRIPTION
This Pr calculates the nonce for the script: complete_liquidity_provision.

This allows us to smoothen the user workflow, as both tx are sent to the gnosis-interface simultaneously.

testplan:
try out the new feature like that:
```
npx truffle exec scripts/complete_liquidity_provision.js --targetToken=1 --stableToken=2 --lowestLimit=190 --highestLimit=215 --currentPrice=187 --masterSafe=$MASTER_SAFE --investmentTargetToken=0 --investmentStableToken=0 --fleetSize=20 --network=rinkeby
```
and make sure that you can sign both transactions in our rinkeby safe