### PR TITLE
[Easy] pin solidity data structures

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@gnosis.pm/dex-contracts": "^0.2.13",
     "@gnosis.pm/owl-token": "^3.1.0",
     "@gnosis.pm/safe-contracts": "github:gnosis/safe-contracts#v1.1.1-dev.1",
-    "@gnosis.pm/solidity-data-structures": "^1.2.2",
+    "@gnosis.pm/solidity-data-structures": "=1.2.4",
     "@gnosis.pm/util-contracts": "^2.0.6",
     "@truffle/contract": "^4.2.2",
     "axios": "^0.19.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,7 +214,7 @@
     solc "^0.5.9"
     truffle-hdwallet-provider "0.0.7-beta.1"
 
-"@gnosis.pm/solidity-data-structures@^1.2.2":
+"@gnosis.pm/solidity-data-structures@=1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/solidity-data-structures/-/solidity-data-structures-1.2.4.tgz#e7e0a2e4c3460a0166e7b985e7851e3a54e86607"
   integrity sha512-s5AV1cTf1ERYPCWdC8+Zgx0oZDJTClpkbtXs8RcBFnuhADLd0QTwBowlS8iDsnQtfLNhcF0bDB1rzokJOSUGhg==


### PR DESCRIPTION
Similar to the changes made in dex-contracts, we pin this version of solidity data structures so that dependabot stops asking.

https://github.com/gnosis/dex-contracts/pull/704#pullrequestreview-403493548


Closes #172 