### PR TITLE
Fix --brackets argument in withdraw script

### DIFF
--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -12,7 +12,7 @@ const argv = require("./utils/default_yargs")
     type: "string",
     describe: "file name (and path) to the list of withdrawals",
   })
-  .option("from", {
+  .option("brackets", {
     type: "string",
     describe:
       "comma-separated list of brackets from which to withdraw the entire balance. Compatible with all valid combinations of --requestWithdraw, --withdraw, --transferFundsToMaster",


### PR DESCRIPTION
One of the arguments of the withdraw script was not modified to reflect the changes in the wrapper done in PR #168. This PR fixes that.