### PR TITLE
Use OpenZeppelin's npm package

### DIFF
--- a/contracts/Dependencies.sol
+++ b/contracts/Dependencies.sol
@@ -6,8 +6,8 @@ pragma solidity ^0.5.0;
 //
 //  For other environments, only use compiled contracts from the NPM package.
 // Token Dependencies
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Mintable.sol";
 import "@gnosis.pm/owl-token/contracts/TokenOWLProxy.sol";
 import "@gnosis.pm/owl-token/contracts/TokenOWL.sol";
 // Batch Exchange dependencies

--- a/contracts/test/DetailedMintableToken.sol
+++ b/contracts/test/DetailedMintableToken.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Mintable.sol";
 
 contract DetailedMintableToken is ERC20Mintable {
     uint8 private _decimals;

--- a/package.json
+++ b/package.json
@@ -14,17 +14,6 @@
   "bugs": {
     "url": "https://github.com/gnosis/dex-liquidity-provision/issues"
   },
-  "devDependencies": {
-    "@gnosis.pm/mock-contract": "^3.0.0",
-    "eslint": "^6.8.0",
-    "eslint-plugin-no-only-tests": "^2.4.0",
-    "eslint-plugin-react": "^7.19.0",
-    "ganache-cli": "6.9.1",
-    "prettier": "^2.0.5",
-    "sol-merger": "^2.0.1",
-    "tmp-promise": "^2.1.0",
-    "truffle-plugin-verify": "^0.3.10"
-  },
   "engines": {
     "node": "^10.0.0"
   },
@@ -39,6 +28,17 @@
     "flatten": "export FLATTENED_DIR=\"./build/flattenedContracts\" && mkdir -p $FLATTENED_DIR && npx sol-merger \"contracts/*.sol\" $FLATTENED_DIR && echo \"Flattened contracts stored in $FLATTENED_DIR\" && unset FLATTENED_DIR",
     "networks-inject": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/inject_network_info.js",
     "networks-extract": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/extract_network_info.js"
+  },
+  "devDependencies": {
+    "@gnosis.pm/mock-contract": "^3.0.0",
+    "eslint": "^6.8.0",
+    "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-react": "^7.19.0",
+    "ganache-cli": "6.9.1",
+    "prettier": "^2.0.5",
+    "sol-merger": "^2.0.1",
+    "tmp-promise": "^2.0.2",
+    "truffle-plugin-verify": "^0.3.10"
   },
   "dependencies": {
     "@gnosis.pm/dex-contracts": "^0.2.13",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@gnosis.pm/safe-contracts": "github:gnosis/safe-contracts#v1.1.1-dev.1",
     "@gnosis.pm/solidity-data-structures": "=1.2.4",
     "@gnosis.pm/util-contracts": "^2.0.6",
+    "@openzeppelin/contracts": "=2.5.0",
     "@truffle/contract": "^4.2.2",
     "axios": "^0.19.2",
     "bn.js": "^5.1.1",
@@ -55,7 +56,6 @@
     "eth-lightwallet": "^4.0.0",
     "ethereumjs-util": "^6.2.0",
     "node-fetch": "^2.6.0",
-    "openzeppelin-solidity": "^2.5.1",
     "synthetix-js": "^2.21.12",
     "truffle": "^5.1.24",
     "truffle-hdwallet-provider": "^1.0.0-web3one.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -290,6 +290,11 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.72.0.tgz#43df23af013ad1135407e5cf33ca6e4c4c7708d5"
   integrity sha512-o+TYF8vBcyySRsb2kqBDv/KMeme8a2nwWoG+lAWzbDmWfb2/MrVWYCVYDYvjXdSoI/Cujqy1i0gIDrkdxa9chA==
 
+"@openzeppelin/contracts@=2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-2.5.0.tgz#e327a98ba1d26b7756ff62885a0aa0967a375449"
+  integrity sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg==
+
 "@resolver-engine/core@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.2.1.tgz#0d71803f6d3b8cb2e9ed481a1bf0ca5f5256d0c0"
@@ -5076,7 +5081,7 @@ openzeppelin-solidity@^1.12.0:
   resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz#7b9c55975e73370d4541e3442b30cb3d91ac973a"
   integrity sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA==
 
-openzeppelin-solidity@^2.0.0, openzeppelin-solidity@^2.5.1:
+openzeppelin-solidity@^2.0.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-2.5.1.tgz#1cdcce30c4c6a7b6625dab62ccd0440a813ab597"
   integrity sha512-oCGtQPLOou4su76IMr4XXJavy9a8OZmAXeUZ8diOdFznlL/mlkIlYr7wajqCzH4S47nlKPS7m0+a2nilCTpVPQ==
@@ -6540,7 +6545,7 @@ timers-ext@^0.1.5:
     es5-ext "~0.10.46"
     next-tick "1"
 
-tmp-promise@^2.1.0:
+tmp-promise@^2.0.2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-2.1.0.tgz#b3e70d34ec294279e7c3abbf12b20c7290a3b084"
   integrity sha512-vpg4MiaO80NeB53/tj8RHVHOGkCGOXZ8FMrJqDtJVlgrslkBNNkrAScfE7oJBTry06kc1MrV7SPVVc1auoY0lA==


### PR DESCRIPTION
A new way to depend on OZ.

Note also that I have moved the `dev-dependencies` down in `package.json`

Very similar to https://github.com/gnosis/dex-contracts/pull/716, but notice that our `yarn.lock` still have traces of old versions of OZ. It appears that`gnosis-safe`, `chainlink` and `synthetix` all depend on them.