### PR TITLE
Two new kwargs to snx-liqudity script

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@gnosis.pm/safe-contracts": "github:gnosis/safe-contracts#v1.1.1-dev.1",
     "@gnosis.pm/solidity-data-structures": "=1.2.4",
     "@gnosis.pm/util-contracts": "^2.0.6",
-    "@truffle/contract": "^4.2.2",
+    "@truffle/contract": "4.1.15",
     "axios": "^0.19.2",
     "bn.js": "^5.1.1",
     "canonical-weth": "^1.4.0",
@@ -56,7 +56,7 @@
     "ethereumjs-util": "^6.2.0",
     "node-fetch": "^2.6.0",
     "openzeppelin-solidity": "^2.5.1",
-    "synthetix-js": "^2.21.12",
+    "synthetix-js": "=2.21.9",
     "truffle": "^5.1.24",
     "truffle-hdwallet-provider": "^1.0.0-web3one.1"
   },

--- a/scripts/synthetix/facilitate_trade.js
+++ b/scripts/synthetix/facilitate_trade.js
@@ -5,6 +5,19 @@ const fetch = require("node-fetch")
 const { getExchange } = require("../utils/trading_strategy_helpers")(web3, artifacts)
 const { getUnlimitedOrderAmounts } = require("../utils/price_utils")(web3, artifacts)
 
+const argv = require("../utils/default_yargs")
+  .option("gasPrice", {
+    type: "string",
+    describe: "Gas price to be used for order submission",
+    choices: ["lowest", "safeLow", "standard", "fast", "fastest"],
+    default: "standard",
+  })
+  .option("gasPriceScale", {
+    type: "float",
+    describe: "Scale used as a multiplier to the gas price",
+    default: 1.0,
+  }).argv
+
 // These are fixed constants for the current version of the dex-contracts
 const sETHByNetwork = {
   1: {
@@ -91,10 +104,15 @@ module.exports = async (callback) => {
     const buyTokens = [sETH, sUSD].map((token) => token.exchangeId)
     const sellTokens = [sUSD, sETH].map((token) => token.exchangeId)
 
-    const gasPrices = (await fetch(gasStationURL[networkId])).json()
+    const gasPrices = await (await fetch(gasStationURL[networkId])).json()
+    const scaledGasPrice = parseInt(gasPrices[argv.gasPrice] * argv.gasPriceScale)
+    console.log(
+      `Using current "${argv.gasPrice}" gas price (${gasPrices[argv.gasPrice]}) 
+      scaled by ${argv.gasPriceScale}: ${scaledGasPrice}`
+    )
     await exchange.placeValidFromOrders(buyTokens, sellTokens, validFroms, validTos, buyAmounts, sellAmounts, {
       from: account,
-      gasPrice: gasPrices.fast,
+      gasPrice: scaledGasPrice,
     })
     callback()
   } catch (error) {

--- a/scripts/synthetix/facilitate_trade.js
+++ b/scripts/synthetix/facilitate_trade.js
@@ -106,10 +106,7 @@ module.exports = async (callback) => {
 
     const gasPrices = await (await fetch(gasStationURL[networkId])).json()
     const scaledGasPrice = parseInt(gasPrices[argv.gasPrice] * argv.gasPriceScale)
-    console.log(
-      `Using current "${argv.gasPrice}" gas price (${gasPrices[argv.gasPrice]}) 
-      scaled by ${argv.gasPriceScale}: ${scaledGasPrice}`
-    )
+    console.log(`Using current "${argv.gasPrice}" gas price scaled by ${argv.gasPriceScale}: ${scaledGasPrice}`)
     await exchange.placeValidFromOrders(buyTokens, sellTokens, validFroms, validTos, buyAmounts, sellAmounts, {
       from: account,
       gasPrice: scaledGasPrice,

--- a/yarn.lock
+++ b/yarn.lock
@@ -353,7 +353,7 @@
   dependencies:
     source-map-support "^0.5.16"
 
-"@truffle/contract-schema@^3.0.14", "@truffle/contract-schema@^3.1.0":
+"@truffle/contract-schema@^3.0.14", "@truffle/contract-schema@^3.0.23":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.1.0.tgz#00c04c427a2ecd74fe4399e1896dda49820959c4"
   integrity sha512-eCMc1CwAmxIpQDsuGM9rCp4q/6GMcdQLTw3Tzd1qufyuti0vWGQwJbBAgSvfofr9ItXHueGwn7I5lVsIbOVYpQ==
@@ -362,13 +362,13 @@
     crypto-js "^3.1.9-1"
     debug "^4.1.0"
 
-"@truffle/contract@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.2.2.tgz#13f14b1becfcfefd73247e1acfef6bc4f3e48050"
-  integrity sha512-SxwXITIgBYysyMa6/G9zU3yZCzPfHjqDrbPa5QSlS6n3NKMd06mz1L8slV9iZdzqFWe1Rd7U9/bGP+UXmNiScA==
+"@truffle/contract@4.1.15":
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.1.15.tgz#c82ef6e98e02d069f3cbf9c6d2fc88e142769ad1"
+  integrity sha512-3LHxoVYBziLguvPq6u0VdZsc1l2OIXjDuVGJDYdddfKuDNX/2NuH1JYRP2FM0PA8OYBuGyFolmlldPWRzuucng==
   dependencies:
     "@truffle/blockchain-utils" "^0.0.18"
-    "@truffle/contract-schema" "^3.1.0"
+    "@truffle/contract-schema" "^3.0.23"
     "@truffle/error" "^0.0.8"
     "@truffle/interface-adapter" "^0.4.6"
     bignumber.js "^7.2.1"
@@ -6401,10 +6401,10 @@ sync-rpc@^1.2.1:
   dependencies:
     get-port "^3.1.0"
 
-synthetix-js@^2.21.12:
-  version "2.21.12"
-  resolved "https://registry.yarnpkg.com/synthetix-js/-/synthetix-js-2.21.12.tgz#ac61baf7df93005402c30c8a7493ba7649a11d9c"
-  integrity sha512-K/Q5d3ddJtHysbHxpIHJeMmNE0s4UbGUxIaz3q6GCPb7jPAdSlTtVi8Jml0Kj4zZ6Us0hiQp75fMLpI/RuelAw==
+synthetix-js@=2.21.9:
+  version "2.21.9"
+  resolved "https://registry.yarnpkg.com/synthetix-js/-/synthetix-js-2.21.9.tgz#0cb1ed221ffd5a45afa0230f24c7d5f179e79e87"
+  integrity sha512-jmGqqqF6yR6AmWDaG9afY2E+vCG/ZTizGMLJIpsEidmetTWKuqjlAG9yY2SRUH2NF+yJA8rNj3igWqjhjglfYg==
   dependencies:
     "@ledgerhq/hw-app-eth" "4.74.2"
     "@ledgerhq/hw-transport" "4.74.2"
@@ -6415,14 +6415,14 @@ synthetix-js@^2.21.12:
     ethers "4.0.44"
     hdkey "1.1.1"
     lodash "4.17.15"
-    synthetix "2.21.12"
+    synthetix "2.21.9"
     trezor-connect "7.0.3"
     walletlink "1.0.0"
 
-synthetix@2.21.12:
-  version "2.21.12"
-  resolved "https://registry.yarnpkg.com/synthetix/-/synthetix-2.21.12.tgz#7eac93362d1184e269524167913e75dd6da26bcf"
-  integrity sha512-wyN+P2hYnRBL4SxUIc/JkoOL3IjYPB1mVxe+SEuIuRTk9uKiQoBWcOmAMZNLlvbmwByb3OnLHg+rEtM4oReLrA==
+synthetix@2.21.9:
+  version "2.21.9"
+  resolved "https://registry.yarnpkg.com/synthetix/-/synthetix-2.21.9.tgz#7e11e3ba8603683a975b1b724c18c36279dca78b"
+  integrity sha512-ScXk6IS148tDtq7fA+YHG64FoQ9S5LVmXHmp1qwzIScoeNbdHeeWaQ6rmBa+fbAq4Ej1S3WHNN5jqQ1N7TGIYA==
   dependencies:
     chainlink "0.7.10"
     commander "^2.19.0"


### PR DESCRIPTION
We introduce a way to declare the desired gas price to send along with the orderplacement transaction  "gasPrice" and "gasPriceScale". 


Unfortunately, I had to revert a few recently bumped versions in order to run the latest docker image because of [this](https://github.com/trufflesuite/truffle/issues/3024#issuecomment-623663893) issue with `@truffle/contract`. Will promptly bump all the versions ASAP.
**Test Plan:**

```
truffle exec scripts/synthetix/facilitate_trade.js --network rinkeby --gasPrice fast --gasPriceScale 1.2
```

Expect to see something like this in the console logs

```
Using network 'rinkeby'.

Using account 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
sETH Price 204.85369360931420279
Using current "fast" gas price scaled by 1.2: 12000000001 <------ This is new!
[HDWalletProvider] Using nonce:  25704
```