### PR TITLE
[fix] hardcoded gas value

### DIFF
--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -28,9 +28,9 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     if (nonce === null) {
       nonce = (await masterSafe.nonce()).toNumber()
     }
-    const safeTxGas = 4000000 // Since the gas can not yet be estimated reliably, we are hard coding it.
-    // 4000000 is a magic value: This value ensures that the user gets a gas limit proposal in Metask
-    // of roughly 6m - MetaMask adds a buffer of roughly 50% here.
+    const safeTxGas = 6000000 // Since the gas can not be estimated reliably yet, we are hard coding it.
+    // This is the gas limit enforced by the gnosis-safe transaction. Metamask will show a even higher gas
+    // limit as it adds a buffer of roughly 50%.
     const baseGas = 0
     console.log("Aquiring Transaction Hash")
     const transactionHash = await masterSafe.getTransactionHash(


### PR DESCRIPTION
In the previous PR hardcoding the gasLimit, I only checked that MetaMask shows sufficient gas for the transaction. 
But actually, the gasAmount is then restricted by the Gnosis safe to 4 million, which might not always be sufficient. Hence, I increased the hardcoded value.

<img width="1234" alt="Screen Shot 2020-05-06 at 13 14 54" src="https://user-images.githubusercontent.com/7348154/81170857-ae962600-8f9b-11ea-99f6-e99778c59c45.png">

testplan:
run the following command:


```
export NETWORK_NAME=rinkeby
export GAS_PRICE_GWEI=9
export MASTER_SAFE=your master safe
export PK=...

npx truffle exec scripts/complete_liquidity_provision.js --targetToken=0 --stableToken=7 --lowestLimit=0.10 --highestLimit=1 --currentPrice=0.70 --masterSafe=$MASTER_SAFE --investmentTargetToken=0.05 --investmentStableToken=0.05 --fleetSize=20 --network=$NETWORK_NAME
```
and see the transaction goes through.

The downside of this PR is that we are signing tx of 9M gas in Metamask.