### PR TITLE
Use existing brackets instead of new fleet (if desired)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,9 +15,9 @@ yarn run networks-inject
 ```
 
 Create a gnosis-safe wallet [here-mainnet](https://gnosis-safe.io) or [here-rinkeby](https://rinkeby.gnosis-safe.io). This wallet will be called your Master Safe in the following. It is used to bundle the transactions and setup the bracket-traders.
-This Master Safe must have an additional owner `0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1`, known as the "Proposer" account. The following scripts will use this account to propose transactions to the interface. This implies that the mnemonic phrase for this "Proposer" account is stored in plain text within this project.
+This Master Safe must have an additional owner `0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1`, known as the "Proposer" account. The following scripts will use this account to propose transactions to the interface. This implies that the mnemonic phrase for this "Proposer" account is available in plain text within this project.
 
-In order to have a secure setup, make sure that _your Master Safe always requires one more signature than just the signature of the Proposer account to send a transaction_. _Otherwise, everyone can steal the funds from your account!_
+In order to have a secure setup, make sure your Master Safe always requires one more signature than just the signature of the Proposer account to send a transaction_. Otherwise, everyone can steal the funds from your account!_
 
 Setup env variables for the deployment process:
 
@@ -34,16 +34,16 @@ export MASTER_SAFE=<master safe>
 In order to deploy new bracket-trader contracts, place orders on behalf of the newly mined contracts and fund their accounts on the exchange, one only has to run the `complete_liquidity_provision` script.
 It will send one ethereum transaction and send two transactions request to the gnosis-safe interface.
 
-The ethereum transasction will create the bracket-traders. For this transaction the provided private key will be used to pay for the gas.
+The ethereum transaction will create the bracket-traders. For this transaction the provided private key will be used to pay for the gas.
 The first request of the script will generate orders on behalf of the bracket-traders.
-Please sign this transaction in the gnosis-safe interface and double check that the prices of the orders are as intended - for example in [telegram-mainnet](https://t.me/gnosis_protocol) or [telegram-rinkeby](https://t.me/gnosis_protocol_dev) channels.
+Please sign this transaction in the gnosis-safe interface and double check the order prices are intended - for example in [telegram-mainnet](https://t.me/gnosis_protocol) or [telegram-rinkeby](https://t.me/gnosis_protocol_dev) channels.
 The second request generates a transaction funding the bracket-traders' accounts on the exchange.
 Making the requests to the gnosis-interfaces does not cost any gas. However, signing and executing the transactions in the gnosis-safe interface will incur gas costs.
 
 Here is an example script invocation:
 
 ```js
-npx truffle exec scripts/complete_liquidity_provision.js --targetToken=1 --stableToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --investmentTargetToken=10 --investmentStableToken=1000 --fleetSize=20 --network=$NETWORK_NAME
+npx truffle exec scripts/complete_liquidity_provision.js --targetToken=1 --stableToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --investmentTargetToken=10 --investmentStableToken=1000 --fleetSize=10 --network=$NETWORK_NAME
 ```
 
 The prices must be specified in terms of 1 target token = x stable tokens.
@@ -59,7 +59,7 @@ Instead of doing all the steps with one script, the different steps can also be 
 
 ### Deploy safes
 
-Requires that Master is already deployed.
+Requires that Master Safe has already been deployed.
 
 An example of the usage would be:
 

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -87,7 +87,7 @@ module.exports = async (callback) => {
     const investmentTargetToken = toErc20Units(argv.investmentTargetToken, targetTokenDecimals)
     const investmentStableToken = toErc20Units(argv.investmentStableToken, stableTokenDecimals)
 
-    if (argv.brackets.length > 0) {
+    if (argv.brackets) {
       assert(argv.fleetSize === argv.brackets.length, "Please ensure fleetSize equals number of brackets")
     }
     assert(argv.fleetSize % 2 === 0, "Fleet size must be a even number for easy deployment script")

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -117,7 +117,7 @@ module.exports = async (callback) => {
     }
 
     let bracketAddresses
-    if (argv.brackets.length > 0) {
+    if (argv.brackets) {
       console.log("==> Skipping safe deployment and using brackets safeOwners")
       bracketAddresses = argv.brackets
       // Ensure that safes are all owned solely by masterSafe

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -88,10 +88,7 @@ module.exports = async (callback) => {
     const investmentStableToken = toErc20Units(argv.investmentStableToken, stableTokenDecimals)
 
     if (argv.brackets.length > 0) {
-      assert(
-        argv.fleetSize === argv.brackets.length, 
-        "Please ensure fleetSize equals number of brackets"
-      )
+      assert(argv.fleetSize === argv.brackets.length, "Please ensure fleetSize equals number of brackets")
     }
     assert(argv.fleetSize % 2 === 0, "Fleet size must be a even number for easy deployment script")
 
@@ -135,7 +132,7 @@ module.exports = async (callback) => {
       console.log(`==> Deploying ${argv.fleetSize} trading brackets`)
       bracketAddresses = await deployFleetOfSafes(masterSafe.address, argv.fleetSize, true)
       console.log("List of bracket traders in one line:", bracketAddresses.join())
-      // Sleeping for 3 seconds to make sure Infura nodes have processed 
+      // Sleeping for 3 seconds to make sure Infura nodes have processed
       // all newly deployed contracts so they can be awaited.
       await sleep(3000)
     }

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -25,6 +25,13 @@ const argv = require("./utils/default_yargs")
     default: 20,
     describe: "Even number of brackets to be deployed",
   })
+  .option("brackets", {
+    type: "string",
+    describe: "Trader account addresses to place orders on behalf of",
+    coerce: (str) => {
+      return str.split(",")
+    },
+  })
   .option("targetToken", {
     type: "int",
     describe: "Token whose target price is to be specified (i.e. ETH)",
@@ -79,9 +86,13 @@ module.exports = async (callback) => {
     const investmentTargetToken = toErc20Units(argv.investmentTargetToken, targetTokenDecimals)
     const investmentStableToken = toErc20Units(argv.investmentStableToken, stableTokenDecimals)
 
-    assert(argv.fleetSize % 2 == 0, "Fleet size must be a even number for easy deployment script")
+    if (argv.brackets.length > 0) {
+      // Override fleetSize with num brackets when provided.
+      argv.fleetSize = argv.brackets.length
+    }
+    assert(argv.fleetSize % 2 === 0, "Fleet size must be a even number for easy deployment script")
 
-    console.log("1. Sanity checks")
+    console.log("==> Performing safety checks")
     if (!(await checkSufficiencyOfBalance(targetToken, masterSafe.address, investmentTargetToken))) {
       callback(`Error: MasterSafe has insufficient balance for the token ${targetToken.address}.`)
     }
@@ -105,15 +116,29 @@ module.exports = async (callback) => {
       callback("Error: Choose a smaller fleetSize, otherwise your payload will be to big for Infura nodes")
     }
 
-    console.log(`2. Deploying ${argv.fleetSize} trading brackets`)
-    const bracketAddresses = await deployFleetOfSafes(masterSafe.address, argv.fleetSize, true)
-    console.log("List of bracket traders in one line:", bracketAddresses.join())
+    let bracketAddresses
+    if (argv.brackets.length > 0) {
+      console.log("==> Skipping safe deployment and using brackets safeOwners")
+      bracketAddresses = argv.brackets
+      // Ensure that safes are all owned solely by masterSafe
+      for (const safeAddr of argv.brackets) {
+        const safeOwners = await (await GnosisSafe.at(safeAddr)).getOwners()
+        // TODO: write function like safeOwnedSolelyBy(safe, owner) -> Bool
+        if (!(safeOwners.length === 1 && safeOwners.includes(masterSafe.address))) {
+          callback(`Error: Bracket ${safeAddr} is not owned (or at least not solely) by master safe ${masterSafe.address}`)
+        }
+      }
+    } else {
+      console.log(`==> Deploying ${argv.fleetSize} trading brackets`)
+      bracketAddresses = await deployFleetOfSafes(masterSafe.address, argv.fleetSize, true)
+      console.log("List of bracket traders in one line:", bracketAddresses.join())
+    }
 
     // Sleeping for 3 seconds to make sure Infura nodes have processed all newly deployed contracts so that
     // they can be awaited.
     await sleep(3000)
 
-    console.log("3. Building orders and deposits")
+    console.log("==> Building orders and deposits")
     const orderTransaction = await buildOrders(
       masterSafe.address,
       bracketAddresses,
@@ -136,11 +161,11 @@ module.exports = async (callback) => {
       true
     )
 
-    console.log("4. Sending the order placing transaction to gnosis-safe interface, please execute this transaction first")
+    console.log("==> Sending the order placing transaction to gnosis-safe interface, please execute this transaction first")
     const nonce = (await masterSafe.nonce()).toNumber()
     await signAndSend(masterSafe, orderTransaction, argv.network, nonce)
 
-    console.log("5. Sending the funds transferring transaction, please execute this transaction second")
+    console.log("==> Sending the funds transferring transaction, please execute this transaction second")
     await signAndSend(masterSafe, bundledFundingTransaction, argv.network, nonce + 1)
 
     callback()


### PR DESCRIPTION
This change allows users to specify the existing sub safes for use in the bracket strategy. Note that step numbers were removed because the logical ordering no longer makes sense.

Observe that the safes are required to be solely owned by master safe and the script will error out if this is not the case.


I made a few grammatical changes to the README while I was on this, will happily move it into a different PR.

closes #191

**Test Plan:**

This one will work, 

```
npx truffle exec scripts/complete_liquidity_provision.js --targetToken 1 --stableToken 4 --lowestLimit 200 --fleetSize 2 --highestLimit 216 --currentPrice 208 --masterSafe 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c --investmentTargetToken 0.1 --investmentStableToken 1 --network rinkeby --brackets=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636,0xfA4a18c2218945bC018BF94D093BCa66c88D3c40
```

and return the following output:


```
==> Performing safety checks
==> Skipping safe deployment and using brackets safeOwners
==> Building orders and deposits
Batch Exchange 0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2
Constructing bracket trading strategy order data between the limits 200-216 USDC per WETH
Safe 0 - 0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636:
  Buy  WETH with USDC at 200
  Sell WETH for  USDC at 207.8460969082653
Safe 1 - 0xfA4a18c2218945bC018BF94D093BCa66c88D3c40:
  Buy  WETH with USDC at 207.8460969082653
  Sell WETH for  USDC at 216.00000000000006
Transaction bundle size 4
==> Sending the order placing transaction to gnosis-safe interface, please execute this transaction first
Aquiring Transaction Hash
Signing and posting multi-send transaction request from proposer account 0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1
Transaction awaiting execution in the interface https://rinkeby.gnosis-safe.io/app/#/safes/0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c/transactions
==> Sending the funds transferring transaction, please execute this transaction second
Aquiring Transaction Hash
Signing and posting multi-send transaction request from proposer account 0x90f8bf6a479f320ead074411a4b0e7944ea8c9c1
Transaction awaiting execution in the interface https://rinkeby.gnosis-safe.io/app/#/safes/0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c/transactions
```



For a that failing example replace either one of those brackets addresses with some other safe address that is not solely owner by master safe

Example:

- `0xe6858FF4C3Dbecb91E7A91aEC9913DDbB9b30344` owned by two owners that are not the master safe.

- `0x3273449DB03e0e1bc80586b6093911b3624556EA` which is owned by multiple accounts (including the master safe), but not owned solely by the master safe.


