### PR TITLE
[GasEstimate] Use safe method to estimate gas for internal call

### DIFF
--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -35,7 +35,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     // The value returned by requiredTxGas is encoded in a revert error message. For retrieving the hex
     // encoded uint value the first 68 bytes of the error message need to be removed.
     const txGasEstimate = parseInt(estimateResponse.substring(138), 16)
-    // Multiply with 64/63 due to EIP-150
+    // Multiply with 64/63 due to EIP-150 (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-150.md)
     return Math.ceil((txGasEstimate * 64) / 63)
   }
 

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -29,12 +29,10 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
       data: estimateCall,
       gasPrice: 0,
     })
-    console.log(estimateResponse)
     // https://docs.gnosis.io/safe/docs/contracts_tx_execution/#safe-transaction-gas-limit-estimation
     // The value returned by requiredTxGas is encoded in a revert error message. For retrieving the hex
     // encoded uint value the first 68 bytes of the error message need to be removed.
     const txGasEstimate = parseInt(estimateResponse.substring(138), 16)
-    console.log(txGasEstimate)
     return txGasEstimate
   }
 

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -35,7 +35,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     // The value returned by requiredTxGas is encoded in a revert error message. For retrieving the hex
     // encoded uint value the first 68 bytes of the error message need to be removed.
     const txGasEstimate = parseInt(estimateResponse.substring(138), 16)
-    return txGasEstimate
+    // Multiply with 64/63 due to EIP-150
+    return Math.ceil((txGasEstimate * 64) / 63)
   }
 
   /**


### PR DESCRIPTION
Fixes #154 

Instead of hardcoding an internal gas limit (which already turned out to be brittle, cf #209), we should use the Safe's functionality to estimate the internal call appropriately.

This is also done in the [safe-proxy-kit](https://github.com/gnosis/contract-proxy-kit/pull/49/files) and an example of how to do it can be found in the safe contracts [unit tests](https://github.com/gnosis/safe-contracts/pull/188)

There are two tiny unrelated changes in this PR. One is a hotfix for #200 and the other one is a formatting issue that made only printed as:

> Error: Error while talking to the gnosis-interface: [object Object] 

### Test Plan

```
export NETWORK_NAME=rinkeby
export GAS_PRICE_GWEI=9
export MASTER_SAFE=your master safe
export PK=...

npx truffle exec scripts/complete_liquidity_provision.js --targetToken=0 --stableToken=7 --lowestLimit=0.10 --highestLimit=1 --currentPrice=0.70 --masterSafe=$MASTER_SAFE --investmentTargetToken=0.05 --investmentStableToken=0.05 --fleetSize=20 --network=$NETWORK_NAME
```

See txs go through.

Or check

https://rinkeby.etherscan.io/tx/0xbcf31282c2350f8e521123d76d243a3c8a995f21024a8b25776c98c12993b450#internal

which shows the hardcoded value of 4M **before this PR** and

https://rinkeby.etherscan.io/tx/0x37deb7cd729e52e2d29d195df6b4ac16299f1b6b90b14e6f53300e201d39d3e3#internal

for the exact estimated value **after this PR** (2.9M)
