### PR TITLE
[Easy] allow PKs with both 0x and no prefix

### DIFF
--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -15,6 +15,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     mainnet: "",
   }
 
+  const withHexPrefix = (string) => (string.startsWith("0x") ? string : `0x${string}`)
+
   const promptUser = function (message) {
     return new Promise((resolve) => rl.question(message, (answer) => resolve(answer)))
   }
@@ -45,7 +47,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
       ADDRESS_0,
       nonce
     )
-    const privateKey = process.env.PK
+    const privateKey = withHexPrefix(process.env.PK)
     const account = web3.eth.accounts.privateKeyToAccount(privateKey)
     console.log(`Signing and posting multi-send transaction request from proposer account ${account.address}`)
     const sigs = signHashWithPrivateKey(transactionHash, privateKey)


### PR DESCRIPTION
#200 only works with 0x prefixed PKs. However truffle itself allows both prefixed and non-prefixed keys and when exporting from MM one would have to manually add the prefix.

This PR makes it so that the code works with both.

### Test Plan

- export PK=0x...
- run script and see we can propose a tx
- export PK=... (without prefix)
- see this works as well 