### PR TITLE
Change amount withdrawn with --brackets

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "networks-extract": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/extract_network_info.js"
   },
   "dependencies": {
-    "@gnosis.pm/dex-contracts": "^0.2.13",
+    "@gnosis.pm/dex-contracts": "^0.2.15",
     "@gnosis.pm/owl-token": "^3.1.0",
     "@gnosis.pm/safe-contracts": "github:gnosis/safe-contracts#v1.1.1-dev.1",
     "@gnosis.pm/solidity-data-structures": "=1.2.4",

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -54,22 +54,26 @@ module.exports = function (web3, artifacts) {
     const token = tokenData.instance
     if (argv.requestWithdraw) {
       amount = bnMaxUint.toString()
-    } else if (argv.withdraw) {
-      const pendingWithdrawal = await exchange.getPendingWithdraw(bracketAddress, tokenData.address)
-      amount = pendingWithdrawal[0].toString()
-      if (pendingWithdrawal[1].toNumber() >= currentBatchId) {
-        const batchIdsLeft = pendingWithdrawal[1].toNumber() - currentBatchId + 1
-        log(
-          `Warning: requested withdrawal of ${amount} ${
-            tokenData.symbol
-          } for bracket ${bracketAddress} cannot be executed until ${batchIdsLeft} ${
-            batchIdsLeft == 1 ? "batch" : "batches"
-          } from now, skipping`
-        )
-        amount = "0"
-      }
     } else {
-      amount = (await token.balanceOf(bracketAddress)).toString()
+      if (argv.withdraw) {
+        // replace with getWithdrawableAmount(bracketAddress, tokenData.address, exchange, web3)
+        const pendingWithdrawal = await exchange.getPendingWithdraw(bracketAddress, tokenData.address)
+        amount = pendingWithdrawal[0].toString()
+        if (pendingWithdrawal[1].toNumber() >= currentBatchId) {
+          const batchIdsLeft = pendingWithdrawal[1].toNumber() - currentBatchId + 1
+          log(
+            `Warning: requested withdrawal of ${amount} ${
+              tokenData.symbol
+            } for bracket ${bracketAddress} cannot be executed until ${batchIdsLeft} ${
+              batchIdsLeft == 1 ? "batch" : "batches"
+            } from now, skipping`
+          )
+          amount = "0"
+        }
+      }
+      if (argv.transferFundsToMaster) {
+        amount = amount || (await token.balanceOf(bracketAddress)).toString()
+      }
     }
     return amount
   }

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -42,7 +42,7 @@ module.exports = function (web3, artifacts) {
     }
   }
 
-  const getMaxWithdrawableAmount = async function (argv, bracketAddress, tokenData, exchange) {
+  const determineAmountToWithdraw = async function (argv, bracketAddress, tokenData, exchange) {
     let amount
     const token = tokenData.instance
     if (argv.requestWithdraw) {
@@ -82,7 +82,7 @@ module.exports = function (web3, artifacts) {
         for (const bracketAddress of argv.brackets) tokenBracketPairs.push([bracketAddress, tokenData])
       const maxWithdrawableAmounts = await Promise.all(
         tokenBracketPairs.map(([bracketAddress, tokenData]) =>
-          getMaxWithdrawableAmount(argv, bracketAddress, tokenData, exchange)
+          determineAmountToWithdraw(argv, bracketAddress, tokenData, exchange)
         )
       )
       withdrawals = []

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -11,6 +11,7 @@ module.exports = function (web3, artifacts) {
     buildTransferFundsToMaster,
     buildWithdrawAndTransferFundsToMaster,
   } = require("../utils/trading_strategy_helpers")(web3, artifacts)
+  const { bnMaxUint } = require("../utils/printing_tools.js")
 
   const assertGoodArguments = function (argv) {
     if (!argv.masterSafe) throw new Error("Argument error: --masterSafe is required")
@@ -51,8 +52,9 @@ module.exports = function (web3, artifacts) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
     let amount
     const token = tokenData.instance
-    if (argv.requestWithdraw) amount = (await exchange.getBalance(bracketAddress, tokenData.address)).toString()
-    else if (argv.withdraw) {
+    if (argv.requestWithdraw) {
+      amount = bnMaxUint.toString()
+    } else if (argv.withdraw) {
       const pendingWithdrawal = await exchange.getPendingWithdraw(bracketAddress, tokenData.address)
       amount = pendingWithdrawal[0].toString()
       if (pendingWithdrawal[1].toNumber() >= currentBatchId) {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -453,7 +453,7 @@ contract("Withdraw script", function (accounts) {
       const transaction = await prepareWithdraw(argv)
       // if the built transaction used the token balance of the bracket instead of zero, then
       // the following transaction would fail.
-      await await execTransaction(masterSafe, safeOwner.privateKey, transaction)
+      await execTransaction(masterSafe, safeOwner.privateKey, transaction)
     })
   })
   it("fails on bad input", async () => {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -453,7 +453,7 @@ contract("Withdraw script", function (accounts) {
       const transaction = await prepareWithdraw(argv)
       // if the built transaction used the token balance of the bracket instead of zero, then
       // the following transaction would fail.
-      await execTransaction(masterSafe, lw, transaction)
+      await await execTransaction(masterSafe, safeOwner.privateKey, transaction)
     })
   })
   it("fails on bad input", async () => {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -19,6 +19,8 @@ const { waitForNSeconds, execTransaction } = require("../../scripts/utils/intern
 const prepareWithdraw = require("../../scripts/wrapper/withdraw")(web3, artifacts)
 const { toErc20Units, fromErc20Units } = require("../../scripts/utils/printing_tools")
 
+const bnMaxUint256 = new BN(2).pow(new BN(256)).subn(1)
+
 contract("Withdraw script", function (accounts) {
   let lw
   let gnosisSafeMasterCopy
@@ -265,10 +267,10 @@ contract("Withdraw script", function (accounts) {
       const transaction = await prepareWithdraw(argv)
       await execTransaction(masterSafe, lw, transaction)
 
-      for (const { amount, tokenAddress, bracketAddress } of deposits) {
+      for (const { tokenAddress, bracketAddress } of deposits) {
         const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()
         assert.notEqual(requestedWithdrawal, "0", "Withdrawal was not requested")
-        assert.equal(requestedWithdrawal, amount, "Bad amount requested to withdraw")
+        assert.equal(requestedWithdrawal, bnMaxUint256.toString(), "Bad amount requested to withdraw")
       }
     })
     it("requests withdrawals with token Ids", async () => {
@@ -294,10 +296,10 @@ contract("Withdraw script", function (accounts) {
       const transaction = await prepareWithdraw(argv)
       await execTransaction(masterSafe, lw, transaction)
 
-      for (const { amount, tokenAddress, bracketAddress } of deposits) {
+      for (const { tokenAddress, bracketAddress } of deposits) {
         const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()
         assert.notEqual(requestedWithdrawal, "0", "Withdrawal was not requested")
-        assert.equal(requestedWithdrawal, amount, "Bad amount requested to withdraw")
+        assert.equal(requestedWithdrawal, bnMaxUint256.toString(), "Bad amount requested to withdraw")
       }
     })
     it("withdraws", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,10 +174,10 @@
     "@ethersproject/constants" ">=5.0.0-beta.128"
     "@ethersproject/logger" ">=5.0.0-beta.129"
 
-"@gnosis.pm/dex-contracts@^0.2.13":
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.2.13.tgz#80c53d8661dfba65119bcb1365aeac8eaf4f7bc4"
-  integrity sha512-Td1q1Gc7tFZChyBoQN9QVv+bR1jGxFUD0LwkLmgVdSQtuB0KBU68LutoLv86YHJnoUqL24Lfk3icfRLQXOEUDQ==
+"@gnosis.pm/dex-contracts@^0.2.15":
+  version "0.2.15"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.2.15.tgz#254314c6f8dff33a022a3d2b67035b08f0782c94"
+  integrity sha512-rvGuiHfl12F70qBiJimUv/uGdn5+Dfao2xAbhiQh9/wJBt5A5nVYONnZ13JFfIoOrSJTRT1n61SEhLfLOlG6dw==
   dependencies:
     bn.js "^5.1.1"
 


### PR DESCRIPTION
Implements the changes described in #159.
When executing `withdraw.js` with `--brackets`:
- `--requestWithdraw` uses the maximum value for `uint256`. The idea is that a user who doesn't specify the amounts with a deposit file simply wants to withdraw everything in the brackets. Before this PR the script would only request to withdraw the amount that was available at the time of the request, meaning that amounts deriving from future trades would not be withdrawn. The new behavior is also useful for an emergency shutdown of the brackets.
- `--withdraw` and `--withdraw --transferFundsToMaster` compute the actual amount available for withdrawing. Before they relied on the amount specified in the withdraw request.
- `--transferFundsToMaster` is unchanged.

Downside of the changes is that the user is not warned anymore when using `--withdraw` if there are funds available to be withdrawn but no withdraw was requested or the withdraw is not yet valid.

Closes #159.

Test plan: unit tests.