### PR TITLE
Replace unlimited orders with limited but large orders

### DIFF
--- a/scripts/synthetix/facilitate_trade.js
+++ b/scripts/synthetix/facilitate_trade.js
@@ -3,7 +3,7 @@ const ethers = require("ethers")
 const fetch = require("node-fetch")
 
 const { getExchange } = require("../utils/trading_strategy_helpers")(web3, artifacts)
-const { getUnlimitedOrderAmounts } = require("../utils/price_utils")(web3, artifacts)
+const { getLargeOrderAmounts } = require("../utils/price_utils")(web3, artifacts)
 
 const argv = require("../utils/default_yargs")
   .option("gasPrice", {
@@ -80,12 +80,12 @@ module.exports = async (callback) => {
     const sUSDTosETHFee = parseFloat(snxjs.utils.formatEther(await snxjs.Exchanger.feeRateForExchange(sUSDKey, sETHKey)))
 
     // Compute buy-sell amounts based on unlimited orders with rates from above.
-    const [buyETHAmount, sellSUSDAmount] = getUnlimitedOrderAmounts(
+    const [buyETHAmount, sellSUSDAmount] = getLargeOrderAmounts(
       formatedRate * (1 - sUSDTosETHFee),
       sETH.decimals,
       sUSD.decimals
     )
-    const [sellETHAmount, buySUSDAmount] = getUnlimitedOrderAmounts(
+    const [sellETHAmount, buySUSDAmount] = getLargeOrderAmounts(
       formatedRate * (1 + sETHTosUSDFee),
       sUSD.decimals,
       sETH.decimals

--- a/scripts/synthetix/facilitate_trade.js
+++ b/scripts/synthetix/facilitate_trade.js
@@ -80,16 +80,8 @@ module.exports = async (callback) => {
     const sUSDTosETHFee = parseFloat(snxjs.utils.formatEther(await snxjs.Exchanger.feeRateForExchange(sUSDKey, sETHKey)))
 
     // Compute buy-sell amounts based on unlimited orders with rates from above.
-    const [buyETHAmount, sellSUSDAmount] = getLargeOrderAmounts(
-      formatedRate * (1 - sUSDTosETHFee),
-      sETH.decimals,
-      sUSD.decimals
-    )
-    const [sellETHAmount, buySUSDAmount] = getLargeOrderAmounts(
-      formatedRate * (1 + sETHTosUSDFee),
-      sUSD.decimals,
-      sETH.decimals
-    )
+    const [buyETHAmount, sellSUSDAmount] = getLargeOrderAmounts(formatedRate * (1 - sUSDTosETHFee), sETH.decimals, sUSD.decimals)
+    const [sellETHAmount, buySUSDAmount] = getLargeOrderAmounts(formatedRate * (1 + sETHTosUSDFee), sUSD.decimals, sETH.decimals)
 
     const buyAmounts = [buyETHAmount, buySUSDAmount]
     const sellAmounts = [sellSUSDAmount, sellETHAmount]

--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -1,0 +1,11 @@
+const BN = require("bn.js")
+
+const MAX_UINT_128 = new BN(2).pow(new BN(128)).sub(new BN(1))
+
+// see https://github.com/gnosis/dex-liquidity-provision/issues/203#issuecomment-624772889 for details
+const ORDER_AMOUNT_MARGIN = new BN(10).pow(new BN(9))
+const MAX_ORDER_AMOUNT = MAX_UINT_128.div(ORDER_AMOUNT_MARGIN)
+
+module.exports = {
+  MAX_ORDER_AMOUNT,
+}

--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -6,7 +6,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const exchangeUtils = require("@gnosis.pm/dex-contracts")
   const { Fraction } = require("@gnosis.pm/dex-contracts/src")
 
-  const max128 = new BN(2).pow(new BN(128)).subn(1)
+  const { MAX_ORDER_AMOUNT } = require("./constants.js")
 
   const checkCorrectnessOfDeposits = async (
     currentPrice,
@@ -179,11 +179,11 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {integer} stableTokenDecimals number of decimals of the stable token
    * @return {BN[2]} amounts of stable token and target token for an unlimited order at the input price
    */
-  const getUnlimitedOrderAmounts = function (price, targetTokenDecimals, stableTokenDecimals) {
-    let targetTokenAmount = max128.clone()
+  const getLargeOrderAmounts = function (price, targetTokenDecimals, stableTokenDecimals) {
+    let targetTokenAmount = MAX_ORDER_AMOUNT.clone()
     let stableTokenAmount = getOutputAmountFromPrice(price, targetTokenAmount, targetTokenDecimals, stableTokenDecimals)
     if (stableTokenAmount.gt(targetTokenAmount)) {
-      stableTokenAmount = max128.clone()
+      stableTokenAmount = MAX_ORDER_AMOUNT.clone()
       targetTokenAmount = getOutputAmountFromPrice(1 / price, stableTokenAmount, stableTokenDecimals, targetTokenDecimals)
       assert(stableTokenAmount.gte(targetTokenAmount), "Error: unable to create unlimited order")
     }
@@ -225,9 +225,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     areBoundsReasonable,
     checkCorrectnessOfDeposits,
     getOutputAmountFromPrice,
-    getUnlimitedOrderAmounts,
+    getLargeOrderAmounts,
     getDexagPrice,
     checkNoProfitableOffer,
-    max128,
   }
 }

--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -179,11 +179,11 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {integer} stableTokenDecimals number of decimals of the stable token
    * @return {BN[2]} amounts of stable token and target token for an unlimited order at the input price
    */
-  const getLargeOrderAmounts = function (price, targetTokenDecimals, stableTokenDecimals) {
-    let targetTokenAmount = MAX_ORDER_AMOUNT.clone()
+  const getLargeOrderAmounts = function (price, targetTokenDecimals, stableTokenDecimals, orderSizeLimit = MAX_ORDER_AMOUNT) {
+    let targetTokenAmount = orderSizeLimit.clone()
     let stableTokenAmount = getOutputAmountFromPrice(price, targetTokenAmount, targetTokenDecimals, stableTokenDecimals)
     if (stableTokenAmount.gt(targetTokenAmount)) {
-      stableTokenAmount = MAX_ORDER_AMOUNT.clone()
+      stableTokenAmount = orderSizeLimit.clone()
       targetTokenAmount = getOutputAmountFromPrice(1 / price, stableTokenAmount, stableTokenDecimals, targetTokenDecimals)
       assert(stableTokenAmount.gte(targetTokenAmount), "Error: unable to create unlimited order")
     }

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -5,7 +5,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const Contract = require("@truffle/contract")
 
   const { buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")(web3, artifacts)
-  const { getUnlimitedOrderAmounts } = require("./price_utils")(web3, artifacts)
+  const { getLargeOrderAmounts } = require("./price_utils")(web3, artifacts)
   const { shortenedAddress, fromErc20Units } = require("./printing_tools")
   const { allElementsOnlyOnce } = require("./js_helpers")
 
@@ -254,18 +254,10 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
         const lowerLimit = lowestLimit * Math.pow(stepSizeAsMultiplier, bracketIndex)
         const upperLimit = lowerLimit * stepSizeAsMultiplier
 
-        const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(
-          upperLimit,
-          targetToken.decimals,
-          stableToken.decimals
-        )
+        const [upperSellAmount, upperBuyAmount] = getLargeOrderAmounts(upperLimit, targetToken.decimals, stableToken.decimals)
         // While the first bracket-order trades standard_token against target_token, the second bracket-order trades
         // target_token against standard_token. Hence the buyAmounts and sellAmounts are switched in the next line.
-        const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(
-          lowerLimit,
-          targetToken.decimals,
-          stableToken.decimals
-        )
+        const [lowerBuyAmount, lowerSellAmount] = getLargeOrderAmounts(lowerLimit, targetToken.decimals, stableToken.decimals)
 
         log(
           `Safe ${bracketIndex} - ${bracketAddress}:\n  Buy  ${targetToken.symbol} with ${stableToken.symbol} at ${lowerLimit}\n  Sell ${targetToken.symbol} for  ${stableToken.symbol} at ${upperLimit}`

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -26,7 +26,8 @@ const {
   maxU32,
 } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
 const { waitForNSeconds, execTransaction } = require("../scripts/utils/internals")(web3, artifacts)
-const { checkCorrectnessOfDeposits, max128 } = require("../scripts/utils/price_utils")(web3, artifacts)
+const { checkCorrectnessOfDeposits } = require("../scripts/utils/price_utils")(web3, artifacts)
+const { MAX_ORDER_AMOUNT } = require("../scripts/utils/constants.js")
 const { toErc20Units, fromErc20Units } = require("../scripts/utils/printing_tools")
 
 const TEN = new BN(10)
@@ -379,7 +380,7 @@ contract("GnosisSafe", function (accounts) {
         {
           amountStableToken: "0.00000000000000000000001",
           amountTargetToken: "3.14159265",
-          stableTokenInfo: { decimals: 40, symbol: "manydecimals" }, // above 38 decimals one token unit does not fit a uint128
+          stableTokenInfo: { decimals: 31, symbol: "manydecimals" }, // above 29 decimals one token unit does not fit MAX_ORDER_AMOUNT
           targetTokenInfo: { decimals: 8, symbol: "WBTC" },
         },
       ]
@@ -550,8 +551,8 @@ contract("GnosisSafe", function (accounts) {
       for (const bracketAddress of bracketSafes) {
         const auctionElements = exchangeUtils.decodeOrdersBN(await exchange.getEncodedUserOrders(bracketAddress))
         const [buyOrder, sellOrder] = auctionElements
-        assert(buyOrder.priceNumerator.eq(max128))
-        assert(sellOrder.priceDenominator.eq(max128))
+        assert(buyOrder.priceNumerator.eq(MAX_ORDER_AMOUNT))
+        assert(sellOrder.priceDenominator.eq(MAX_ORDER_AMOUNT))
       }
     })
     it("Places bracket orders on behalf of a fleet of safes and checks prices for p>1", async () => {
@@ -580,8 +581,8 @@ contract("GnosisSafe", function (accounts) {
         const auctionElements = exchangeUtils.decodeOrdersBN(await exchange.getEncodedUserOrders(bracketAddress))
         assert.equal(auctionElements.length, 2)
         const [buyOrder, sellOrder] = auctionElements
-        assert(buyOrder.priceDenominator.eq(max128))
-        assert(sellOrder.priceNumerator.eq(max128))
+        assert(buyOrder.priceDenominator.eq(MAX_ORDER_AMOUNT))
+        assert(sellOrder.priceNumerator.eq(MAX_ORDER_AMOUNT))
       }
     })
     it("Places bracket orders on behalf of a fleet of safes and checks prices for p<1, with different decimals than 18", async () => {

--- a/test/price_utils.js
+++ b/test/price_utils.js
@@ -135,6 +135,41 @@ describe("getLargeOrderAmounts", () => {
       assertEqualUpToFloatPrecision(targetTokenAmount, expectedTargetTokenAmount)
     }
   })
+  it("allows orderSizeLimit to change default order size", () => {
+    const orderSizeLimit = new BN(10).pow(new BN(21))
+    const testCases = [
+      {
+        price: 160,
+        stableTokenDecimals: 6,
+        targetTokenDecimals: 18,
+        expectedStableTokenAmount: orderSizeLimit.muln(160).div(new BN(10).pow(new BN(18 - 6))),
+        expectedTargetTokenAmount: orderSizeLimit,
+      },
+      {
+        price: 1 / 160,
+        stableTokenDecimals: 6,
+        targetTokenDecimals: 18,
+        expectedStableTokenAmount: orderSizeLimit.divn(160).div(new BN(10).pow(new BN(18 - 6))),
+        expectedTargetTokenAmount: orderSizeLimit,
+      },
+    ]
+    for (const {
+      price,
+      stableTokenDecimals,
+      targetTokenDecimals,
+      expectedStableTokenAmount,
+      expectedTargetTokenAmount,
+    } of testCases) {
+      const [targetTokenAmount, stableTokenAmount] = getLargeOrderAmounts(
+        price,
+        targetTokenDecimals,
+        stableTokenDecimals,
+        orderSizeLimit
+      )
+      assertEqualUpToFloatPrecision(stableTokenAmount, expectedStableTokenAmount)
+      assertEqualUpToFloatPrecision(targetTokenAmount, expectedTargetTokenAmount)
+    }
+  })
 })
 
 contract("PriceOracle", function (accounts) {

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -7,7 +7,7 @@ const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const EvilGnosisSafeProxy = artifacts.require("EvilGnosisSafeProxy")
 
 const { verifyCorrectSetup } = require("../scripts/utils/verify_scripts")(web3, artifacts)
-const { getUnlimitedOrderAmounts } = require("../scripts/utils/price_utils")(web3, artifacts)
+const { getLargeOrderAmounts } = require("../scripts/utils/price_utils")(web3, artifacts)
 const { addCustomMintableTokenToExchange, createTokenAndGetData, deploySafe } = require("./test_utils")
 const { execTransaction, waitForNSeconds, ADDRESS_0 } = require("../scripts/utils/internals")(web3, artifacts)
 const {
@@ -290,8 +290,8 @@ contract("Verification checks", function (accounts) {
       const highestLimit = 120
 
       // create unlimited orders to sell low and buy high
-      const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(highestLimit, 18, 18)
-      const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(lowestLimit, 18, 18)
+      const [upperSellAmount, upperBuyAmount] = getLargeOrderAmounts(highestLimit, 18, 18)
+      const [lowerBuyAmount, lowerSellAmount] = getLargeOrderAmounts(lowestLimit, 18, 18)
 
       const validFrom = (await exchange.getCurrentBatchId.call()).toNumber() + 3
       const buyTokens = [targetToken.id, targetToken.id]
@@ -328,8 +328,8 @@ contract("Verification checks", function (accounts) {
       const highestLimit = 120
 
       // create unlimited orders to sell low and buy high
-      const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(lowestLimit, 18, 18)
-      const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(highestLimit, 18, 18)
+      const [upperSellAmount, upperBuyAmount] = getLargeOrderAmounts(lowestLimit, 18, 18)
+      const [lowerBuyAmount, lowerSellAmount] = getLargeOrderAmounts(highestLimit, 18, 18)
 
       const validFrom = (await exchange.getCurrentBatchId.call()).toNumber() + 3
       const buyTokens = [targetToken.id, stableToken.id]


### PR DESCRIPTION

Removes unlimited order and uses large orders instead. Closes #203.

Before merging I'd run from a master safe that has 10USDC and 1WETH:
```
npx truffle exec scripts/complete_liquidity_provision.js --targetToken=1 --stableToken=6 --lowestLimit=180 --highestLimit=220 --currentPrice=190 --masterSafe=$MASTER_SAFE --investmentTargetToken=1 --investmentStableToken=10 --fleetSize=20 --network=rinkeby
```
and double check the orders on the Telegram bot [here](https://t.me/s/gnosis_protocol_dev).