### PR TITLE
Fix duplicated "y" in user prompt

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -3,8 +3,8 @@ const { fetchTokenInfoFromExchange, getExchange, getSafe, buildOrders } = requir
   artifacts
 )
 const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils.js")(web3, artifacts)
-const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
-const { proceedAnyways } = require("./utils/user_interface_helpers")
+const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
+const { proceedAnyways, promptUser } = require("./utils/user_interface_helpers")
 
 const argv = require("./utils/default_yargs")
   .option("targetToken", {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -12,7 +12,7 @@ const {
 } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils")(web3, artifacts)
 const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
-const { proceedAnyways } = require("./utils/user_interface_helpers")(web3, artifacts)
+const { proceedAnyways } = require("./utils/user_interface_helpers")
 const { toErc20Units } = require("./utils/printing_tools")
 const { sleep } = require("./utils/js_helpers")
 

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -1,7 +1,8 @@
 const fs = require("fs").promises
 
-const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
+const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { buildTransferApproveDepositFromList } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { promptUser } = require("./utils/user_interface_helpers")
 
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {

--- a/scripts/utils/sign_and_send.js
+++ b/scripts/utils/sign_and_send.js
@@ -1,15 +1,9 @@
 module.exports = function (web3 = web3, artifacts = artifacts) {
   const assert = require("assert")
   const axios = require("axios")
-  const readline = require("readline")
 
   const { ADDRESS_0 } = require("./trading_strategy_helpers")(web3, artifacts)
   const { signHashWithPrivateKey } = require("../utils/internals")(web3, artifacts)
-
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  })
 
   const linkPrefix = {
     rinkeby: "rinkeby.",
@@ -17,10 +11,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   }
 
   const withHexPrefix = (string) => (string.startsWith("0x") ? string : `0x${string}`)
-
-  const promptUser = function (message) {
-    return new Promise((resolve) => rl.question(message, (answer) => resolve(answer)))
-  }
 
   const estimateGas = async function (masterSafe, transaction) {
     const estimateCall = masterSafe.contract.methods
@@ -101,6 +91,5 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
   return {
     signAndSend,
-    promptUser,
   }
 }

--- a/scripts/utils/user_interface_helpers.js
+++ b/scripts/utils/user_interface_helpers.js
@@ -5,10 +5,12 @@ const promptUser = function (message) {
     input: process.stdin,
     output: process.stdout,
   })
-  return new Promise((resolve) => rl.question(message, (answer) => {
-    rl.close()
-    resolve(answer)
-  }))
+  return new Promise((resolve) =>
+    rl.question(message, (answer) => {
+      rl.close()
+      resolve(answer)
+    })
+  )
 }
 
 const proceedAnyways = async function (message) {

--- a/scripts/utils/user_interface_helpers.js
+++ b/scripts/utils/user_interface_helpers.js
@@ -1,11 +1,11 @@
 module.exports = function (web3 = web3, artifacts = artifacts) {
   const readline = require("readline")
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
 
   const promptUser = function (message) {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    })
     return new Promise((resolve) => rl.question(message, (answer) => resolve(answer)))
   }
 

--- a/scripts/utils/user_interface_helpers.js
+++ b/scripts/utils/user_interface_helpers.js
@@ -1,23 +1,22 @@
-module.exports = function () {
-  const readline = require("readline")
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  })
+const readline = require("readline")
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+})
 
-  const promptUser = function (message) {
-    return new Promise((resolve) => rl.question(message, (answer) => resolve(answer)))
-  }
+const promptUser = function (message) {
+  return new Promise((resolve) => rl.question(message, (answer) => resolve(answer)))
+}
 
-  const proceedAnyways = async (message) => {
-    const answer = await promptUser(message + " Continue anyway? [yN] ")
-    if (answer === "y" || answer.toLowerCase() === "yes") {
-      return true
-    }
-    return false
+const proceedAnyways = async function (message) {
+  const answer = await promptUser(message + " Continue anyway? [yN] ")
+  if (answer === "y" || answer.toLowerCase() === "yes") {
+    return true
   }
-  return {
-    proceedAnyways,
-    promptUser,
-  }
+  return false
+}
+
+module.exports = {
+  proceedAnyways,
+  promptUser,
 }

--- a/scripts/utils/user_interface_helpers.js
+++ b/scripts/utils/user_interface_helpers.js
@@ -1,11 +1,14 @@
 const readline = require("readline")
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-})
 
 const promptUser = function (message) {
-  return new Promise((resolve) => rl.question(message, (answer) => resolve(answer)))
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+  return new Promise((resolve) => rl.question(message, (answer) => {
+    rl.close()
+    resolve(answer)
+  }))
 }
 
 const proceedAnyways = async function (message) {

--- a/scripts/utils/user_interface_helpers.js
+++ b/scripts/utils/user_interface_helpers.js
@@ -1,5 +1,13 @@
 module.exports = function (web3 = web3, artifacts = artifacts) {
-  const { promptUser } = require("./sign_and_send")(web3, artifacts)
+  const readline = require("readline")
+
+  const promptUser = function (message) {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
+    return new Promise((resolve) => rl.question(message, (answer) => resolve(answer)))
+  }
 
   const proceedAnyways = async (message) => {
     const answer = await promptUser(message + " Continue anyway? [yN] ")
@@ -10,5 +18,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   }
   return {
     proceedAnyways,
+    promptUser,
   }
 }

--- a/scripts/utils/user_interface_helpers.js
+++ b/scripts/utils/user_interface_helpers.js
@@ -1,4 +1,4 @@
-module.exports = function (web3 = web3, artifacts = artifacts) {
+module.exports = function () {
   const readline = require("readline")
   const rl = readline.createInterface({
     input: process.stdin,

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -1,7 +1,7 @@
 const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
-const { promptUser } = require("./utils/user_interface_helpers")
 const prepareWithdraw = require("./wrapper/withdraw")(web3, artifacts)
+const { promptUser } = require("./utils/user_interface_helpers")
 
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -3,7 +3,6 @@ const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { promptUser } = require("./utils/user_interface_helpers")
 const prepareWithdraw = require("./wrapper/withdraw")(web3, artifacts)
 
-
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {
     type: "string",

--- a/scripts/withdraw.js
+++ b/scripts/withdraw.js
@@ -1,6 +1,8 @@
-const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
+const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { promptUser } = require("./utils/user_interface_helpers")
 const prepareWithdraw = require("./wrapper/withdraw")(web3, artifacts)
+
 
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {

--- a/scripts/wrap_eth.js
+++ b/scripts/wrap_eth.js
@@ -1,8 +1,9 @@
 const Contract = require("@truffle/contract")
 
-const { signAndSend, promptUser } = require("./utils/sign_and_send")(web3, artifacts)
+const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { CALL } = require("./utils/internals")(web3, artifacts)
 const { toErc20Units, fromErc20Units } = require("./utils/printing_tools")
+const { promptUser } = require("./utils/user_interface_helpers")
 
 const argv = require("./utils/default_yargs")
   .option("masterSafe", {


### PR DESCRIPTION
Changes here, move the user prompt into a more appropriate location which avoids being unavoidably imported multiple times in files that rely on it.

Closes #189 

### Test Plan:
Run this (with intentionally bad  values)

```sh
npx truffle exec scripts/complete_liquidity_provision.js --targetToken 1 --stableToken 4 --lowestLimit 300 --fleetSize 2 --highestLimit 416 --currentPrice 20 --masterSafe 0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c --investmentTargetToken 0.1 --investmentStableToken 1 --network rinkeby --brackets=0x725fd170B9a8c28caabB9b81Dd0dC80Fb3aa5Db6,0xeda61B1e9f414889ddE0dbe83B3BaCF814A98E87
```

and expect to get the following warnings along with their "proceed Anyway" prompts.

```
Warning: the chosen price differs by more than 2 percent from the price found on dex.ag.
         chosen price: 20 USDC bought for 1 WETH
         dex.ag price: 188.5327344940625 USDC bought for 1 WETH
Price check failed! Continue anyway? [yN] y
Please double check your bounds. They seem to be unreasonable
Please double check your bounds. Current price is not within the bounds
Bound checks failed! Continue anyway? [yN] y
==> Skipping safe deployment and using brackets safeOwners
The following brackets have existing orders:
  0x725fd170B9a8c28caabB9b81Dd0dC80Fb3aa5Db6,0xeda61B1e9f414889ddE0dbe83B3BaCF814A98E87
 Continue anyway? [yN] y
```
