### PR TITLE
stable to quote & target to base

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,7 +47,7 @@ Making the requests to the gnosis-interfaces does not cost any gas. However, sig
 Here is an example script invocation:
 
 ```js
-npx truffle exec scripts/complete_liquidity_provision.js --baseToken=1 --quoteToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --depositBaseToken=10 --depositQuoteToken=1000 --fleetSize=10 --network=$NETWORK_NAME
+npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --depositBaseToken=10 --depositQuoteToken=1000 --fleetSize=10 --network=$NETWORK_NAME
 ```
 
 The prices must be specified in terms of 1 base token = x quote tokens.
@@ -80,7 +80,7 @@ Requires that Master and bracket-traders are already deployed.
 An example of the usage would be:
 
 ```js
-truffle exec scripts/bracket_orders.js --baseToken=1 --quoteToken=7 --currentPrice 270 --lowestLimit 240 --highestLimit 300 --masterSafe=$MASTER_SAFE --brackets=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636,0xfA4a18c2218945bC018BF94D093BCa66c88D3c40 --network=$NETWORK_NAME
+truffle exec scripts/bracket_orders.js --baseTokenId=1 --quoteTokenID=7 --currentPrice 270 --lowestLimit 240 --highestLimit 300 --masterSafe=$MASTER_SAFE --brackets=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636,0xfA4a18c2218945bC018BF94D093BCa66c88D3c40 --network=$NETWORK_NAME
 ```
 
 ### Transfer-Approve-Deposit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,7 +47,7 @@ Making the requests to the gnosis-interfaces does not cost any gas. However, sig
 Here is an example script invocation:
 
 ```js
-npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --depositBaseToken=10 --depositQuoteToken=1000 --fleetSize=10 --network=$NETWORK_NAME
+npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --depositBaseToken=0.1 --depositQuoteToken=10 --fleetSize=10 --network=$NETWORK_NAME
 ```
 
 The prices must be specified in terms of 1 base token = x quote tokens.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,13 +47,13 @@ Making the requests to the gnosis-interfaces does not cost any gas. However, sig
 Here is an example script invocation:
 
 ```js
-npx truffle exec scripts/complete_liquidity_provision.js --baseToken=1 --stableToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --investmentBaseToken=10 --investmentStableToken=1000 --fleetSize=10 --network=$NETWORK_NAME
+npx truffle exec scripts/complete_liquidity_provision.js --baseToken=1 --quoteToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --investmentBaseToken=10 --investmentQuoteToken=1000 --fleetSize=10 --network=$NETWORK_NAME
 ```
 
-The prices must be specified in terms of 1 base token = x stable tokens.
+The prices must be specified in terms of 1 base token = x quote tokens.
 
 This example deploys a liquidity strategy with 20 brackets between the prices 150-200 on the pair WETH-USDC.
-In this script the baseToken is 1, which happens to be WETH, and the stableToken is 4, which happens to be USDC.
+In this script the baseToken is 1, which happens to be WETH, and the quoteToken is 4, which happens to be USDC.
 The token ids of the exchange contract can be read from Etherscan info in the 'Contract/Read Contract' tab, e.g. [here for mainnet](https://etherscan.io/address/0x6f400810b62df8e13fded51be75ff5393eaa841f)
 
 The fleet size should be smaller than or equal to 20, in order to ensure that the transactions can be sent via MetaMask - otherwise, it can happen that the payload is too high for Metamask.
@@ -80,7 +80,7 @@ Requires that Master and bracket-traders are already deployed.
 An example of the usage would be:
 
 ```js
-truffle exec scripts/bracket_orders.js --baseToken=1 --stableToken=7 --currentPrice 270 --lowestLimit 240 --highestLimit 300 --masterSafe=$MASTER_SAFE --brackets=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636,0xfA4a18c2218945bC018BF94D093BCa66c88D3c40 --network=$NETWORK_NAME
+truffle exec scripts/bracket_orders.js --baseToken=1 --quoteToken=7 --currentPrice 270 --lowestLimit 240 --highestLimit 300 --masterSafe=$MASTER_SAFE --brackets=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636,0xfA4a18c2218945bC018BF94D093BCa66c88D3c40 --network=$NETWORK_NAME
 ```
 
 ### Transfer-Approve-Deposit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,13 +47,13 @@ Making the requests to the gnosis-interfaces does not cost any gas. However, sig
 Here is an example script invocation:
 
 ```js
-npx truffle exec scripts/complete_liquidity_provision.js --targetToken=1 --stableToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --investmentTargetToken=10 --investmentStableToken=1000 --fleetSize=10 --network=$NETWORK_NAME
+npx truffle exec scripts/complete_liquidity_provision.js --baseToken=1 --stableToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --investmentBaseToken=10 --investmentStableToken=1000 --fleetSize=10 --network=$NETWORK_NAME
 ```
 
-The prices must be specified in terms of 1 target token = x stable tokens.
+The prices must be specified in terms of 1 base token = x stable tokens.
 
 This example deploys a liquidity strategy with 20 brackets between the prices 150-200 on the pair WETH-USDC.
-In this script the targetToken is 1, which happens to be WETH, and the stableToken is 4, which happens to be USDC.
+In this script the baseToken is 1, which happens to be WETH, and the stableToken is 4, which happens to be USDC.
 The token ids of the exchange contract can be read from Etherscan info in the 'Contract/Read Contract' tab, e.g. [here for mainnet](https://etherscan.io/address/0x6f400810b62df8e13fded51be75ff5393eaa841f)
 
 The fleet size should be smaller than or equal to 20, in order to ensure that the transactions can be sent via MetaMask - otherwise, it can happen that the payload is too high for Metamask.
@@ -80,7 +80,7 @@ Requires that Master and bracket-traders are already deployed.
 An example of the usage would be:
 
 ```js
-truffle exec scripts/bracket_orders.js --targetToken=1 --stableToken=7 --currentPrice 270 --lowestLimit 240 --highestLimit 300 --masterSafe=$MASTER_SAFE --brackets=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636,0xfA4a18c2218945bC018BF94D093BCa66c88D3c40 --network=$NETWORK_NAME
+truffle exec scripts/bracket_orders.js --baseToken=1 --stableToken=7 --currentPrice 270 --lowestLimit 240 --highestLimit 300 --masterSafe=$MASTER_SAFE --brackets=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636,0xfA4a18c2218945bC018BF94D093BCa66c88D3c40 --network=$NETWORK_NAME
 ```
 
 ### Transfer-Approve-Deposit

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,7 +47,7 @@ Making the requests to the gnosis-interfaces does not cost any gas. However, sig
 Here is an example script invocation:
 
 ```js
-npx truffle exec scripts/complete_liquidity_provision.js --baseToken=1 --quoteToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --investmentBaseToken=10 --investmentQuoteToken=1000 --fleetSize=10 --network=$NETWORK_NAME
+npx truffle exec scripts/complete_liquidity_provision.js --baseToken=1 --quoteToken=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --depositBaseToken=10 --depositQuoteToken=1000 --fleetSize=10 --network=$NETWORK_NAME
 ```
 
 The prices must be specified in terms of 1 base token = x quote tokens.

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -7,7 +7,7 @@ const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { proceedAnyways, promptUser } = require("./utils/user_interface_helpers")
 
 const argv = require("./utils/default_yargs")
-  .option("targetToken", {
+  .option("baseToken", {
     type: "int",
     describe: "Token whose target price is to be specified (i.e. ETH)",
     demandOption: true,
@@ -55,12 +55,12 @@ module.exports = async (callback) => {
     const exchange = await getExchange(web3)
 
     // check price against dex.ag's API
-    const targetTokenId = argv.targetToken
+    const baseTokenId = argv.baseToken
     const stableTokenId = argv.stableToken
-    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId])
-    const targetTokenData = await tokenInfoPromises[targetTokenId]
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [baseTokenId, stableTokenId])
+    const baseTokenData = await tokenInfoPromises[baseTokenId]
     const stableTokenData = await tokenInfoPromises[stableTokenId]
-    const priceCheck = await isPriceReasonable(targetTokenData, stableTokenData, argv.currentPrice)
+    const priceCheck = await isPriceReasonable(baseTokenData, stableTokenData, argv.currentPrice)
     const boundCheck = areBoundsReasonable(argv.currentPrice, argv.lowestLimit, argv.highestLimit)
 
     if (priceCheck || (await proceedAnyways("Price check failed!"))) {
@@ -69,7 +69,7 @@ module.exports = async (callback) => {
         const transaction = await buildOrders(
           argv.masterSafe,
           argv.brackets,
-          argv.targetToken,
+          argv.baseToken,
           argv.stableToken,
           argv.lowestLimit,
           argv.highestLimit,
@@ -78,7 +78,7 @@ module.exports = async (callback) => {
         )
 
         const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
-        if (answer == "y" || answer.toLowerCase() == "yes") {
+        if (answer === "y" || answer.toLowerCase() === "yes") {
           await signAndSend(await masterSafePromise(), transaction, argv.network)
         }
       }

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -7,12 +7,12 @@ const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { proceedAnyways, promptUser } = require("./utils/user_interface_helpers")
 
 const argv = require("./utils/default_yargs")
-  .option("baseToken", {
+  .option("baseTokenId", {
     type: "int",
-    describe: "Token whose target price is to be specified (i.e. ETH)",
+    describe: "Base Token whose target price is to be specified (i.e. ETH)",
     demandOption: true,
   })
-  .option("quoteToken", {
+  .option("quoteTokenId", {
     type: "int",
     describe: "Quote Token for which to open orders (i.e. DAI)",
     demandOption: true,
@@ -55,11 +55,9 @@ module.exports = async (callback) => {
     const exchange = await getExchange(web3)
 
     // check price against dex.ag's API
-    const baseTokenId = argv.baseToken
-    const quoteTokenId = argv.quoteToken
-    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [baseTokenId, quoteTokenId])
-    const baseTokenData = await tokenInfoPromises[baseTokenId]
-    const quoteTokenData = await tokenInfoPromises[quoteTokenId]
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [argv.baseTokenId, argv.quoteTokenId])
+    const baseTokenData = await tokenInfoPromises[argv.baseTokenId]
+    const quoteTokenData = await tokenInfoPromises[argv.quoteTokenId]
     const priceCheck = await isPriceReasonable(baseTokenData, quoteTokenData, argv.currentPrice)
     const boundCheck = areBoundsReasonable(argv.currentPrice, argv.lowestLimit, argv.highestLimit)
 
@@ -69,8 +67,8 @@ module.exports = async (callback) => {
         const transaction = await buildOrders(
           argv.masterSafe,
           argv.brackets,
-          argv.baseToken,
-          argv.quoteToken,
+          argv.baseTokenId,
+          argv.quoteTokenId,
           argv.lowestLimit,
           argv.highestLimit,
           true,

--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -12,9 +12,9 @@ const argv = require("./utils/default_yargs")
     describe: "Token whose target price is to be specified (i.e. ETH)",
     demandOption: true,
   })
-  .option("stableToken", {
+  .option("quoteToken", {
     type: "int",
-    describe: "Stable Token for which to open orders (i.e. DAI)",
+    describe: "Quote Token for which to open orders (i.e. DAI)",
     demandOption: true,
   })
   .option("currentPrice", {
@@ -56,11 +56,11 @@ module.exports = async (callback) => {
 
     // check price against dex.ag's API
     const baseTokenId = argv.baseToken
-    const stableTokenId = argv.stableToken
-    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [baseTokenId, stableTokenId])
+    const quoteTokenId = argv.quoteToken
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [baseTokenId, quoteTokenId])
     const baseTokenData = await tokenInfoPromises[baseTokenId]
-    const stableTokenData = await tokenInfoPromises[stableTokenId]
-    const priceCheck = await isPriceReasonable(baseTokenData, stableTokenData, argv.currentPrice)
+    const quoteTokenData = await tokenInfoPromises[quoteTokenId]
+    const priceCheck = await isPriceReasonable(baseTokenData, quoteTokenData, argv.currentPrice)
     const boundCheck = areBoundsReasonable(argv.currentPrice, argv.lowestLimit, argv.highestLimit)
 
     if (priceCheck || (await proceedAnyways("Price check failed!"))) {
@@ -70,7 +70,7 @@ module.exports = async (callback) => {
           argv.masterSafe,
           argv.brackets,
           argv.baseToken,
-          argv.stableToken,
+          argv.quoteToken,
           argv.lowestLimit,
           argv.highestLimit,
           true,

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -39,7 +39,7 @@ const argv = require("./utils/default_yargs")
     describe: "Token whose target price is to be specified (i.e. ETH)",
     demandOption: true,
   })
-  .option("investmentBaseToken", {
+  .option("depositBaseToken", {
     type: "string",
     describe: "Amount to be invested into the baseToken",
     demandOption: true,
@@ -49,7 +49,7 @@ const argv = require("./utils/default_yargs")
     describe: "Trusted Quote Token for which to open orders (i.e. DAI)",
     demandOption: true,
   })
-  .option("investmentQuoteToken", {
+  .option("depositQuoteToken", {
     type: "string",
     describe: "Amount to be invested into the quoteToken",
     demandOption: true,
@@ -94,8 +94,8 @@ module.exports = async (callback) => {
     const { instance: baseToken, decimals: baseTokenDecimals } = baseTokenData
     const { instance: quoteToken, decimals: quoteTokenDecimals } = quoteTokenData
 
-    const investmentBaseToken = toErc20Units(argv.investmentBaseToken, baseTokenDecimals)
-    const investmentQuoteToken = toErc20Units(argv.investmentQuoteToken, quoteTokenDecimals)
+    const depositBaseToken = toErc20Units(argv.depositBaseToken, baseTokenDecimals)
+    const depositQuoteToken = toErc20Units(argv.depositQuoteToken, quoteTokenDecimals)
 
     if (argv.brackets) {
       assert(argv.fleetSize === argv.brackets.length, "Please ensure fleetSize equals number of brackets")
@@ -103,10 +103,10 @@ module.exports = async (callback) => {
     assert(argv.fleetSize % 2 === 0, "Fleet size must be a even number for easy deployment script")
 
     console.log("==> Performing safety checks")
-    if (!(await checkSufficiencyOfBalance(baseToken, masterSafe.address, investmentBaseToken))) {
+    if (!(await checkSufficiencyOfBalance(baseToken, masterSafe.address, depositBaseToken))) {
       callback(`Error: MasterSafe has insufficient balance for the token ${baseToken.address}.`)
     }
-    if (!(await checkSufficiencyOfBalance(quoteToken, masterSafe.address, investmentQuoteToken))) {
+    if (!(await checkSufficiencyOfBalance(quoteToken, masterSafe.address, depositQuoteToken))) {
       callback(`Error: MasterSafe has insufficient balance for the token ${quoteToken.address}.`)
     }
     // check price against dex.ag's API
@@ -178,8 +178,8 @@ module.exports = async (callback) => {
       argv.lowestLimit,
       argv.highestLimit,
       argv.currentPrice,
-      investmentQuoteToken,
-      investmentBaseToken,
+      depositQuoteToken,
+      depositBaseToken,
       true
     )
 

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -34,7 +34,7 @@ const argv = require("./utils/default_yargs")
       return str.split(",")
     },
   })
-  .option("baseToken", {
+  .option("baseTokenId", {
     type: "int",
     describe: "Token whose target price is to be specified (i.e. ETH)",
     demandOption: true,
@@ -44,7 +44,7 @@ const argv = require("./utils/default_yargs")
     describe: "Amount to be invested into the baseToken",
     demandOption: true,
   })
-  .option("quoteToken", {
+  .option("quoteTokenId", {
     type: "int",
     describe: "Trusted Quote Token for which to open orders (i.e. DAI)",
     demandOption: true,
@@ -86,11 +86,9 @@ module.exports = async (callback) => {
     BatchExchange.setProvider(web3.currentProvider)
     const exchange = await BatchExchange.deployed()
 
-    const baseTokenId = argv.baseToken
-    const quoteTokenId = argv.quoteToken
-    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [baseTokenId, quoteTokenId])
-    const baseTokenData = await tokenInfoPromises[baseTokenId]
-    const quoteTokenData = await tokenInfoPromises[quoteTokenId]
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [argv.baseTokenId, argv.quoteTokenId])
+    const baseTokenData = await tokenInfoPromises[argv.baseTokenId]
+    const quoteTokenData = await tokenInfoPromises[argv.quoteTokenId]
     const { instance: baseToken, decimals: baseTokenDecimals } = baseTokenData
     const { instance: quoteToken, decimals: quoteTokenDecimals } = quoteTokenData
 

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -34,14 +34,14 @@ const argv = require("./utils/default_yargs")
       return str.split(",")
     },
   })
-  .option("targetToken", {
+  .option("baseToken", {
     type: "int",
     describe: "Token whose target price is to be specified (i.e. ETH)",
     demandOption: true,
   })
-  .option("investmentTargetToken", {
+  .option("investmentBaseToken", {
     type: "string",
-    describe: "Amount to be invested into the targetToken",
+    describe: "Amount to be invested into the baseToken",
     demandOption: true,
   })
   .option("stableToken", {
@@ -86,15 +86,15 @@ module.exports = async (callback) => {
     BatchExchange.setProvider(web3.currentProvider)
     const exchange = await BatchExchange.deployed()
 
-    const targetTokenId = argv.targetToken
+    const baseTokenId = argv.baseToken
     const stableTokenId = argv.stableToken
-    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [targetTokenId, stableTokenId])
-    const targetTokenData = await tokenInfoPromises[targetTokenId]
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [baseTokenId, stableTokenId])
+    const baseTokenData = await tokenInfoPromises[baseTokenId]
     const stableTokenData = await tokenInfoPromises[stableTokenId]
-    const { instance: targetToken, decimals: targetTokenDecimals } = targetTokenData
+    const { instance: baseToken, decimals: baseTokenDecimals } = baseTokenData
     const { instance: stableToken, decimals: stableTokenDecimals } = stableTokenData
 
-    const investmentTargetToken = toErc20Units(argv.investmentTargetToken, targetTokenDecimals)
+    const investmentBaseToken = toErc20Units(argv.investmentBaseToken, baseTokenDecimals)
     const investmentStableToken = toErc20Units(argv.investmentStableToken, stableTokenDecimals)
 
     if (argv.brackets) {
@@ -103,14 +103,14 @@ module.exports = async (callback) => {
     assert(argv.fleetSize % 2 === 0, "Fleet size must be a even number for easy deployment script")
 
     console.log("==> Performing safety checks")
-    if (!(await checkSufficiencyOfBalance(targetToken, masterSafe.address, investmentTargetToken))) {
-      callback(`Error: MasterSafe has insufficient balance for the token ${targetToken.address}.`)
+    if (!(await checkSufficiencyOfBalance(baseToken, masterSafe.address, investmentBaseToken))) {
+      callback(`Error: MasterSafe has insufficient balance for the token ${baseToken.address}.`)
     }
     if (!(await checkSufficiencyOfBalance(stableToken, masterSafe.address, investmentStableToken))) {
       callback(`Error: MasterSafe has insufficient balance for the token ${stableToken.address}.`)
     }
     // check price against dex.ag's API
-    const priceCheck = await isPriceReasonable(targetTokenData, stableTokenData, argv.currentPrice)
+    const priceCheck = await isPriceReasonable(baseTokenData, stableTokenData, argv.currentPrice)
     if (!priceCheck) {
       if (!(await proceedAnyways("Price check failed!"))) {
         callback("Error: Price checks did not pass")
@@ -164,7 +164,7 @@ module.exports = async (callback) => {
     const orderTransaction = await buildOrders(
       masterSafe.address,
       bracketAddresses,
-      argv.targetToken,
+      argv.baseToken,
       argv.stableToken,
       argv.lowestLimit,
       argv.highestLimit,
@@ -173,13 +173,13 @@ module.exports = async (callback) => {
     const bundledFundingTransaction = await buildTransferApproveDepositFromOrders(
       masterSafe.address,
       bracketAddresses,
-      targetToken.address,
+      baseToken.address,
       stableToken.address,
       argv.lowestLimit,
       argv.highestLimit,
       argv.currentPrice,
       investmentStableToken,
-      investmentTargetToken,
+      investmentBaseToken,
       true
     )
 

--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -34,10 +34,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     const buyBaseTokenOrder = buyBaseTokenOrders[0]
     assert.equal(buyBaseTokenOrder.sellToken, quoteTokenId)
     // price of order is in terms of base tokens per quote token, the inverse is needed
-    const priceBuyingBaseToken = new Fraction(
-      buyBaseTokenOrder.priceNumerator,
-      buyBaseTokenOrder.priceDenominator
-    ).inverted()
+    const priceBuyingBaseToken = new Fraction(buyBaseTokenOrder.priceNumerator, buyBaseTokenOrder.priceDenominator).inverted()
 
     const sellBaseTokenOrders = bracketOrders.filter((order) => order.sellToken == baseTokenId)
     assert.equal(sellBaseTokenOrders.length, 1)
@@ -76,8 +73,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     return (
       (bracketExchangeBalanceQuoteToken === "0" &&
         bracketExchangeBalanceBaseToken === investmentBaseTokenPerBracket.toString()) ||
-      (bracketExchangeBalanceBaseToken === "0" &&
-        bracketExchangeBalanceQuoteToken === investmentQuoteTokenPerBracket.toString())
+      (bracketExchangeBalanceBaseToken === "0" && bracketExchangeBalanceQuoteToken === investmentQuoteTokenPerBracket.toString())
     )
   }
 

--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -14,8 +14,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     exchange,
     quoteToken,
     baseToken,
-    investmentQuoteTokenPerBracket,
-    investmentBaseTokenPerBracket
+    depositQuoteTokenPerBracket,
+    depositBaseTokenPerBracket
   ) => {
     // all prices are of the form: 1 base token = "price" quote tokens
     const bracketExchangeBalanceQuoteToken = (await exchange.getBalance(bracketAddress, quoteToken.address)).toString()
@@ -46,17 +46,17 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
     if (priceSellingBaseToken.lt(currentUnitPrice)) {
       assert.equal(bracketExchangeBalanceBaseToken, "0")
-      assert.equal(bracketExchangeBalanceQuoteToken, investmentQuoteTokenPerBracket.toString())
+      assert.equal(bracketExchangeBalanceQuoteToken, depositQuoteTokenPerBracket.toString())
     } else if (priceBuyingBaseToken.gt(currentUnitPrice)) {
-      assert.equal(bracketExchangeBalanceBaseToken, investmentBaseTokenPerBracket.toString())
+      assert.equal(bracketExchangeBalanceBaseToken, depositBaseTokenPerBracket.toString())
       assert.equal(bracketExchangeBalanceQuoteToken, "0")
     } else {
       assert(
         checkFundingInTheMiddleBracket(
           bracketExchangeBalanceQuoteToken,
           bracketExchangeBalanceBaseToken,
-          investmentQuoteTokenPerBracket,
-          investmentBaseTokenPerBracket
+          depositQuoteTokenPerBracket,
+          depositBaseTokenPerBracket
         )
       )
     }
@@ -65,15 +65,15 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const checkFundingInTheMiddleBracket = function (
     bracketExchangeBalanceQuoteToken,
     bracketExchangeBalanceBaseToken,
-    investmentQuoteTokenPerBracket,
-    investmentBaseTokenPerBracket
+    depositQuoteTokenPerBracket,
+    depositBaseTokenPerBracket
   ) {
     // For the middle bracket the funding can go in either bracket
     // it depends on closer distance from the currentPrice to the limit prices fo the bracket-traders
     return (
       (bracketExchangeBalanceQuoteToken === "0" &&
-        bracketExchangeBalanceBaseToken === investmentBaseTokenPerBracket.toString()) ||
-      (bracketExchangeBalanceBaseToken === "0" && bracketExchangeBalanceQuoteToken === investmentQuoteTokenPerBracket.toString())
+        bracketExchangeBalanceBaseToken === depositBaseTokenPerBracket.toString()) ||
+      (bracketExchangeBalanceBaseToken === "0" && bracketExchangeBalanceQuoteToken === depositQuoteTokenPerBracket.toString())
     )
   }
 

--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -71,8 +71,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     // For the middle bracket the funding can go in either bracket
     // it depends on closer distance from the currentPrice to the limit prices fo the bracket-traders
     return (
-      (bracketExchangeBalanceQuoteToken === "0" &&
-        bracketExchangeBalanceBaseToken === depositBaseTokenPerBracket.toString()) ||
+      (bracketExchangeBalanceQuoteToken === "0" && bracketExchangeBalanceBaseToken === depositBaseTokenPerBracket.toString()) ||
       (bracketExchangeBalanceBaseToken === "0" && bracketExchangeBalanceQuoteToken === depositQuoteTokenPerBracket.toString())
     )
   }

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -426,9 +426,9 @@ withdrawal of or to withdraw the desired funds
    * @param {Address} masterAddress Address of the master safe owning the brackets
    * @param {Address[]} bracketAddresses list of bracket addresses that need the deposit
    * @param {Address} quoteTokenAddress one token to be traded in bracket strategy
-   * @param {number} investmentQuoteToken Amount of quote tokens to be invested (in total)
+   * @param {number} depositQuoteToken Amount of quote tokens to be invested (in total)
    * @param {Address} baseTokenAddress second token to be traded in bracket strategy
-   * @param {number} investmentQuoteToken Amount of base tokens to be invested (in total)
+   * @param {number} depositQuoteToken Amount of base tokens to be invested (in total)
    * @param {bool} storeDepositsAsFile whether to write the executed deposits to a file (defaults to false)
    * @return {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
    */
@@ -440,8 +440,8 @@ withdrawal of or to withdraw the desired funds
     lowestLimit,
     highestLimit,
     currentPrice,
-    investmentQuoteToken,
-    investmentBaseToken,
+    depositQuoteToken,
+    depositBaseToken,
     storeDepositsAsFile = false
   ) {
     const fleetSize = bracketAddresses.length
@@ -461,7 +461,7 @@ withdrawal of or to withdraw the desired funds
 
     for (const i of Array(bracketIndexAtCurrentPrice).keys()) {
       const deposit = {
-        amount: investmentQuoteToken.div(new BN(bracketIndexAtCurrentPrice)).toString(),
+        amount: depositQuoteToken.div(new BN(bracketIndexAtCurrentPrice)).toString(),
         tokenAddress: quoteTokenAddress,
         bracketAddress: bracketAddresses[i],
       }
@@ -469,7 +469,7 @@ withdrawal of or to withdraw the desired funds
     }
     for (const i of Array(fleetSize - bracketIndexAtCurrentPrice).keys()) {
       const deposit = {
-        amount: investmentBaseToken.div(new BN(fleetSize - bracketIndexAtCurrentPrice)).toString(),
+        amount: depositBaseToken.div(new BN(fleetSize - bracketIndexAtCurrentPrice)).toString(),
         tokenAddress: baseTokenAddress,
         bracketAddress: bracketAddresses[bracketIndexAtCurrentPrice + i],
       }

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -256,11 +256,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
         const lowerLimit = lowestLimit * Math.pow(stepSizeAsMultiplier, bracketIndex)
         const upperLimit = lowerLimit * stepSizeAsMultiplier
 
-        const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(
-          upperLimit,
-          baseToken.decimals,
-          quoteToken.decimals
-        )
+        const [upperSellAmount, upperBuyAmount] = getUnlimitedOrderAmounts(upperLimit, baseToken.decimals, quoteToken.decimals)
         // While the first bracket-order sells baseToken for quoteToken, the second buys baseToken for quoteToken at a lower price.
         // Hence the buyAmounts and sellAmounts are switched in the next line.
         const [lowerSellAmount, lowerBuyAmount] = getUnlimitedOrderAmounts(

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -535,14 +535,7 @@ contract("GnosisSafe", function (accounts) {
 
       await exchange.addToken(testToken.address, { from: accounts[0] })
 
-      const transaction = await buildOrders(
-        masterSafe.address,
-        bracketSafes,
-        baseToken,
-        quoteToken,
-        lowestLimit,
-        highestLimit
-      )
+      const transaction = await buildOrders(masterSafe.address, bracketSafes, baseToken, quoteToken, lowestLimit, highestLimit)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)
 
       await checkPricesOfBracketStrategy(lowestLimit, highestLimit, bracketSafes, exchange)
@@ -564,14 +557,7 @@ contract("GnosisSafe", function (accounts) {
       await prepareTokenRegistration(accounts[0], exchange)
       await exchange.addToken(testToken.address, { from: accounts[0] })
 
-      const transaction = await buildOrders(
-        masterSafe.address,
-        bracketSafes,
-        baseToken,
-        quoteToken,
-        lowestLimit,
-        highestLimit
-      )
+      const transaction = await buildOrders(masterSafe.address, bracketSafes, baseToken, quoteToken, lowestLimit, highestLimit)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)
 
       await checkPricesOfBracketStrategy(lowestLimit, highestLimit, bracketSafes, exchange)
@@ -598,14 +584,7 @@ contract("GnosisSafe", function (accounts) {
       await prepareTokenRegistration(accounts[0], exchange)
       await exchange.addToken(testToken2.address, { from: accounts[0] })
       await exchange.tokenIdToAddressMap.call(2)
-      const transaction = await buildOrders(
-        masterSafe.address,
-        bracketSafes,
-        baseToken,
-        quoteToken,
-        lowestLimit,
-        highestLimit
-      )
+      const transaction = await buildOrders(masterSafe.address, bracketSafes, baseToken, quoteToken, lowestLimit, highestLimit)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)
 
       await checkPricesOfBracketStrategy(lowestLimit, highestLimit, bracketSafes, exchange)
@@ -621,14 +600,7 @@ contract("GnosisSafe", function (accounts) {
       await prepareTokenRegistration(accounts[0], exchange)
       await exchange.addToken(testToken.address, { from: accounts[0] })
 
-      const transaction = await buildOrders(
-        masterSafe.address,
-        bracketSafes,
-        baseToken,
-        quoteToken,
-        lowestLimit,
-        highestLimit
-      )
+      const transaction = await buildOrders(masterSafe.address, bracketSafes, baseToken, quoteToken, lowestLimit, highestLimit)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)
 
       await checkPricesOfBracketStrategy(lowestLimit, highestLimit, bracketSafes, exchange)
@@ -643,14 +615,7 @@ contract("GnosisSafe", function (accounts) {
       await prepareTokenRegistration(accounts[0], exchange)
       await exchange.addToken(testToken.address, { from: accounts[0] })
 
-      const transaction = await buildOrders(
-        masterSafe.address,
-        bracketSafes,
-        baseToken,
-        quoteToken,
-        lowestLimit,
-        highestLimit
-      )
+      const transaction = await buildOrders(masterSafe.address, bracketSafes, baseToken, quoteToken, lowestLimit, highestLimit)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)
 
       await checkPricesOfBracketStrategy(lowestLimit, highestLimit, bracketSafes, exchange)

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -195,16 +195,16 @@ contract("GnosisSafe", function (accounts) {
         lowestLimit,
         highestLimit,
         currentPrice,
-        amountStableToken,
+        amountQuoteToken,
         amountbaseToken,
-        stableTokenInfo,
+        quoteTokenInfo,
         baseTokenInfo,
       } = tradeInfo
-      const { decimals: stableTokenDecimals, symbol: stableTokenSymbol } = stableTokenInfo
+      const { decimals: quoteTokenDecimals, symbol: quoteTokenSymbol } = quoteTokenInfo
       const { decimals: baseTokenDecimals, symbol: baseTokenSymbol } = baseTokenInfo
-      const { bracketsWithStableTokenDeposit, bracketsWithbaseTokenDeposit } = expectedDistribution
+      const { bracketsWithQuoteTokenDeposit, bracketsWithbaseTokenDeposit } = expectedDistribution
       assert.equal(
-        bracketsWithStableTokenDeposit + bracketsWithbaseTokenDeposit,
+        bracketsWithQuoteTokenDeposit + bracketsWithbaseTokenDeposit,
         fleetSize,
         "Malformed test case, sum of expected distribution should be equal to the fleet size"
       )
@@ -212,15 +212,15 @@ contract("GnosisSafe", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, fleetSize)
 
-      //Create  stableToken and add it to the exchange
-      const { id: stableTokenId, token: stableToken } = await addCustomMintableTokenToExchange(
+      //Create  quoteToken and add it to the exchange
+      const { id: quoteTokenId, token: quoteToken } = await addCustomMintableTokenToExchange(
         exchange,
-        stableTokenSymbol,
-        stableTokenDecimals,
+        quoteTokenSymbol,
+        quoteTokenDecimals,
         accounts[0]
       )
-      const depositAmountStableToken = toErc20Units(amountStableToken, stableTokenDecimals)
-      await stableToken.mint(masterSafe.address, depositAmountStableToken, { from: accounts[0] })
+      const depositAmountQuoteToken = toErc20Units(amountQuoteToken, quoteTokenDecimals)
+      await quoteToken.mint(masterSafe.address, depositAmountQuoteToken, { from: accounts[0] })
 
       //Create  baseToken and add it to the exchange
       const { id: baseTokenId, token: baseToken } = await addCustomMintableTokenToExchange(
@@ -237,7 +237,7 @@ contract("GnosisSafe", function (accounts) {
         masterSafe.address,
         bracketAddresses,
         baseTokenId,
-        stableTokenId,
+        quoteTokenId,
         lowestLimit,
         highestLimit
       )
@@ -248,11 +248,11 @@ contract("GnosisSafe", function (accounts) {
         masterSafe.address,
         bracketAddresses,
         baseToken.address,
-        stableToken.address,
+        quoteToken.address,
         lowestLimit,
         highestLimit,
         currentPrice,
-        depositAmountStableToken,
+        depositAmountQuoteToken,
         depositAmountbaseToken
       )
       await execTransaction(masterSafe, safeOwner.privateKey, batchTransaction)
@@ -264,9 +264,9 @@ contract("GnosisSafe", function (accounts) {
           currentPrice,
           bracketAddress,
           exchange,
-          stableToken,
+          quoteToken,
           baseToken,
-          bracketsWithStableTokenDeposit == 0 ? 0 : depositAmountStableToken.div(new BN(bracketsWithStableTokenDeposit)),
+          bracketsWithQuoteTokenDeposit == 0 ? 0 : depositAmountQuoteToken.div(new BN(bracketsWithQuoteTokenDeposit)),
           bracketsWithbaseTokenDeposit == 0 ? 0 : depositAmountbaseToken.div(new BN(bracketsWithbaseTokenDeposit))
         )
       }
@@ -277,13 +277,13 @@ contract("GnosisSafe", function (accounts) {
         lowestLimit: 100,
         highestLimit: 121,
         currentPrice: 110,
-        amountStableToken: "0.000000000000001",
+        amountQuoteToken: "0.000000000000001",
         amountbaseToken: "0.000000000000002",
-        stableTokenInfo: { decimals: 18, symbol: "DAI" },
+        quoteTokenInfo: { decimals: 18, symbol: "DAI" },
         baseTokenInfo: { decimals: 18, symbol: "WETH" },
       }
       const expectedDistribution = {
-        bracketsWithStableTokenDeposit: 2,
+        bracketsWithQuoteTokenDeposit: 2,
         bracketsWithbaseTokenDeposit: 2,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
@@ -294,13 +294,13 @@ contract("GnosisSafe", function (accounts) {
         lowestLimit: 25,
         highestLimit: 400,
         currentPrice: 100,
-        amountStableToken: "1",
+        amountQuoteToken: "1",
         amountbaseToken: "2",
-        stableTokenInfo: { decimals: 18, symbol: "DAI" },
+        quoteTokenInfo: { decimals: 18, symbol: "DAI" },
         baseTokenInfo: { decimals: 18, symbol: "WETH" },
       }
       const expectedDistribution = {
-        bracketsWithStableTokenDeposit: 2,
+        bracketsWithQuoteTokenDeposit: 2,
         bracketsWithbaseTokenDeposit: 2,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
@@ -311,13 +311,13 @@ contract("GnosisSafe", function (accounts) {
         lowestLimit: 0.09,
         highestLimit: 0.12,
         currentPrice: 0.105,
-        amountStableToken: "0.000000000000001",
+        amountQuoteToken: "0.000000000000001",
         amountbaseToken: "0.000000000000002",
-        stableTokenInfo: { decimals: 18, symbol: "WETH" },
+        quoteTokenInfo: { decimals: 18, symbol: "WETH" },
         baseTokenInfo: { decimals: 18, symbol: "DAI" },
       }
       const expectedDistribution = {
-        bracketsWithStableTokenDeposit: 2,
+        bracketsWithQuoteTokenDeposit: 2,
         bracketsWithbaseTokenDeposit: 2,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
@@ -328,13 +328,13 @@ contract("GnosisSafe", function (accounts) {
         lowestLimit: 0.8,
         highestLimit: 1.2,
         currentPrice: 0.9,
-        amountStableToken: "0.000000000000001",
+        amountQuoteToken: "0.000000000000001",
         amountbaseToken: "0.000000000000002",
-        stableTokenInfo: { decimals: 18, symbol: "DAI" },
+        quoteTokenInfo: { decimals: 18, symbol: "DAI" },
         baseTokenInfo: { decimals: 18, symbol: "sUSD" },
       }
       const expectedDistribution = {
-        bracketsWithStableTokenDeposit: 1,
+        bracketsWithQuoteTokenDeposit: 1,
         bracketsWithbaseTokenDeposit: 3,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
@@ -345,13 +345,13 @@ contract("GnosisSafe", function (accounts) {
         lowestLimit: 0.8,
         highestLimit: 1.2,
         currentPrice: 0.7,
-        amountStableToken: "0.000000000000001",
+        amountQuoteToken: "0.000000000000001",
         amountbaseToken: "0.000000000000002",
-        stableTokenInfo: { decimals: 18, symbol: "DAI" },
+        quoteTokenInfo: { decimals: 18, symbol: "DAI" },
         baseTokenInfo: { decimals: 18, symbol: "sUSD" },
       }
       const expectedDistribution = {
-        bracketsWithStableTokenDeposit: 0,
+        bracketsWithQuoteTokenDeposit: 0,
         bracketsWithbaseTokenDeposit: 4,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
@@ -359,27 +359,27 @@ contract("GnosisSafe", function (accounts) {
     describe("can use automatic deposits to transfer tokens with arbitrary amount of decimals", () => {
       const tokenSetups = [
         {
-          amountStableToken: "10000",
+          amountQuoteToken: "10000",
           amountbaseToken: "100",
-          stableTokenInfo: { decimals: 6, symbol: "USDC" },
+          quoteTokenInfo: { decimals: 6, symbol: "USDC" },
           baseTokenInfo: { decimals: 18, symbol: "WETH" },
         },
         {
-          amountStableToken: "100",
+          amountQuoteToken: "100",
           amountbaseToken: "10000",
-          stableTokenInfo: { decimals: 18, symbol: "WETH" },
+          quoteTokenInfo: { decimals: 18, symbol: "WETH" },
           baseTokenInfo: { decimals: 6, symbol: "USDC" },
         },
         {
-          amountStableToken: "3333",
+          amountQuoteToken: "3333",
           amountbaseToken: "100.000001",
-          stableTokenInfo: { decimals: 0, symbol: "nodecimals" },
+          quoteTokenInfo: { decimals: 0, symbol: "nodecimals" },
           baseTokenInfo: { decimals: 6, symbol: "USDC" },
         },
         {
-          amountStableToken: "0.00000000000000000000001",
+          amountQuoteToken: "0.00000000000000000000001",
           amountbaseToken: "3.14159265",
-          stableTokenInfo: { decimals: 40, symbol: "manydecimals" }, // above 38 decimals one token unit does not fit a uint128
+          quoteTokenInfo: { decimals: 40, symbol: "manydecimals" }, // above 38 decimals one token unit does not fit a uint128
           baseTokenInfo: { decimals: 8, symbol: "WBTC" },
         },
       ]
@@ -391,7 +391,7 @@ contract("GnosisSafe", function (accounts) {
           currentPrice: 110,
         }
         const expectedDistribution = {
-          bracketsWithStableTokenDeposit: 2,
+          bracketsWithQuoteTokenDeposit: 2,
           bracketsWithbaseTokenDeposit: 2,
         }
         for (const tokenSetup of tokenSetups) {
@@ -407,7 +407,7 @@ contract("GnosisSafe", function (accounts) {
           currentPrice: 100,
         }
         const expectedDistribution = {
-          bracketsWithStableTokenDeposit: 2,
+          bracketsWithQuoteTokenDeposit: 2,
           bracketsWithbaseTokenDeposit: 2,
         }
         for (const tokenSetup of tokenSetups) {
@@ -423,7 +423,7 @@ contract("GnosisSafe", function (accounts) {
           currentPrice: 110,
         }
         const expectedDistribution = {
-          bracketsWithStableTokenDeposit: 3,
+          bracketsWithQuoteTokenDeposit: 3,
           bracketsWithbaseTokenDeposit: 5,
         }
         for (const tokenSetup of tokenSetups) {
@@ -431,7 +431,7 @@ contract("GnosisSafe", function (accounts) {
           await testAutomaticDeposits(tradeInfo, expectedDistribution)
         }
       })
-      it("when p is outside the brackets and only stable token is deposited", async () => {
+      it("when p is outside the brackets and only quote token is deposited", async () => {
         const tradeInfoWithoutTokens = {
           fleetSize: 4,
           lowestLimit: 100,
@@ -439,7 +439,7 @@ contract("GnosisSafe", function (accounts) {
           currentPrice: 150,
         }
         const expectedDistribution = {
-          bracketsWithStableTokenDeposit: 4,
+          bracketsWithQuoteTokenDeposit: 4,
           bracketsWithbaseTokenDeposit: 0,
         }
         for (const tokenSetup of tokenSetups) {
@@ -455,7 +455,7 @@ contract("GnosisSafe", function (accounts) {
           currentPrice: 80,
         }
         const expectedDistribution = {
-          bracketsWithStableTokenDeposit: 0,
+          bracketsWithQuoteTokenDeposit: 0,
           bracketsWithbaseTokenDeposit: 4,
         }
         for (const tokenSetup of tokenSetups) {
@@ -469,13 +469,13 @@ contract("GnosisSafe", function (accounts) {
           lowestLimit: 5e194,
           highestLimit: 20e194,
           currentPrice: 10e194,
-          amountStableToken: "10",
+          amountQuoteToken: "10",
           amountbaseToken: fromErc20Units(new BN("5000000"), 200),
-          stableTokenInfo: { decimals: 3, symbol: "fewdecimals" },
+          quoteTokenInfo: { decimals: 3, symbol: "fewdecimals" },
           baseTokenInfo: { decimals: 200, symbol: "manydecimals" },
         }
         const expectedDistribution = {
-          bracketsWithStableTokenDeposit: 2,
+          bracketsWithQuoteTokenDeposit: 2,
           bracketsWithbaseTokenDeposit: 2,
         }
         await testAutomaticDeposits(tradeInfo, expectedDistribution)
@@ -488,7 +488,7 @@ contract("GnosisSafe", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 6)
       const baseToken = 0 // ETH
-      const stableToken = 1 // DAI
+      const quoteToken = 1 // DAI
       const lowestLimit = 90
       const highestLimit = 120
       await prepareTokenRegistration(accounts[0], exchange)
@@ -500,7 +500,7 @@ contract("GnosisSafe", function (accounts) {
         masterSafe.address,
         bracketAddresses,
         baseToken,
-        stableToken,
+        quoteToken,
         lowestLimit,
         highestLimit
       )
@@ -528,7 +528,7 @@ contract("GnosisSafe", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       const baseToken = 0 // ETH
-      const stableToken = 1 // DAI
+      const quoteToken = 1 // DAI
       const lowestLimit = 0.09
       const highestLimit = 0.12
       await prepareTokenRegistration(accounts[0], exchange)
@@ -539,7 +539,7 @@ contract("GnosisSafe", function (accounts) {
         masterSafe.address,
         bracketSafes,
         baseToken,
-        stableToken,
+        quoteToken,
         lowestLimit,
         highestLimit
       )
@@ -558,7 +558,7 @@ contract("GnosisSafe", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       const baseToken = 0 // ETH
-      const stableToken = 1 // DAI
+      const quoteToken = 1 // DAI
       const lowestLimit = 80
       const highestLimit = 110
       await prepareTokenRegistration(accounts[0], exchange)
@@ -568,7 +568,7 @@ contract("GnosisSafe", function (accounts) {
         masterSafe.address,
         bracketSafes,
         baseToken,
-        stableToken,
+        quoteToken,
         lowestLimit,
         highestLimit
       )
@@ -590,7 +590,7 @@ contract("GnosisSafe", function (accounts) {
       testToken = await TestToken.new("TEST6", 6)
       const testToken2 = await TestToken.new("TEST4", 4)
       const baseToken = 2 // "TEST4"
-      const stableToken = 1 // "TEST6"
+      const quoteToken = 1 // "TEST6"
       const lowestLimit = 0.8
       const highestLimit = 1.1
       await prepareTokenRegistration(accounts[0], exchange)
@@ -602,7 +602,7 @@ contract("GnosisSafe", function (accounts) {
         masterSafe.address,
         bracketSafes,
         baseToken,
-        stableToken,
+        quoteToken,
         lowestLimit,
         highestLimit
       )
@@ -615,7 +615,7 @@ contract("GnosisSafe", function (accounts) {
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       testToken = await TestToken.new("TEST6", 6)
       const baseToken = 0 // ETH
-      const stableToken = 1 // "TEST6"
+      const quoteToken = 1 // "TEST6"
       const lowestLimit = 80
       const highestLimit = 110
       await prepareTokenRegistration(accounts[0], exchange)
@@ -625,7 +625,7 @@ contract("GnosisSafe", function (accounts) {
         masterSafe.address,
         bracketSafes,
         baseToken,
-        stableToken,
+        quoteToken,
         lowestLimit,
         highestLimit
       )
@@ -637,7 +637,7 @@ contract("GnosisSafe", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       const baseToken = 0 // ETH
-      const stableToken = 1 // DAI
+      const quoteToken = 1 // DAI
       const lowestLimit = 0.8
       const highestLimit = 1.1
       await prepareTokenRegistration(accounts[0], exchange)
@@ -647,7 +647,7 @@ contract("GnosisSafe", function (accounts) {
         masterSafe.address,
         bracketSafes,
         baseToken,
-        stableToken,
+        quoteToken,
         lowestLimit,
         highestLimit
       )
@@ -659,14 +659,14 @@ contract("GnosisSafe", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       const baseToken = 0 // ETH
-      const stableToken = 1 // DAI
+      const quoteToken = 1 // DAI
       const lowestLimit = 120
       const highestLimit = 90
       await prepareTokenRegistration(accounts[0], exchange)
       await exchange.addToken(testToken.address, { from: accounts[0] })
 
       await assertNodejs.rejects(
-        buildOrders(masterSafe.address, bracketSafes, baseToken, stableToken, lowestLimit, highestLimit),
+        buildOrders(masterSafe.address, bracketSafes, baseToken, quoteToken, lowestLimit, highestLimit),
         {
           name: "AssertionError [ERR_ASSERTION]",
           message: "Lowest limit must be lower than highest limit",

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -196,15 +196,15 @@ contract("GnosisSafe", function (accounts) {
         highestLimit,
         currentPrice,
         amountStableToken,
-        amountTargetToken,
+        amountbaseToken,
         stableTokenInfo,
-        targetTokenInfo,
+        baseTokenInfo,
       } = tradeInfo
       const { decimals: stableTokenDecimals, symbol: stableTokenSymbol } = stableTokenInfo
-      const { decimals: targetTokenDecimals, symbol: targetTokenSymbol } = targetTokenInfo
-      const { bracketsWithStableTokenDeposit, bracketsWithTargetTokenDeposit } = expectedDistribution
+      const { decimals: baseTokenDecimals, symbol: baseTokenSymbol } = baseTokenInfo
+      const { bracketsWithStableTokenDeposit, bracketsWithbaseTokenDeposit } = expectedDistribution
       assert.equal(
-        bracketsWithStableTokenDeposit + bracketsWithTargetTokenDeposit,
+        bracketsWithStableTokenDeposit + bracketsWithbaseTokenDeposit,
         fleetSize,
         "Malformed test case, sum of expected distribution should be equal to the fleet size"
       )
@@ -222,21 +222,21 @@ contract("GnosisSafe", function (accounts) {
       const depositAmountStableToken = toErc20Units(amountStableToken, stableTokenDecimals)
       await stableToken.mint(masterSafe.address, depositAmountStableToken, { from: accounts[0] })
 
-      //Create  targetToken and add it to the exchange
-      const { id: targetTokenId, token: targetToken } = await addCustomMintableTokenToExchange(
+      //Create  baseToken and add it to the exchange
+      const { id: baseTokenId, token: baseToken } = await addCustomMintableTokenToExchange(
         exchange,
-        targetTokenSymbol,
-        targetTokenDecimals,
+        baseTokenSymbol,
+        baseTokenDecimals,
         accounts[0]
       )
-      const depositAmountTargetToken = toErc20Units(amountTargetToken, targetTokenDecimals)
-      await targetToken.mint(masterSafe.address, depositAmountTargetToken, { from: accounts[0] })
+      const depositAmountbaseToken = toErc20Units(amountbaseToken, baseTokenDecimals)
+      await baseToken.mint(masterSafe.address, depositAmountbaseToken, { from: accounts[0] })
 
       // Build orders
       const orderTransaction = await buildOrders(
         masterSafe.address,
         bracketAddresses,
-        targetTokenId,
+        baseTokenId,
         stableTokenId,
         lowestLimit,
         highestLimit
@@ -247,13 +247,13 @@ contract("GnosisSafe", function (accounts) {
       const batchTransaction = await buildTransferApproveDepositFromOrders(
         masterSafe.address,
         bracketAddresses,
-        targetToken.address,
+        baseToken.address,
         stableToken.address,
         lowestLimit,
         highestLimit,
         currentPrice,
         depositAmountStableToken,
-        depositAmountTargetToken
+        depositAmountbaseToken
       )
       await execTransaction(masterSafe, safeOwner.privateKey, batchTransaction)
       // Close auction for deposits to be reflected in exchange balance
@@ -265,9 +265,9 @@ contract("GnosisSafe", function (accounts) {
           bracketAddress,
           exchange,
           stableToken,
-          targetToken,
+          baseToken,
           bracketsWithStableTokenDeposit == 0 ? 0 : depositAmountStableToken.div(new BN(bracketsWithStableTokenDeposit)),
-          bracketsWithTargetTokenDeposit == 0 ? 0 : depositAmountTargetToken.div(new BN(bracketsWithTargetTokenDeposit))
+          bracketsWithbaseTokenDeposit == 0 ? 0 : depositAmountbaseToken.div(new BN(bracketsWithbaseTokenDeposit))
         )
       }
     }
@@ -278,13 +278,13 @@ contract("GnosisSafe", function (accounts) {
         highestLimit: 121,
         currentPrice: 110,
         amountStableToken: "0.000000000000001",
-        amountTargetToken: "0.000000000000002",
+        amountbaseToken: "0.000000000000002",
         stableTokenInfo: { decimals: 18, symbol: "DAI" },
-        targetTokenInfo: { decimals: 18, symbol: "WETH" },
+        baseTokenInfo: { decimals: 18, symbol: "WETH" },
       }
       const expectedDistribution = {
         bracketsWithStableTokenDeposit: 2,
-        bracketsWithTargetTokenDeposit: 2,
+        bracketsWithbaseTokenDeposit: 2,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
     })
@@ -295,13 +295,13 @@ contract("GnosisSafe", function (accounts) {
         highestLimit: 400,
         currentPrice: 100,
         amountStableToken: "1",
-        amountTargetToken: "2",
+        amountbaseToken: "2",
         stableTokenInfo: { decimals: 18, symbol: "DAI" },
-        targetTokenInfo: { decimals: 18, symbol: "WETH" },
+        baseTokenInfo: { decimals: 18, symbol: "WETH" },
       }
       const expectedDistribution = {
         bracketsWithStableTokenDeposit: 2,
-        bracketsWithTargetTokenDeposit: 2,
+        bracketsWithbaseTokenDeposit: 2,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
     })
@@ -312,13 +312,13 @@ contract("GnosisSafe", function (accounts) {
         highestLimit: 0.12,
         currentPrice: 0.105,
         amountStableToken: "0.000000000000001",
-        amountTargetToken: "0.000000000000002",
+        amountbaseToken: "0.000000000000002",
         stableTokenInfo: { decimals: 18, symbol: "WETH" },
-        targetTokenInfo: { decimals: 18, symbol: "DAI" },
+        baseTokenInfo: { decimals: 18, symbol: "DAI" },
       }
       const expectedDistribution = {
         bracketsWithStableTokenDeposit: 2,
-        bracketsWithTargetTokenDeposit: 2,
+        bracketsWithbaseTokenDeposit: 2,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
     })
@@ -329,13 +329,13 @@ contract("GnosisSafe", function (accounts) {
         highestLimit: 1.2,
         currentPrice: 0.9,
         amountStableToken: "0.000000000000001",
-        amountTargetToken: "0.000000000000002",
+        amountbaseToken: "0.000000000000002",
         stableTokenInfo: { decimals: 18, symbol: "DAI" },
-        targetTokenInfo: { decimals: 18, symbol: "sUSD" },
+        baseTokenInfo: { decimals: 18, symbol: "sUSD" },
       }
       const expectedDistribution = {
         bracketsWithStableTokenDeposit: 1,
-        bracketsWithTargetTokenDeposit: 3,
+        bracketsWithbaseTokenDeposit: 3,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
     })
@@ -346,13 +346,13 @@ contract("GnosisSafe", function (accounts) {
         highestLimit: 1.2,
         currentPrice: 0.7,
         amountStableToken: "0.000000000000001",
-        amountTargetToken: "0.000000000000002",
+        amountbaseToken: "0.000000000000002",
         stableTokenInfo: { decimals: 18, symbol: "DAI" },
-        targetTokenInfo: { decimals: 18, symbol: "sUSD" },
+        baseTokenInfo: { decimals: 18, symbol: "sUSD" },
       }
       const expectedDistribution = {
         bracketsWithStableTokenDeposit: 0,
-        bracketsWithTargetTokenDeposit: 4,
+        bracketsWithbaseTokenDeposit: 4,
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
     })
@@ -360,27 +360,27 @@ contract("GnosisSafe", function (accounts) {
       const tokenSetups = [
         {
           amountStableToken: "10000",
-          amountTargetToken: "100",
+          amountbaseToken: "100",
           stableTokenInfo: { decimals: 6, symbol: "USDC" },
-          targetTokenInfo: { decimals: 18, symbol: "WETH" },
+          baseTokenInfo: { decimals: 18, symbol: "WETH" },
         },
         {
           amountStableToken: "100",
-          amountTargetToken: "10000",
+          amountbaseToken: "10000",
           stableTokenInfo: { decimals: 18, symbol: "WETH" },
-          targetTokenInfo: { decimals: 6, symbol: "USDC" },
+          baseTokenInfo: { decimals: 6, symbol: "USDC" },
         },
         {
           amountStableToken: "3333",
-          amountTargetToken: "100.000001",
+          amountbaseToken: "100.000001",
           stableTokenInfo: { decimals: 0, symbol: "nodecimals" },
-          targetTokenInfo: { decimals: 6, symbol: "USDC" },
+          baseTokenInfo: { decimals: 6, symbol: "USDC" },
         },
         {
           amountStableToken: "0.00000000000000000000001",
-          amountTargetToken: "3.14159265",
+          amountbaseToken: "3.14159265",
           stableTokenInfo: { decimals: 40, symbol: "manydecimals" }, // above 38 decimals one token unit does not fit a uint128
-          targetTokenInfo: { decimals: 8, symbol: "WBTC" },
+          baseTokenInfo: { decimals: 8, symbol: "WBTC" },
         },
       ]
       it("when p is in the middle of the brackets", async () => {
@@ -392,7 +392,7 @@ contract("GnosisSafe", function (accounts) {
         }
         const expectedDistribution = {
           bracketsWithStableTokenDeposit: 2,
-          bracketsWithTargetTokenDeposit: 2,
+          bracketsWithbaseTokenDeposit: 2,
         }
         for (const tokenSetup of tokenSetups) {
           const tradeInfo = { ...JSON.parse(JSON.stringify(tradeInfoWithoutTokens)), ...JSON.parse(JSON.stringify(tokenSetup)) }
@@ -408,7 +408,7 @@ contract("GnosisSafe", function (accounts) {
         }
         const expectedDistribution = {
           bracketsWithStableTokenDeposit: 2,
-          bracketsWithTargetTokenDeposit: 2,
+          bracketsWithbaseTokenDeposit: 2,
         }
         for (const tokenSetup of tokenSetups) {
           const tradeInfo = { ...JSON.parse(JSON.stringify(tradeInfoWithoutTokens)), ...JSON.parse(JSON.stringify(tokenSetup)) }
@@ -424,7 +424,7 @@ contract("GnosisSafe", function (accounts) {
         }
         const expectedDistribution = {
           bracketsWithStableTokenDeposit: 3,
-          bracketsWithTargetTokenDeposit: 5,
+          bracketsWithbaseTokenDeposit: 5,
         }
         for (const tokenSetup of tokenSetups) {
           const tradeInfo = { ...JSON.parse(JSON.stringify(tradeInfoWithoutTokens)), ...JSON.parse(JSON.stringify(tokenSetup)) }
@@ -440,14 +440,14 @@ contract("GnosisSafe", function (accounts) {
         }
         const expectedDistribution = {
           bracketsWithStableTokenDeposit: 4,
-          bracketsWithTargetTokenDeposit: 0,
+          bracketsWithbaseTokenDeposit: 0,
         }
         for (const tokenSetup of tokenSetups) {
           const tradeInfo = { ...JSON.parse(JSON.stringify(tradeInfoWithoutTokens)), ...JSON.parse(JSON.stringify(tokenSetup)) }
           await testAutomaticDeposits(tradeInfo, expectedDistribution)
         }
       })
-      it("when p is outside the brackets and only target token is deposited", async () => {
+      it("when p is outside the brackets and only base token is deposited", async () => {
         const tradeInfoWithoutTokens = {
           fleetSize: 4,
           lowestLimit: 100,
@@ -456,7 +456,7 @@ contract("GnosisSafe", function (accounts) {
         }
         const expectedDistribution = {
           bracketsWithStableTokenDeposit: 0,
-          bracketsWithTargetTokenDeposit: 4,
+          bracketsWithbaseTokenDeposit: 4,
         }
         for (const tokenSetup of tokenSetups) {
           const tradeInfo = { ...JSON.parse(JSON.stringify(tradeInfoWithoutTokens)), ...JSON.parse(JSON.stringify(tokenSetup)) }
@@ -470,13 +470,13 @@ contract("GnosisSafe", function (accounts) {
           highestLimit: 20e194,
           currentPrice: 10e194,
           amountStableToken: "10",
-          amountTargetToken: fromErc20Units(new BN("5000000"), 200),
+          amountbaseToken: fromErc20Units(new BN("5000000"), 200),
           stableTokenInfo: { decimals: 3, symbol: "fewdecimals" },
-          targetTokenInfo: { decimals: 200, symbol: "manydecimals" },
+          baseTokenInfo: { decimals: 200, symbol: "manydecimals" },
         }
         const expectedDistribution = {
           bracketsWithStableTokenDeposit: 2,
-          bracketsWithTargetTokenDeposit: 2,
+          bracketsWithbaseTokenDeposit: 2,
         }
         await testAutomaticDeposits(tradeInfo, expectedDistribution)
       })
@@ -487,7 +487,7 @@ contract("GnosisSafe", function (accounts) {
     it("Places bracket orders on behalf of a fleet of safes and checks for profitability and validity", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 6)
-      const targetToken = 0 // ETH
+      const baseToken = 0 // ETH
       const stableToken = 1 // DAI
       const lowestLimit = 90
       const highestLimit = 120
@@ -499,7 +499,7 @@ contract("GnosisSafe", function (accounts) {
       const transaction = await buildOrders(
         masterSafe.address,
         bracketAddresses,
-        targetToken,
+        baseToken,
         stableToken,
         lowestLimit,
         highestLimit
@@ -527,7 +527,7 @@ contract("GnosisSafe", function (accounts) {
     it("Places bracket orders on behalf of a fleet of safes and checks price for p< 1", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
-      const targetToken = 0 // ETH
+      const baseToken = 0 // ETH
       const stableToken = 1 // DAI
       const lowestLimit = 0.09
       const highestLimit = 0.12
@@ -538,7 +538,7 @@ contract("GnosisSafe", function (accounts) {
       const transaction = await buildOrders(
         masterSafe.address,
         bracketSafes,
-        targetToken,
+        baseToken,
         stableToken,
         lowestLimit,
         highestLimit
@@ -557,7 +557,7 @@ contract("GnosisSafe", function (accounts) {
     it("Places bracket orders on behalf of a fleet of safes and checks prices for p>1", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
-      const targetToken = 0 // ETH
+      const baseToken = 0 // ETH
       const stableToken = 1 // DAI
       const lowestLimit = 80
       const highestLimit = 110
@@ -567,7 +567,7 @@ contract("GnosisSafe", function (accounts) {
       const transaction = await buildOrders(
         masterSafe.address,
         bracketSafes,
-        targetToken,
+        baseToken,
         stableToken,
         lowestLimit,
         highestLimit
@@ -589,7 +589,7 @@ contract("GnosisSafe", function (accounts) {
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       testToken = await TestToken.new("TEST6", 6)
       const testToken2 = await TestToken.new("TEST4", 4)
-      const targetToken = 2 // "TEST4"
+      const baseToken = 2 // "TEST4"
       const stableToken = 1 // "TEST6"
       const lowestLimit = 0.8
       const highestLimit = 1.1
@@ -601,7 +601,7 @@ contract("GnosisSafe", function (accounts) {
       const transaction = await buildOrders(
         masterSafe.address,
         bracketSafes,
-        targetToken,
+        baseToken,
         stableToken,
         lowestLimit,
         highestLimit
@@ -614,7 +614,7 @@ contract("GnosisSafe", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
       testToken = await TestToken.new("TEST6", 6)
-      const targetToken = 0 // ETH
+      const baseToken = 0 // ETH
       const stableToken = 1 // "TEST6"
       const lowestLimit = 80
       const highestLimit = 110
@@ -624,7 +624,7 @@ contract("GnosisSafe", function (accounts) {
       const transaction = await buildOrders(
         masterSafe.address,
         bracketSafes,
-        targetToken,
+        baseToken,
         stableToken,
         lowestLimit,
         highestLimit
@@ -636,7 +636,7 @@ contract("GnosisSafe", function (accounts) {
     it("Places bracket orders on behalf of a fleet of safes and checks prices for p>1 && p<1", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
-      const targetToken = 0 // ETH
+      const baseToken = 0 // ETH
       const stableToken = 1 // DAI
       const lowestLimit = 0.8
       const highestLimit = 1.1
@@ -646,7 +646,7 @@ contract("GnosisSafe", function (accounts) {
       const transaction = await buildOrders(
         masterSafe.address,
         bracketSafes,
-        targetToken,
+        baseToken,
         stableToken,
         lowestLimit,
         highestLimit
@@ -658,7 +658,7 @@ contract("GnosisSafe", function (accounts) {
     it("Failing when lowest limit is higher than highest limit", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketSafes = await deployFleetOfSafes(masterSafe.address, 6)
-      const targetToken = 0 // ETH
+      const baseToken = 0 // ETH
       const stableToken = 1 // DAI
       const lowestLimit = 120
       const highestLimit = 90
@@ -666,7 +666,7 @@ contract("GnosisSafe", function (accounts) {
       await exchange.addToken(testToken.address, { from: accounts[0] })
 
       await assertNodejs.rejects(
-        buildOrders(masterSafe.address, bracketSafes, targetToken, stableToken, lowestLimit, highestLimit),
+        buildOrders(masterSafe.address, bracketSafes, baseToken, stableToken, lowestLimit, highestLimit),
         {
           name: "AssertionError [ERR_ASSERTION]",
           message: "Lowest limit must be lower than highest limit",

--- a/test/price_utils.js
+++ b/test/price_utils.js
@@ -73,63 +73,63 @@ describe("getUnlimitedOrderAmounts", () => {
     const testCases = [
       {
         price: 160,
-        stableTokenDecimals: 18,
+        quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedStableTokenAmount: max128,
+        expectedQuoteTokenAmount: max128,
         expectedbaseTokenAmount: max128.divn(160),
       },
       {
         price: 1 / 160,
-        stableTokenDecimals: 18,
+        quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedStableTokenAmount: max128.divn(160),
+        expectedQuoteTokenAmount: max128.divn(160),
         expectedbaseTokenAmount: max128,
       },
       {
         price: 1,
-        stableTokenDecimals: 18,
+        quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedStableTokenAmount: max128,
+        expectedQuoteTokenAmount: max128,
         expectedbaseTokenAmount: max128,
       },
       {
         price: 1 + Number.EPSILON,
-        stableTokenDecimals: 18,
+        quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedStableTokenAmount: max128,
+        expectedQuoteTokenAmount: max128,
         expectedbaseTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
       },
       {
         price: 1 - Number.EPSILON,
-        stableTokenDecimals: 18,
+        quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedStableTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
+        expectedQuoteTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
         expectedbaseTokenAmount: max128,
       },
       {
         price: 100,
-        stableTokenDecimals: 165,
+        quoteTokenDecimals: 165,
         baseTokenDecimals: 200,
-        expectedStableTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 - 2))),
+        expectedQuoteTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 - 2))),
         expectedbaseTokenAmount: max128,
       },
       {
         price: 100,
-        stableTokenDecimals: 200,
+        quoteTokenDecimals: 200,
         baseTokenDecimals: 165,
-        expectedStableTokenAmount: max128,
+        expectedQuoteTokenAmount: max128,
         expectedbaseTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 + 2))),
       },
     ]
     for (const {
       price,
-      stableTokenDecimals,
+      quoteTokenDecimals,
       baseTokenDecimals,
-      expectedStableTokenAmount,
+      expectedQuoteTokenAmount,
       expectedbaseTokenAmount,
     } of testCases) {
-      const [baseTokenAmount, stableTokenAmount] = getUnlimitedOrderAmounts(price, baseTokenDecimals, stableTokenDecimals)
-      assertEqualUpToFloatPrecision(stableTokenAmount, expectedStableTokenAmount)
+      const [baseTokenAmount, quoteTokenAmount] = getUnlimitedOrderAmounts(price, baseTokenDecimals, quoteTokenDecimals)
+      assertEqualUpToFloatPrecision(quoteTokenAmount, expectedQuoteTokenAmount)
       assertEqualUpToFloatPrecision(baseTokenAmount, expectedbaseTokenAmount)
     }
   })
@@ -149,8 +149,8 @@ contract("PriceOracle", function (accounts) {
       const acceptedPriceDeviationInPercentage = 99
       const price = 1000
       const baseTokenData = { symbol: "WETH" }
-      const stableTokenData = { symbol: "DAI" }
-      assert(await isPriceReasonable(baseTokenData, stableTokenData, price, acceptedPriceDeviationInPercentage))
+      const quoteTokenData = { symbol: "DAI" }
+      assert(await isPriceReasonable(baseTokenData, quoteTokenData, price, acceptedPriceDeviationInPercentage))
     })
     it("checks that bracket traders does not sell unprofitable for tokens with the same decimals", async () => {
       const WETHtokenId = (await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])).id

--- a/test/price_utils.js
+++ b/test/price_utils.js
@@ -74,63 +74,63 @@ describe("getUnlimitedOrderAmounts", () => {
       {
         price: 160,
         stableTokenDecimals: 18,
-        targetTokenDecimals: 18,
+        baseTokenDecimals: 18,
         expectedStableTokenAmount: max128,
-        expectedTargetTokenAmount: max128.divn(160),
+        expectedbaseTokenAmount: max128.divn(160),
       },
       {
         price: 1 / 160,
         stableTokenDecimals: 18,
-        targetTokenDecimals: 18,
+        baseTokenDecimals: 18,
         expectedStableTokenAmount: max128.divn(160),
-        expectedTargetTokenAmount: max128,
+        expectedbaseTokenAmount: max128,
       },
       {
         price: 1,
         stableTokenDecimals: 18,
-        targetTokenDecimals: 18,
+        baseTokenDecimals: 18,
         expectedStableTokenAmount: max128,
-        expectedTargetTokenAmount: max128,
+        expectedbaseTokenAmount: max128,
       },
       {
         price: 1 + Number.EPSILON,
         stableTokenDecimals: 18,
-        targetTokenDecimals: 18,
+        baseTokenDecimals: 18,
         expectedStableTokenAmount: max128,
-        expectedTargetTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
+        expectedbaseTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
       },
       {
         price: 1 - Number.EPSILON,
         stableTokenDecimals: 18,
-        targetTokenDecimals: 18,
+        baseTokenDecimals: 18,
         expectedStableTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
-        expectedTargetTokenAmount: max128,
+        expectedbaseTokenAmount: max128,
       },
       {
         price: 100,
         stableTokenDecimals: 165,
-        targetTokenDecimals: 200,
+        baseTokenDecimals: 200,
         expectedStableTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 - 2))),
-        expectedTargetTokenAmount: max128,
+        expectedbaseTokenAmount: max128,
       },
       {
         price: 100,
         stableTokenDecimals: 200,
-        targetTokenDecimals: 165,
+        baseTokenDecimals: 165,
         expectedStableTokenAmount: max128,
-        expectedTargetTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 + 2))),
+        expectedbaseTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 + 2))),
       },
     ]
     for (const {
       price,
       stableTokenDecimals,
-      targetTokenDecimals,
+      baseTokenDecimals,
       expectedStableTokenAmount,
-      expectedTargetTokenAmount,
+      expectedbaseTokenAmount,
     } of testCases) {
-      const [targetTokenAmount, stableTokenAmount] = getUnlimitedOrderAmounts(price, targetTokenDecimals, stableTokenDecimals)
+      const [baseTokenAmount, stableTokenAmount] = getUnlimitedOrderAmounts(price, baseTokenDecimals, stableTokenDecimals)
       assertEqualUpToFloatPrecision(stableTokenAmount, expectedStableTokenAmount)
-      assertEqualUpToFloatPrecision(targetTokenAmount, expectedTargetTokenAmount)
+      assertEqualUpToFloatPrecision(baseTokenAmount, expectedbaseTokenAmount)
     }
   })
 })
@@ -148,9 +148,9 @@ contract("PriceOracle", function (accounts) {
       //the following test especially checks that the price p is not inverted (1/p) and is not below 1
       const acceptedPriceDeviationInPercentage = 99
       const price = 1000
-      const targetTokenData = { symbol: "WETH" }
+      const baseTokenData = { symbol: "WETH" }
       const stableTokenData = { symbol: "DAI" }
-      assert(await isPriceReasonable(targetTokenData, stableTokenData, price, acceptedPriceDeviationInPercentage))
+      assert(await isPriceReasonable(baseTokenData, stableTokenData, price, acceptedPriceDeviationInPercentage))
     })
     it("checks that bracket traders does not sell unprofitable for tokens with the same decimals", async () => {
       const WETHtokenId = (await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])).id

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -341,10 +341,10 @@ contract("Verification checks", function (accounts) {
       const baseToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
       const quoteToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
 
-      const investmentQuoteToken = new BN("1000000000000000000000000")
-      const investmentBaseToken = new BN("1000000000000000000000000")
-      await quoteToken.token.mint(masterSafe.address, investmentQuoteToken, { from: accounts[0] })
-      await baseToken.token.mint(masterSafe.address, investmentBaseToken, { from: accounts[0] })
+      const depositQuoteToken = new BN("1000000000000000000000000")
+      const depositBaseToken = new BN("1000000000000000000000000")
+      await quoteToken.token.mint(masterSafe.address, depositQuoteToken, { from: accounts[0] })
+      await baseToken.token.mint(masterSafe.address, depositBaseToken, { from: accounts[0] })
       const lowestLimit = 90
       const highestLimit = 120
       const currentPrice = 100
@@ -367,8 +367,8 @@ contract("Verification checks", function (accounts) {
         lowestLimit,
         highestLimit,
         currentPrice,
-        investmentQuoteToken,
-        investmentBaseToken,
+        depositQuoteToken,
+        depositBaseToken,
         true
       )
       await execTransaction(masterSafe, safeOwner.privateKey, bundledFundingTransaction)

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -107,7 +107,7 @@ contract("Verification checks", function (accounts) {
   let exchange
   let gnosisSafeMasterCopy
   let proxyFactory
-  let targetToken
+  let baseToken
   let stableToken
   let safeOwner
   beforeEach(async function () {
@@ -122,9 +122,9 @@ contract("Verification checks", function (accounts) {
     exchange = await BatchExchange.deployed()
 
     // TODO: this is needed as fetching the orderbook on an empty orderbook throws. This can be fixed in the future
-    targetToken = (await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])).id
+    baseToken = (await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])).id
     stableToken = (await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])).id
-    await exchange.placeOrder(targetToken, stableToken, 1234124, 11241234, 11234234, { from: accounts[0] })
+    await exchange.placeOrder(baseToken, stableToken, 1234124, 11241234, 11234234, { from: accounts[0] })
   })
   describe("Owner is master safe", async () => {
     it("throws if the masterSafe is not the only owner", async () => {
@@ -262,7 +262,7 @@ contract("Verification checks", function (accounts) {
     it("throws if orders do not buy and sell the same tokens in a loop", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddress = (await deployFleetOfSafes(masterSafe.address, 1))[0]
-      const targetToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
+      const baseToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
       const stableToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
       const lowestLimit = 90
       const highestLimit = 120
@@ -272,7 +272,7 @@ contract("Verification checks", function (accounts) {
       const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(lowestLimit, 18, 18)
 
       const validFrom = (await exchange.getCurrentBatchId.call()).toNumber() + 3
-      const buyTokens = [targetToken.id, targetToken.id]
+      const buyTokens = [baseToken.id, baseToken.id]
       const sellTokens = [stableToken.id, stableToken.id]
       const validFroms = [validFrom, validFrom]
       const validTos = [maxU32, maxU32]
@@ -300,7 +300,7 @@ contract("Verification checks", function (accounts) {
     it("throws if orders of one bracket are not profitable", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddress = (await deployFleetOfSafes(masterSafe.address, 1))[0]
-      const targetToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
+      const baseToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
       const stableToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
       const lowestLimit = 90
       const highestLimit = 120
@@ -310,8 +310,8 @@ contract("Verification checks", function (accounts) {
       const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(highestLimit, 18, 18)
 
       const validFrom = (await exchange.getCurrentBatchId.call()).toNumber() + 3
-      const buyTokens = [targetToken.id, stableToken.id]
-      const sellTokens = [stableToken.id, targetToken.id]
+      const buyTokens = [baseToken.id, stableToken.id]
+      const sellTokens = [stableToken.id, baseToken.id]
       const validFroms = [validFrom, validFrom]
       const validTos = [maxU32, maxU32]
       const buyAmounts = [lowerBuyAmount.toString(), upperBuyAmount.toString()]
@@ -338,13 +338,13 @@ contract("Verification checks", function (accounts) {
     it("throws if there are profitable orders", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 3)
-      const targetToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
+      const baseToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
       const stableToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
 
       const investmentStableToken = new BN("1000000000000000000000000")
-      const investmentTargetToken = new BN("1000000000000000000000000")
+      const investmentBaseToken = new BN("1000000000000000000000000")
       await stableToken.token.mint(masterSafe.address, investmentStableToken, { from: accounts[0] })
-      await targetToken.token.mint(masterSafe.address, investmentTargetToken, { from: accounts[0] })
+      await baseToken.token.mint(masterSafe.address, investmentBaseToken, { from: accounts[0] })
       const lowestLimit = 90
       const highestLimit = 120
       const currentPrice = 100
@@ -352,7 +352,7 @@ contract("Verification checks", function (accounts) {
       const transaction = await buildOrders(
         masterSafe.address,
         bracketAddresses,
-        targetToken.id,
+        baseToken.id,
         stableToken.id,
         lowestLimit,
         highestLimit
@@ -362,13 +362,13 @@ contract("Verification checks", function (accounts) {
       const bundledFundingTransaction = await buildTransferApproveDepositFromOrders(
         masterSafe.address,
         bracketAddresses,
-        targetToken.token.address,
+        baseToken.token.address,
         stableToken.token.address,
         lowestLimit,
         highestLimit,
         currentPrice,
         investmentStableToken,
-        investmentTargetToken,
+        investmentBaseToken,
         true
       )
       await execTransaction(masterSafe, safeOwner.privateKey, bundledFundingTransaction)

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -108,7 +108,7 @@ contract("Verification checks", function (accounts) {
   let gnosisSafeMasterCopy
   let proxyFactory
   let baseToken
-  let stableToken
+  let quoteToken
   let safeOwner
   beforeEach(async function () {
     safeOwner = {
@@ -123,8 +123,8 @@ contract("Verification checks", function (accounts) {
 
     // TODO: this is needed as fetching the orderbook on an empty orderbook throws. This can be fixed in the future
     baseToken = (await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])).id
-    stableToken = (await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])).id
-    await exchange.placeOrder(baseToken, stableToken, 1234124, 11241234, 11234234, { from: accounts[0] })
+    quoteToken = (await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])).id
+    await exchange.placeOrder(baseToken, quoteToken, 1234124, 11241234, 11234234, { from: accounts[0] })
   })
   describe("Owner is master safe", async () => {
     it("throws if the masterSafe is not the only owner", async () => {
@@ -263,7 +263,7 @@ contract("Verification checks", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddress = (await deployFleetOfSafes(masterSafe.address, 1))[0]
       const baseToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
-      const stableToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
+      const quoteToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
       const lowestLimit = 90
       const highestLimit = 120
 
@@ -273,7 +273,7 @@ contract("Verification checks", function (accounts) {
 
       const validFrom = (await exchange.getCurrentBatchId.call()).toNumber() + 3
       const buyTokens = [baseToken.id, baseToken.id]
-      const sellTokens = [stableToken.id, stableToken.id]
+      const sellTokens = [quoteToken.id, quoteToken.id]
       const validFroms = [validFrom, validFrom]
       const validTos = [maxU32, maxU32]
       const buyAmounts = [lowerBuyAmount.toString(), upperBuyAmount.toString()]
@@ -301,7 +301,7 @@ contract("Verification checks", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddress = (await deployFleetOfSafes(masterSafe.address, 1))[0]
       const baseToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
-      const stableToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
+      const quoteToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
       const lowestLimit = 90
       const highestLimit = 120
 
@@ -310,8 +310,8 @@ contract("Verification checks", function (accounts) {
       const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(highestLimit, 18, 18)
 
       const validFrom = (await exchange.getCurrentBatchId.call()).toNumber() + 3
-      const buyTokens = [baseToken.id, stableToken.id]
-      const sellTokens = [stableToken.id, baseToken.id]
+      const buyTokens = [baseToken.id, quoteToken.id]
+      const sellTokens = [quoteToken.id, baseToken.id]
       const validFroms = [validFrom, validFrom]
       const validTos = [maxU32, maxU32]
       const buyAmounts = [lowerBuyAmount.toString(), upperBuyAmount.toString()]
@@ -339,11 +339,11 @@ contract("Verification checks", function (accounts) {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 3)
       const baseToken = await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])
-      const stableToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
+      const quoteToken = await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])
 
-      const investmentStableToken = new BN("1000000000000000000000000")
+      const investmentQuoteToken = new BN("1000000000000000000000000")
       const investmentBaseToken = new BN("1000000000000000000000000")
-      await stableToken.token.mint(masterSafe.address, investmentStableToken, { from: accounts[0] })
+      await quoteToken.token.mint(masterSafe.address, investmentQuoteToken, { from: accounts[0] })
       await baseToken.token.mint(masterSafe.address, investmentBaseToken, { from: accounts[0] })
       const lowestLimit = 90
       const highestLimit = 120
@@ -353,7 +353,7 @@ contract("Verification checks", function (accounts) {
         masterSafe.address,
         bracketAddresses,
         baseToken.id,
-        stableToken.id,
+        quoteToken.id,
         lowestLimit,
         highestLimit
       )
@@ -363,11 +363,11 @@ contract("Verification checks", function (accounts) {
         masterSafe.address,
         bracketAddresses,
         baseToken.token.address,
-        stableToken.token.address,
+        quoteToken.token.address,
         lowestLimit,
         highestLimit,
         currentPrice,
-        investmentStableToken,
+        investmentQuoteToken,
         investmentBaseToken,
         true
       )


### PR DESCRIPTION
As discussed in the issue, we have chosen to with more commonly used language for our previously "target" and "stable" tokens. That is, we now use the more common, "quote" and "base" currencies for which "quote" is the one whose price is specified in relation to a "base" token. See [investopedia](https://www.investopedia.com/terms/b/basecurrency.asp) for discussion on the naming convention.


Note also that the term "investment" has been replaced with "deposit" and we now specify `TokenId` instead of just `Token` in the script arguments.


Closes #231

Test Plan:

In our case, since the brackets were originally meant to be between ETH and DAI, since we are always "quoting" the price of ETH in units of DAI, please see a few relevant changes in the comments that explicitly mention ETH and DAI to confirm that the changes made are appropriate. 

Note that "target" -> "base" and "stable" -> "quote"

Also, unit tests should be passing.