### PR TITLE
[Easy] Rework unlimited order function usage

### DIFF
--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -263,10 +263,10 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
         )
         // While the first bracket-order sells targetToken for stableToken, the second buys targetToken for stableToken at a lower price.
         // Hence the buyAmounts and sellAmounts are switched in the next line.
-        const [lowerBuyAmount, lowerSellAmount] = getUnlimitedOrderAmounts(
-          lowerLimit,
-          targetToken.decimals,
-          stableToken.decimals
+        const [lowerSellAmount, lowerBuyAmount] = getUnlimitedOrderAmounts(
+          1 / lowerLimit,
+          stableToken.decimals,
+          targetToken.decimals
         )
 
         log(


### PR DESCRIPTION
Previously, we were taking advantage of some non-intuitive symmetric properties emitted by the `unlimitedOrderAmounts` function that were difficult to interpret. This PR simply uses the function directly as was intended rather than assuming any prior knowledge about the function's "special properties".

