### PR TITLE
[Easy] BN was causing error in `gasEstimation` function.

### DIFF
--- a/scripts/wrap_eth.js
+++ b/scripts/wrap_eth.js
@@ -33,7 +33,7 @@ module.exports = async (callback) => {
     const transactionData = await weth.contract.methods.deposit().encodeABI()
     const transaction = {
       to: weth.address,
-      value: amountInWei,
+      value: amountInWei.toString(),
       operation: CALL,
       data: transactionData,
     }


### PR DESCRIPTION
Closes #238

Test Plan:

```sh
export PK=0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
npx truffle exec scripts/wrap_eth.js --masterSafe 0x8990c564ec303C7b26d3d5556ef0910E58Be08Ce --amount 10 --network rinkeby --dry-run
```