### PR TITLE
Do not track *.env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ automaticallyGeneratedDeposits.json
 package-lock.json
 
 bracket-addresses.csv
+
+# Do not track local env vars (PK, MASTER_SAFE, etc...)
+*.env


### PR DESCRIPTION
Some users might want to have a local `.env` file where they keep their script parameters like `PK` and `MASTER_SAFE` etc... This would allow people to ensure their .env files are untracked.

Sample file:

```
PK=0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
MASTER_SAFE=0x8990c564ec303C7b26d3d5556ef0910E58Be08Ce

```