### PR TITLE
[Easy] Rename fleetSize -> numBrackets

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,7 +49,7 @@ Making the requests to the gnosis-interfaces does not cost any gas. However, sig
 Here is an example script invocation:
 
 ```js
-npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --depositBaseToken=0.1 --depositQuoteToken=10 --fleetSize=10 --network=$NETWORK_NAME
+npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=$MASTER_SAFE --depositBaseToken=0.1 --depositQuoteToken=10 --numBrackets=10 --network=$NETWORK_NAME
 ```
 
 The prices must be specified in terms of 1 base token = x quote tokens.
@@ -72,7 +72,7 @@ Requires that Master Safe has already been deployed.
 An example of the usage would be:
 
 ```js
-npx truffle exec scripts/deploy_safes.js --masterSafe=$MASTER_SAFE --fleetSize=20 --network=$NETWORK_NAME
+npx truffle exec scripts/deploy_safes.js --masterSafe=$MASTER_SAFE --numSafes=20 --network=$NETWORK_NAME
 ```
 
 ### Place Orders

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -23,7 +23,7 @@ const argv = default_yargs
     describe: "Address of Gnosis Safe owning every bracket",
     demandOption: true,
   })
-  .option("fleetSize", {
+  .option("numBrackets", {
     type: "int",
     default: 20,
     describe: "Number of brackets to be deployed",
@@ -98,7 +98,7 @@ module.exports = async (callback) => {
     const depositQuoteToken = toErc20Units(argv.depositQuoteToken, quoteTokenDecimals)
 
     if (argv.brackets) {
-      assert(argv.fleetSize === argv.brackets.length, "Please ensure fleetSize equals number of brackets")
+      assert(argv.numBrackets === argv.brackets.length, "Please ensure numBrackets equals number of brackets")
     }
 
     console.log("==> Performing safety checks")
@@ -121,8 +121,8 @@ module.exports = async (callback) => {
         callback("Error: Bound checks did not pass")
       }
     }
-    if (argv.fleetSize > 23) {
-      callback("Error: Choose a smaller fleetSize, otherwise your payload will be to big for Infura nodes")
+    if (argv.numBrackets > 23) {
+      callback("Error: Choose a smaller numBrackets, otherwise your payload will be to big for Infura nodes")
     }
 
     let bracketAddresses
@@ -145,8 +145,8 @@ module.exports = async (callback) => {
       }
     } else {
       assert(!argv.verify, "Trading Brackets need to be provided via --brackets when verifying a transaction")
-      console.log(`==> Deploying ${argv.fleetSize} trading brackets`)
-      bracketAddresses = await deployFleetOfSafes(masterSafe.address, argv.fleetSize)
+      console.log(`==> Deploying ${argv.numBrackets} trading brackets`)
+      bracketAddresses = await deployFleetOfSafes(masterSafe.address, argv.numBrackets)
       console.log("List of deployed brackets:", bracketAddresses.join())
       // Sleeping for 3 seconds to make sure Infura nodes have processed
       // all newly deployed contracts so they can be awaited.

--- a/scripts/deploy_safes.js
+++ b/scripts/deploy_safes.js
@@ -7,7 +7,7 @@ const argv = default_yargs
     describe: "Address of Gnosis Safe that is going to own the new fleet",
     demandOption: true,
   })
-  .option("fleetSize", {
+  .option("numSafes", {
     type: "int",
     describe: "Number of (sub)safes to be deployed",
     demandOption: true,
@@ -16,9 +16,9 @@ const argv = default_yargs
 module.exports = async (callback) => {
   try {
     console.log("Master Safe:", argv.masterSafe)
-    console.log(`Deploying a fleet of Safes of size ${argv.fleetSize}`)
+    console.log(`Deploying a fleet of Safes of size ${argv.numSafes}`)
     console.log("Using account:", (await web3.eth.getAccounts())[0])
-    const fleet = await deployFleetOfSafes(argv.masterSafe, argv.fleetSize)
+    const fleet = await deployFleetOfSafes(argv.masterSafe, argv.numSafes)
     console.log(" Addresses", fleet.join())
     callback()
   } catch (error) {

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -443,14 +443,14 @@ withdrawal of or to withdraw the desired funds
     depositBaseToken,
     storeDepositsAsFile = false
   ) {
-    const fleetSize = bracketAddresses.length
+    const numBrackets = bracketAddresses.length
     const stepSizeAsMultiplier = Math.pow(highestLimit / lowestLimit, 1 / bracketAddresses.length)
     // bracketIndexAtCurrentPrice is calculated with: lowestLimit * stepSizeAsMultiplier ^ x = currentPrice and solved for x
     // in case the currentPrice is at the limit price of two bracket-trader, only the first bracket-trader - the one with the
     // second order will be funded.
     let bracketIndexAtCurrentPrice = Math.round(Math.log(currentPrice / lowestLimit) / Math.log(stepSizeAsMultiplier))
-    if (bracketIndexAtCurrentPrice > fleetSize) {
-      bracketIndexAtCurrentPrice = fleetSize
+    if (bracketIndexAtCurrentPrice > numBrackets) {
+      bracketIndexAtCurrentPrice = numBrackets
     }
     if (bracketIndexAtCurrentPrice < 0) {
       bracketIndexAtCurrentPrice = 0
@@ -466,9 +466,9 @@ withdrawal of or to withdraw the desired funds
       }
       deposits.push(deposit)
     }
-    for (const i of Array(fleetSize - bracketIndexAtCurrentPrice).keys()) {
+    for (const i of Array(numBrackets - bracketIndexAtCurrentPrice).keys()) {
       const deposit = {
-        amount: depositBaseToken.div(new BN(fleetSize - bracketIndexAtCurrentPrice)).toString(),
+        amount: depositBaseToken.div(new BN(numBrackets - bracketIndexAtCurrentPrice)).toString(),
         tokenAddress: baseTokenAddress,
         bracketAddress: bracketAddresses[bracketIndexAtCurrentPrice + i],
       }

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -191,7 +191,7 @@ contract("GnosisSafe", function (accounts) {
     })
     const testAutomaticDeposits = async function (tradeInfo, expectedDistribution) {
       const {
-        fleetSize,
+        numBrackets,
         lowestLimit,
         highestLimit,
         currentPrice,
@@ -205,12 +205,12 @@ contract("GnosisSafe", function (accounts) {
       const { bracketsWithQuoteTokenDeposit, bracketsWithbaseTokenDeposit } = expectedDistribution
       assert.equal(
         bracketsWithQuoteTokenDeposit + bracketsWithbaseTokenDeposit,
-        fleetSize,
+        numBrackets,
         "Malformed test case, sum of expected distribution should be equal to the fleet size"
       )
 
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
-      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, fleetSize)
+      const bracketAddresses = await deployFleetOfSafes(masterSafe.address, numBrackets)
 
       //Create  quoteToken and add it to the exchange
       const { id: quoteTokenId, token: quoteToken } = await addCustomMintableTokenToExchange(
@@ -273,7 +273,7 @@ contract("GnosisSafe", function (accounts) {
     }
     it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p > 1", async () => {
       const tradeInfo = {
-        fleetSize: 4,
+        numBrackets: 4,
         lowestLimit: 100,
         highestLimit: 121,
         currentPrice: 110,
@@ -288,9 +288,9 @@ contract("GnosisSafe", function (accounts) {
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
     })
-    it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p > 1, fleetSize = 1", async () => {
+    it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p > 1, numBrackets = 1", async () => {
       const tradeInfo = {
-        fleetSize: 1,
+        numBrackets: 1,
         lowestLimit: 100,
         highestLimit: 121,
         currentPrice: 110,
@@ -305,9 +305,9 @@ contract("GnosisSafe", function (accounts) {
       }
       await testAutomaticDeposits(tradeInfo, expectedDistribution)
     })
-    it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p > 1, fleetSize = 19", async () => {
+    it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p > 1, numBrackets = 19", async () => {
       const tradeInfo = {
-        fleetSize: 19,
+        numBrackets: 19,
         lowestLimit: 100,
         highestLimit: 121,
         currentPrice: 120,
@@ -324,7 +324,7 @@ contract("GnosisSafe", function (accounts) {
     })
     it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p > 1 and wide brackets", async () => {
       const tradeInfo = {
-        fleetSize: 4,
+        numBrackets: 4,
         lowestLimit: 25,
         highestLimit: 400,
         currentPrice: 100,
@@ -341,7 +341,7 @@ contract("GnosisSafe", function (accounts) {
     })
     it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p < 1", async () => {
       const tradeInfo = {
-        fleetSize: 4,
+        numBrackets: 4,
         lowestLimit: 0.09,
         highestLimit: 0.12,
         currentPrice: 0.105,
@@ -358,7 +358,7 @@ contract("GnosisSafe", function (accounts) {
     })
     it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic, p<1 && p>1", async () => {
       const tradeInfo = {
-        fleetSize: 4,
+        numBrackets: 4,
         lowestLimit: 0.8,
         highestLimit: 1.2,
         currentPrice: 0.9,
@@ -375,7 +375,7 @@ contract("GnosisSafe", function (accounts) {
     })
     it("transfers tokens from fund account through trader accounts and into exchange via automatic deposit logic with currentPrice outside of price bounds", async () => {
       const tradeInfo = {
-        fleetSize: 4,
+        numBrackets: 4,
         lowestLimit: 0.8,
         highestLimit: 1.2,
         currentPrice: 0.7,
@@ -419,7 +419,7 @@ contract("GnosisSafe", function (accounts) {
       ]
       it("when p is in the middle of the brackets", async () => {
         const tradeInfoWithoutTokens = {
-          fleetSize: 4,
+          numBrackets: 4,
           lowestLimit: 100,
           highestLimit: 121,
           currentPrice: 110,
@@ -435,7 +435,7 @@ contract("GnosisSafe", function (accounts) {
       })
       it("when p is in the middle of the brackets and the steps are wide", async () => {
         const tradeInfoWithoutTokens = {
-          fleetSize: 4,
+          numBrackets: 4,
           lowestLimit: 25,
           highestLimit: 400,
           currentPrice: 100,
@@ -451,7 +451,7 @@ contract("GnosisSafe", function (accounts) {
       })
       it("when p is not in the middle but still inside the brackets", async () => {
         const tradeInfoWithoutTokens = {
-          fleetSize: 8,
+          numBrackets: 8,
           lowestLimit: 100,
           highestLimit: 130,
           currentPrice: 110,
@@ -467,7 +467,7 @@ contract("GnosisSafe", function (accounts) {
       })
       it("when p is outside the brackets and only quote token is deposited", async () => {
         const tradeInfoWithoutTokens = {
-          fleetSize: 4,
+          numBrackets: 4,
           lowestLimit: 100,
           highestLimit: 130,
           currentPrice: 150,
@@ -483,7 +483,7 @@ contract("GnosisSafe", function (accounts) {
       })
       it("when p is outside the brackets and only base token is deposited", async () => {
         const tradeInfoWithoutTokens = {
-          fleetSize: 4,
+          numBrackets: 4,
           lowestLimit: 100,
           highestLimit: 130,
           currentPrice: 80,
@@ -499,7 +499,7 @@ contract("GnosisSafe", function (accounts) {
       })
       it("with extreme prices and decimals", async () => {
         const tradeInfo = {
-          fleetSize: 4,
+          numBrackets: 4,
           lowestLimit: 5e194,
           highestLimit: 20e194,
           currentPrice: 10e194,
@@ -558,7 +558,7 @@ contract("GnosisSafe", function (accounts) {
         assert.equal(buyOrder.validFrom, currentBatch)
       }
     })
-    it("Places bracket orders on behalf of a fleet of safes and checks for profitability and validity, fleetSize = 1", async () => {
+    it("Places bracket orders on behalf of a fleet of safes and checks for profitability and validity, numBrackets = 1", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner.account], 1))
       const bracketAddresses = await deployFleetOfSafes(masterSafe.address, 1)
       const baseToken = 0 // ETH


### PR DESCRIPTION
This PR simply renames  `fleetSize` to `numBrackets` in all appropriate user facing locations.

Closes #253


Test Plan

```sh
npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=4 --lowestLimit=150 --highestLimit=200 --currentPrice=175 --masterSafe=0x8990c564ec303C7b26d3d5556ef0910E58Be08Ce --depositBaseToken=0.1 --depositQuoteToken=10 --numBrackets=10 --network=rinkeby --dry-run
```