### PR TITLE
Move constants to own file

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -2,9 +2,10 @@ const { fetchTokenInfoFromExchange, getExchange, getSafe, buildOrders } = requir
   web3,
   artifacts
 )
-const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils.js")(web3, artifacts)
+const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils")(web3, artifacts)
 const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { proceedAnyways, promptUser } = require("./utils/user_interface_helpers")
+const { DEFAULT_ORDER_EXPIRY } = require("./utils/constants")
 
 const { default_yargs, checkBracketsForDuplicate } = require("./utils/default_yargs")
 const argv = default_yargs
@@ -47,7 +48,7 @@ const argv = default_yargs
   .option("expiry", {
     type: "int",
     describe: "Maximum auction batch for which these orders are valid",
-    default: 2 ** 32 - 1,
+    default: DEFAULT_ORDER_EXPIRY,
   })
   .check(checkBracketsForDuplicate).argv
 

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -15,7 +15,7 @@ const { proceedAnyways } = require("./utils/user_interface_helpers")
 const { toErc20Units } = require("./utils/printing_tools")
 const { sleep } = require("./utils/js_helpers")
 const { verifyBracketsWellFormed } = require("./utils/verify_scripts")(web3, artifacts)
-const { DEFAULT_NUMBER_OF_SAFES } = require("./utils/constants")
+const { DEFAULT_NUM_SAFES } = require("./utils/constants")
 const { default_yargs, checkBracketsForDuplicate } = require("./utils/default_yargs")
 
 const argv = default_yargs
@@ -26,7 +26,7 @@ const argv = default_yargs
   })
   .option("numBrackets", {
     type: "int",
-    default: DEFAULT_NUMBER_OF_SAFES,
+    default: DEFAULT_NUM_SAFES,
     describe: "Number of brackets to be deployed",
   })
   .option("brackets", {

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -15,8 +15,9 @@ const { proceedAnyways } = require("./utils/user_interface_helpers")
 const { toErc20Units } = require("./utils/printing_tools")
 const { sleep } = require("./utils/js_helpers")
 const { verifyBracketsWellFormed } = require("./utils/verify_scripts")(web3, artifacts)
-
+const { DEFAULT_NUMBER_OF_SAFES } = require("./utils/constants")
 const { default_yargs, checkBracketsForDuplicate } = require("./utils/default_yargs")
+
 const argv = default_yargs
   .option("masterSafe", {
     type: "string",
@@ -25,7 +26,7 @@ const argv = default_yargs
   })
   .option("numBrackets", {
     type: "int",
-    default: 20,
+    default: DEFAULT_NUMBER_OF_SAFES,
     describe: "Number of brackets to be deployed",
   })
   .option("brackets", {

--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -2,7 +2,7 @@ const BN = require("bn.js")
 
 const ZERO_ADDRESS = "0x" + "0".repeat(40)
 
-// We chose the maximum admissible value minus one in order to distinguish orders from "non-expiring" orders of the web interface
+// We chose the maximum admissible value (2**32-1) minus one in order to distinguish orders from "non-expiring" orders of the web interface
 const DEFAULT_ORDER_EXPIRY = 2 ** 32 - 2
 
 const DEFAULT_NUMBER_OF_SAFES = 20

--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -1,5 +1,41 @@
+const BN = require("bn.js")
+
 const ZERO_ADDRESS = "0x" + "0".repeat(40)
+
+// We chose the maximum admissible value minus one in order to distinguish orders from "non-expiring" orders of the web interface
+const DEFAULT_ORDER_EXPIRY = 2 ** 32 - 2
+
+const DEFAULT_NUMBER_OF_SAFES = 20
+
+// numbers identifying which operation is to be executed by a Gnosis Safe when calling execTransaction
+const CALL = 0
+const DELEGATECALL = 1
+
+const ZERO = new BN(0)
+const ONE = new BN(1)
+const TWO = new BN(2)
+const TEN = new BN(10)
+const BN128 = new BN(128)
+const BN256 = new BN(256)
+
+const MAXUINT128 = TWO.pow(BN128).sub(ONE)
+const MAXUINT256 = TWO.pow(BN256).sub(ONE)
+
+const FLOAT_TOLERANCE = TWO.pow(new BN(52))
 
 module.exports = {
   ZERO_ADDRESS,
+  DEFAULT_ORDER_EXPIRY,
+  DEFAULT_NUMBER_OF_SAFES,
+  CALL,
+  DELEGATECALL,
+  ZERO,
+  ONE,
+  TWO,
+  TEN,
+  BN128,
+  BN256,
+  MAXUINT128,
+  MAXUINT256,
+  FLOAT_TOLERANCE,
 }

--- a/scripts/utils/constants.js
+++ b/scripts/utils/constants.js
@@ -5,7 +5,7 @@ const ZERO_ADDRESS = "0x" + "0".repeat(40)
 // We chose the maximum admissible value (2**32-1) minus one in order to distinguish orders from "non-expiring" orders of the web interface
 const DEFAULT_ORDER_EXPIRY = 2 ** 32 - 2
 
-const DEFAULT_NUMBER_OF_SAFES = 20
+const DEFAULT_NUM_SAFES = 20
 
 // numbers identifying which operation is to be executed by a Gnosis Safe when calling execTransaction
 const CALL = 0
@@ -26,7 +26,7 @@ const FLOAT_TOLERANCE = TWO.pow(new BN(52))
 module.exports = {
   ZERO_ADDRESS,
   DEFAULT_ORDER_EXPIRY,
-  DEFAULT_NUMBER_OF_SAFES,
+  DEFAULT_NUM_SAFES,
   CALL,
   DELEGATECALL,
   ZERO,

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -1,7 +1,7 @@
 module.exports = function (web3 = web3, artifacts = artifacts) {
   const ethUtil = require("ethereumjs-util")
 
-  const { ZERO_ADDRESS } = require("./constants")
+  const { ZERO_ADDRESS, CALL, DELEGATECALL } = require("./constants")
 
   const IProxy = artifacts.require("IProxy")
   const GnosisSafe = artifacts.require("GnosisSafe.sol")
@@ -9,9 +9,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
   const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const multiSendPromise = MultiSend.deployed()
-
-  const CALL = 0
-  const DELEGATECALL = 1
 
   /**
    * @typedef Transaction

--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -5,8 +5,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
   const exchangeUtils = require("@gnosis.pm/dex-contracts")
   const { Fraction } = require("@gnosis.pm/dex-contracts")
-
-  const max128 = new BN(2).pow(new BN(128)).subn(1)
+  const { MAXUINT128 } = require("./constants")
 
   const checkCorrectnessOfDeposits = async (
     currentPrice,
@@ -175,10 +174,10 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @return {BN[2]} amounts of quote token and base token for an unlimited order at the input price
    */
   const getUnlimitedOrderAmounts = function (price, baseTokenDecimals, quoteTokenDecimals) {
-    let baseTokenAmount = max128.clone()
+    let baseTokenAmount = MAXUINT128.clone()
     let quoteTokenAmount = getOutputAmountFromPrice(price, baseTokenAmount, baseTokenDecimals, quoteTokenDecimals)
     if (quoteTokenAmount.gt(baseTokenAmount)) {
-      quoteTokenAmount = max128.clone()
+      quoteTokenAmount = MAXUINT128.clone()
       baseTokenAmount = getOutputAmountFromPrice(1 / price, quoteTokenAmount, quoteTokenDecimals, baseTokenDecimals)
       assert(quoteTokenAmount.gte(baseTokenAmount), "Error: unable to create unlimited order")
     }
@@ -227,6 +226,5 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     getUnlimitedOrderAmounts,
     getDexagPrice,
     checkNoProfitableOffer,
-    max128,
   }
 }

--- a/scripts/utils/printing_tools.js
+++ b/scripts/utils/printing_tools.js
@@ -1,11 +1,6 @@
 const BN = require("bn.js")
 
-const bnZero = new BN(0)
-const bnOne = new BN(1)
-const bnTwo = new BN(2)
-const bnTen = new BN(10)
-const bn256 = new BN(256)
-const bnMaxUint = bnTwo.pow(bn256).sub(bnOne)
+const { ZERO, BN256, MAXUINT256, TEN } = require("./constants")
 
 /**
  * A generalized version of "toWei" for tokens with an arbitrary amount of decimals.
@@ -16,7 +11,7 @@ const bnMaxUint = bnTwo.pow(bn256).sub(bnOne)
  */
 const toErc20Units = function (amount, decimals) {
   const bnDecimals = new BN(decimals) // three different types are accepted for "decimals": integer, string and BN. The BN library takes care of the conversion
-  if (bnDecimals.lt(bnZero) || bnDecimals.gte(bn256))
+  if (bnDecimals.lt(ZERO) || bnDecimals.gte(BN256))
     throw Error("Invalid number of decimals for ERC20 token: " + decimals.toString()) // ERC20 decimals is stored in a uint8
   decimals = bnDecimals.toNumber() // safe conversion to num, since 0 <= decimals < 256  const re = /^(\d+)(\.(\d+))?$/ // a sequence of at least one digit (0-9), followed by optionally a dot and another sequence of at least one digit
   const re = /^(\d+)(\.(\d+))?$/ // a sequence of at least one digit (0-9), followed by optionally a dot and another sequence of at least one digit
@@ -26,8 +21,8 @@ const toErc20Units = function (amount, decimals) {
   if (decimalString.length != decimals) throw Error("Too many decimals for the token in input string")
   const integerPart = new BN(match[1])
   const decimalPart = new BN(decimalString)
-  const representation = integerPart.mul(bnTen.pow(new BN(decimals))).add(decimalPart)
-  if (representation.gt(bnMaxUint)) throw Error("Number larger than ERC20 token maximum amount (uint256)")
+  const representation = integerPart.mul(TEN.pow(new BN(decimals))).add(decimalPart)
+  if (representation.gt(MAXUINT256)) throw Error("Number larger than ERC20 token maximum amount (uint256)")
   return representation
 }
 
@@ -40,10 +35,10 @@ const toErc20Units = function (amount, decimals) {
 const fromErc20Units = function (amount, decimals) {
   amount = new BN(amount) // in case amount were a string, it converts it to BN, otherwise no effects
   const bnDecimals = new BN(decimals) // three different types are accepted for "decimals": integer, string and BN. The BN library takes care of the conversion
-  if (bnDecimals.lt(bnZero) || bnDecimals.gte(bn256))
+  if (bnDecimals.lt(ZERO) || bnDecimals.gte(BN256))
     throw Error("Invalid number of decimals for ERC20 token: " + decimals.toString()) // ERC20 decimals is stored in a uint8
   decimals = bnDecimals.toNumber() // safe conversion to num, since 0 <= decimals < 256
-  if (amount.gt(bnMaxUint)) throw Error("Number larger than ERC20 token maximum amount (uint256)")
+  if (amount.gt(MAXUINT256)) throw Error("Number larger than ERC20 token maximum amount (uint256)")
   if (decimals == 0) return amount.toString()
   const paddedAmount = amount.toString().padStart(decimals + 1, "0")
   let decimalPart = paddedAmount.slice(-decimals) // rightmost "decimals" characters of the string
@@ -66,6 +61,4 @@ module.exports = {
   toErc20Units,
   fromErc20Units,
   shortenedAddress,
-  bnMaxUint,
-  bnOne,
 }

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -4,10 +4,11 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const fs = require("fs")
   const Contract = require("@truffle/contract")
 
-  const { buildBundledTransaction, buildExecTransaction, CALL } = require("./internals")(web3, artifacts)
+  const { buildBundledTransaction, buildExecTransaction } = require("./internals")(web3, artifacts)
   const { getUnlimitedOrderAmounts } = require("./price_utils")(web3, artifacts)
   const { shortenedAddress, fromErc20Units } = require("./printing_tools")
   const { allElementsOnlyOnce } = require("./js_helpers")
+  const { DEFAULT_ORDER_EXPIRY, CALL } = require("./constants")
 
   const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
   const GnosisSafe = artifacts.require("GnosisSafe")
@@ -17,9 +18,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const exchangePromise = BatchExchange.deployed()
   const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const fleetFactoryPromise = FleetFactory.deployed()
-
-  const maxU32 = 2 ** 32 - 1
-  const maxUINT = new BN(2).pow(new BN(256)).sub(new BN(1))
 
   /**
    * Ethereum addresses are composed of the prefix "0x", a common identifier for hexadecimal,
@@ -220,7 +218,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {number} currentPrice Price at which the order brackets will be centered (e.g. current price of ETH in USD)
    * @param {number} [priceRangePercentage=20] Percentage above and below the target price for which orders are to be placed
    * @param {integer} [validFrom=3] Number of batches (from current) until orders become valid
-   * @param {integer} [expiry=maxU32] Maximum auction batch for which these orders are valid (e.g. maxU32)
+   * @param {integer} [expiry=DEFAULT_ORDER_EXPIRY] Maximum auction batch for which these orders are valid (e.g. maxU32)
    * @return {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
    */
   const buildOrders = async function (
@@ -231,7 +229,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     lowestLimit,
     highestLimit,
     debug = false,
-    expiry = maxU32 - 1 // We did not choose maxU32, in order to distinguish orders from "non-expiring" orders of the web interface
+    expiry = DEFAULT_ORDER_EXPIRY
   ) {
     const log = debug ? (...a) => console.log(...a) : () => {}
 
@@ -662,7 +660,5 @@ withdrawal of the desired funds
     getAllowances,
     assertNoAllowances,
     hasExistingOrders,
-    maxU32,
-    maxUINT,
   }
 }

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -12,7 +12,7 @@ module.exports = function (web3, artifacts) {
     buildTransferFundsToMaster,
     buildWithdrawAndTransferFundsToMaster,
   } = require("../utils/trading_strategy_helpers")(web3, artifacts)
-  const { bnMaxUint } = require("../utils/printing_tools.js")
+  const { MAXUINT256 } = require("../utils/constants")
 
   const assertGoodArguments = function (argv) {
     if (!argv.masterSafe) throw new Error("Argument error: --masterSafe is required")
@@ -46,7 +46,7 @@ module.exports = function (web3, artifacts) {
     let amount
     const token = tokenData.instance
     if (argv.requestWithdraw) {
-      amount = bnMaxUint.toString()
+      amount = MAXUINT256.toString()
     } else {
       if (argv.withdraw) {
         amount = await getWithdrawableAmount(bracketAddress, tokenData.address, exchange, web3)

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -23,13 +23,11 @@ const {
   buildTransferFundsToMaster,
   buildWithdrawAndTransferFundsToMaster,
   isOnlySafeOwner,
-  maxU32,
 } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
 const { waitForNSeconds, execTransaction } = require("../scripts/utils/internals")(web3, artifacts)
-const { checkCorrectnessOfDeposits, max128 } = require("../scripts/utils/price_utils")(web3, artifacts)
+const { checkCorrectnessOfDeposits } = require("../scripts/utils/price_utils")(web3, artifacts)
 const { toErc20Units, fromErc20Units } = require("../scripts/utils/printing_tools")
-
-const TEN = new BN(10)
+const { DEFAULT_ORDER_EXPIRY, TEN, MAXUINT128 } = require("../scripts/utils/constants")
 
 const checkPricesOfBracketStrategy = async function (lowestLimit, highestLimit, bracketSafes, exchange) {
   const stepSizeAsMultiplier = Math.pow(highestLimit / lowestLimit, 1 / bracketSafes.length)
@@ -552,8 +550,8 @@ contract("GnosisSafe", function (accounts) {
         const amountAfterBuying = amountAfterSelling.mul(buyOrder.priceNumerator).div(buyOrder.priceDenominator)
         assert.equal(amountAfterBuying.gt(initialAmount), true, "Brackets are not profitable")
 
-        assert.equal(buyOrder.validUntil, maxU32 - 1, `Got ${sellOrder}`)
-        assert.equal(sellOrder.validUntil, maxU32 - 1, `Got ${sellOrder}`)
+        assert.equal(buyOrder.validUntil, DEFAULT_ORDER_EXPIRY, `Got ${sellOrder}`)
+        assert.equal(sellOrder.validUntil, DEFAULT_ORDER_EXPIRY, `Got ${sellOrder}`)
         assert.equal(buyOrder.validFrom, currentBatch)
         assert.equal(buyOrder.validFrom, currentBatch)
       }
@@ -592,8 +590,8 @@ contract("GnosisSafe", function (accounts) {
         const amountAfterBuying = amountAfterSelling.mul(buyOrder.priceNumerator).div(buyOrder.priceDenominator)
         assert.equal(amountAfterBuying.gt(initialAmount), true, "Brackets are not profitable")
 
-        assert.equal(buyOrder.validUntil, maxU32 - 1, `Got ${buyOrder}`)
-        assert.equal(sellOrder.validUntil, maxU32 - 1, `Got ${sellOrder}`)
+        assert.equal(buyOrder.validUntil, DEFAULT_ORDER_EXPIRY, `Got ${buyOrder}`)
+        assert.equal(sellOrder.validUntil, DEFAULT_ORDER_EXPIRY, `Got ${sellOrder}`)
         assert.equal(buyOrder.validFrom, currentBatch)
         assert.equal(buyOrder.validFrom, currentBatch)
       }
@@ -649,8 +647,8 @@ contract("GnosisSafe", function (accounts) {
       for (const bracketAddress of bracketSafes) {
         const auctionElements = exchangeUtils.decodeOrders(await exchange.getEncodedUserOrders(bracketAddress))
         const [buyOrder, sellOrder] = auctionElements
-        assert(buyOrder.priceNumerator.eq(max128))
-        assert(sellOrder.priceDenominator.eq(max128))
+        assert(buyOrder.priceNumerator.eq(MAXUINT128))
+        assert(sellOrder.priceDenominator.eq(MAXUINT128))
       }
     })
     it("Places bracket orders on behalf of a fleet of safes and checks prices for p>1", async () => {
@@ -672,8 +670,8 @@ contract("GnosisSafe", function (accounts) {
         const auctionElements = exchangeUtils.decodeOrders(await exchange.getEncodedUserOrders(bracketAddress))
         assert.equal(auctionElements.length, 2)
         const [buyOrder, sellOrder] = auctionElements
-        assert(buyOrder.priceDenominator.eq(max128))
-        assert(sellOrder.priceNumerator.eq(max128))
+        assert(buyOrder.priceDenominator.eq(MAXUINT128))
+        assert(sellOrder.priceNumerator.eq(MAXUINT128))
       }
     })
     it("Places bracket orders on behalf of a fleet of safes and checks prices for p<1, with different decimals than 18", async () => {

--- a/test/price_utils.js
+++ b/test/price_utils.js
@@ -11,13 +11,11 @@ const {
   checkNoProfitableOffer,
 } = require("../scripts/utils/price_utils")(web3, artifacts)
 const { fetchTokenInfoFromExchange } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
-
-const max128 = new BN(2).pow(new BN(128)).subn(1)
-const floatTolerance = new BN(2).pow(new BN(52)) // same tolerance as float precision
+const { MAXUINT128, FLOAT_TOLERANCE } = require("../scripts/utils/constants")
 
 const assertEqualUpToFloatPrecision = function (value, expected) {
   const differenceFromExpected = value.sub(expected).abs()
-  assert(differenceFromExpected.mul(floatTolerance).lt(expected))
+  assert(differenceFromExpected.mul(FLOAT_TOLERANCE).lt(expected))
 }
 
 describe("getOutputAmountFromPrice", () => {
@@ -75,50 +73,50 @@ describe("getUnlimitedOrderAmounts", () => {
         price: 160,
         quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedQuoteTokenAmount: max128,
-        expectedbaseTokenAmount: max128.divn(160),
+        expectedQuoteTokenAmount: MAXUINT128,
+        expectedbaseTokenAmount: MAXUINT128.divn(160),
       },
       {
         price: 1 / 160,
         quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedQuoteTokenAmount: max128.divn(160),
-        expectedbaseTokenAmount: max128,
+        expectedQuoteTokenAmount: MAXUINT128.divn(160),
+        expectedbaseTokenAmount: MAXUINT128,
       },
       {
         price: 1,
         quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedQuoteTokenAmount: max128,
-        expectedbaseTokenAmount: max128,
+        expectedQuoteTokenAmount: MAXUINT128,
+        expectedbaseTokenAmount: MAXUINT128,
       },
       {
         price: 1 + Number.EPSILON,
         quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedQuoteTokenAmount: max128,
-        expectedbaseTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
+        expectedQuoteTokenAmount: MAXUINT128,
+        expectedbaseTokenAmount: MAXUINT128.sub(new BN(2).pow(new BN(128 - 52))),
       },
       {
         price: 1 - Number.EPSILON,
         quoteTokenDecimals: 18,
         baseTokenDecimals: 18,
-        expectedQuoteTokenAmount: max128.sub(new BN(2).pow(new BN(128 - 52))),
-        expectedbaseTokenAmount: max128,
+        expectedQuoteTokenAmount: MAXUINT128.sub(new BN(2).pow(new BN(128 - 52))),
+        expectedbaseTokenAmount: MAXUINT128,
       },
       {
         price: 100,
         quoteTokenDecimals: 165,
         baseTokenDecimals: 200,
-        expectedQuoteTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 - 2))),
-        expectedbaseTokenAmount: max128,
+        expectedQuoteTokenAmount: MAXUINT128.div(new BN(10).pow(new BN(200 - 165 - 2))),
+        expectedbaseTokenAmount: MAXUINT128,
       },
       {
         price: 100,
         quoteTokenDecimals: 200,
         baseTokenDecimals: 165,
-        expectedQuoteTokenAmount: max128,
-        expectedbaseTokenAmount: max128.div(new BN(10).pow(new BN(200 - 165 + 2))),
+        expectedQuoteTokenAmount: MAXUINT128,
+        expectedbaseTokenAmount: MAXUINT128.div(new BN(10).pow(new BN(200 - 165 + 2))),
       },
     ]
     for (const {

--- a/test/printing_tools.js
+++ b/test/printing_tools.js
@@ -5,7 +5,8 @@
 const assert = require("assert")
 const BN = require("bn.js")
 
-const { toErc20Units, fromErc20Units, bnMaxUint, bnOne } = require("../scripts/utils/printing_tools")
+const { toErc20Units, fromErc20Units } = require("../scripts/utils/printing_tools")
+const { MAXUINT256, ONE } = require("../scripts/utils/constants")
 
 const goodTwoWayPairs = [
   {
@@ -39,18 +40,18 @@ const goodTwoWayPairs = [
     decimals: 18,
   },
   {
-    user: "0." + bnMaxUint.toString().padStart(255, "0"),
-    machine: bnMaxUint.toString(),
+    user: "0." + MAXUINT256.toString().padStart(255, "0"),
+    machine: MAXUINT256.toString(),
     decimals: 255,
   },
   {
-    user: bnMaxUint.toString(),
-    machine: bnMaxUint.toString(),
+    user: MAXUINT256.toString(),
+    machine: MAXUINT256.toString(),
     decimals: 0,
   },
   {
-    user: bnMaxUint.toString().slice(0, -18) + "." + bnMaxUint.toString().slice(-18),
-    machine: bnMaxUint.toString(),
+    user: MAXUINT256.toString().slice(0, -18) + "." + MAXUINT256.toString().slice(-18),
+    machine: MAXUINT256.toString(),
     decimals: 18,
   },
   {
@@ -294,17 +295,17 @@ describe("toErc20Units", () => {
         error: "tooManyDecimals",
       },
       {
-        user: bnMaxUint.add(bnOne).toString(),
+        user: MAXUINT256.add(ONE).toString(),
         decimals: 0,
         error: "tooLargeNumber",
       },
       {
-        user: "0." + bnMaxUint.add(bnOne).toString().padStart(255, "0"),
+        user: "0." + MAXUINT256.add(ONE).toString().padStart(255, "0"),
         decimals: 255,
         error: "tooLargeNumber",
       },
       {
-        user: bnMaxUint.add(bnOne).toString().slice(0, -18) + "." + bnMaxUint.add(bnOne).toString().slice(-18),
+        user: MAXUINT256.add(ONE).toString().slice(0, -18) + "." + MAXUINT256.add(ONE).toString().slice(-18),
         decimals: 18,
         error: "tooLargeNumber",
       },
@@ -426,17 +427,17 @@ describe("fromErc20Units", () => {
         error: "invalidDecimals",
       },
       {
-        machine: bnMaxUint.add(bnOne).toString(),
+        machine: MAXUINT256.add(ONE).toString(),
         decimals: 0,
         error: "tooLargeNumber",
       },
       {
-        machine: bnMaxUint.add(bnOne).toString(),
+        machine: MAXUINT256.add(ONE).toString(),
         decimals: 18,
         error: "tooLargeNumber",
       },
       {
-        machine: bnMaxUint.add(bnOne).toString(),
+        machine: MAXUINT256.add(ONE).toString(),
         decimals: 255,
         error: "tooLargeNumber",
       },

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -16,10 +16,9 @@ const {
   deployFleetOfSafes,
   buildOrders,
   buildTransferApproveDepositFromOrders,
-  maxU32,
 } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
-const { buildExecTransaction, CALL } = require("../scripts/utils/internals")(web3, artifacts)
-//const { ZERO_ADDRESS } = require("../scripts/utils/constants")
+const { buildExecTransaction } = require("../scripts/utils/internals")(web3, artifacts)
+const { DEFAULT_ORDER_EXPIRY, CALL /*, ZERO_ADDRESS*/ } = require("../scripts/utils/constants")
 
 contract("verification checks - for allowances", async (accounts) => {
   describe("allowances", async () => {
@@ -277,7 +276,7 @@ contract("Verification checks", function (accounts) {
       const buyTokens = [baseToken.id, baseToken.id]
       const sellTokens = [quoteToken.id, quoteToken.id]
       const validFroms = [validFrom, validFrom]
-      const validTos = [maxU32, maxU32]
+      const validTos = [DEFAULT_ORDER_EXPIRY, DEFAULT_ORDER_EXPIRY]
       const buyAmounts = [lowerBuyAmount.toString(), upperBuyAmount.toString()]
       const sellAmounts = [lowerSellAmount.toString(), upperSellAmount.toString()]
 
@@ -315,7 +314,7 @@ contract("Verification checks", function (accounts) {
       const buyTokens = [baseToken.id, quoteToken.id]
       const sellTokens = [quoteToken.id, baseToken.id]
       const validFroms = [validFrom, validFrom]
-      const validTos = [maxU32, maxU32]
+      const validTos = [DEFAULT_ORDER_EXPIRY, DEFAULT_ORDER_EXPIRY]
       const buyAmounts = [lowerBuyAmount.toString(), upperBuyAmount.toString()]
       const sellAmounts = [lowerSellAmount.toString(), upperSellAmount.toString()]
 


### PR DESCRIPTION
Moves many of the constants defined in this repo into a single constant file.
Note that these constants are used for both scripts and tests, so if we get a constant wrong then the tests may not catch the ensuing errors.

I did not touch constants defined for the Synthetix script.
Note that this PR fixes a small bug that causes orders created with the order creation script to not have the same expiration date as those created with the complete liquidity provision script.
 
Closes #223.