### PR TITLE
Split withdraw script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,41 +97,53 @@ npx truffle exec scripts/transfer_approve_deposit.js --masterSafe=$MASTER_SAFE -
 
 ### Withdrawing
 
-To withdraw funds from the bracket traders, all withdrawals have to be specified in a file with the following format:
+Funds can be withdrawn using the scripts `request_withdraw.js` and `withdraw.js`.
+
+To this end, you must specify the brackets you want to withdraw from with `--brackets` and the tokens to be withdrawn using either `--tokens` (which takes a list of addresses) or `--tokenIds` (which takes a list of token IDs).
+
+First, a withdraw request must be created for each bracket and token.
+The following command request withdrawing of all DAI and WETH (token ID 7 and 1 respectively) for the brackets at addresses `0x1` and `0x2`:
+
+```js
+npx truffle exec scripts/request_withdraw.js --masterSafe=$MASTER_SAFE --brackets=0x1,0x2 --tokenIds=1,7 --network=$NETWORK_NAME
+```
+
+This command can be used to halt all tradings involving these brackets and tokens: Even if orders are still up, no trading will be possible starting from the next batch after the corresponding transaction has been confirmed.
+No funds will have moved yet, but a withdraw request will have been registered on the exchange.
+
+The next step transfers the funds from the exchange to the master Safe.
+Internally, it composes two steps together: withdrawing funds from the exchange to each brackets, and then transferring funds from the brackets to master.
+The parameters of the call are the same as before, the only change is the name of the script to be executed:
+
+```js
+npx truffle exec scripts/withdraw.js --masterSafe=$MASTER_SAFE --brackets=0x1,0x2 --tokenIds=1,7 --network=$NETWORK_NAME
+```
+
+If necessary, for example if some funds are stuck in some of the bracket, the previous command can be split into two independent units: withdrawing from the exchange into the bracket and transferring funds from the bracket into the master Safe.
+
+```js
+npx truffle exec scripts/withdraw.js --withdraw --masterSafe=$MASTER_SAFE --brackets=0x1,0x2 --tokenIds=1,7 --network=$NETWORK_NAME
+```
+
+```js
+npx truffle exec scripts/withdraw.js --transferFundsToMaster --masterSafe=$MASTER_SAFE --brackets=0x1,0x2 --tokenIds=1,7 --network=$NETWORK_NAME
+```
+
+For a more fine-grained management of the amounts to be withdrawn, withdrawal files can be used instead of `--brackets`, `--tokens`, and `--tokenIds` in both `request_withdraw.js` and `withdraw.js`.
+All desired withdrawals should be specified in a JSON file with the following format:
 
 ```
+[
     {
         "amount": "100000000000000000",
         "tokenAddress": "0xc778417e063141139fce010982780140aa0cd5ab",
         "bracketAddress": "0xfA4a18c2218945bC018BF94D093BCa66c88D3c40"
-    }
+    },
+    ...
 ]
 ```
 
-If you have forgotten the addresses of your brackets, then you should read in the next section how to retrieve them.
-
-The script can automatically determine the amount, instead of having to specify it on the file.
-This is achieved by adding the flag `--allTokens` to the withraw command. This is possible in any of the following commands.
-
-Withdrawing is a two-step process: first, withdrawals must be requested on the exchange; then the withdrawals can be executed, and at the same time the funds can be sent back to the master Safe.
-
-```js
-npx truffle exec scripts/withdraw.js --requestWithdraw --masterSafe=$MASTER_SAFE --withdrawalFile="./examples/exampleDepositList.json" --network=$NETWORK_NAME
-```
-
-```js
-npx truffle exec scripts/withdraw.js --withdraw --transferFundsToMaster --masterSafe=$MASTER_SAFE --withdrawalFile="./examples/exampleDepositList.json" --network=$NETWORK_NAME
-```
-
-The latter instruction can be split into two independent units, if needed: withdrawing from the exchange to the bracket and transferring funds from the bracket to the master Safe.
-
-```js
-npx truffle exec scripts/withdraw.js --withdraw --masterSafe=$MASTER_SAFE --withdrawalFile="./examples/exampleDepositList.json" --network=$NETWORK_NAME
-```
-
-```js
-npx truffle exec scripts/withdraw.js --transferFundsToMaster --masterSafe=$MASTER_SAFE --withdrawalFile="./examples/exampleDepositList.json" --network=$NETWORK_NAME
-```
+See `examples/exampleDepositList.json` for a concrete example.
 
 ### Documenting brackets
 

--- a/scripts/claim_withdraw.js
+++ b/scripts/claim_withdraw.js
@@ -1,25 +1,15 @@
 const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
-const { defaultWithdrawYargs, prepareWithdraw } = require("./wrapper/withdraw")(web3, artifacts)
+const { defaultWithdrawYargs, prepareWithdrawAndTransferFundsToMaster } = require("./wrapper/withdraw")(web3, artifacts)
 const { promptUser } = require("./utils/user_interface_helpers")
 
-const argv = defaultWithdrawYargs
-  .option("withdraw", {
-    type: "boolean",
-    default: false,
-    describe: "only withdraw from the exchange to the brackets, without transferring to master",
-  })
-  .option("transferFundsToMaster", {
-    type: "boolean",
-    default: false,
-    describe: "do not withdraw from the exchange but only transfer back tokens from the brackets to master",
-  }).argv
+const argv = defaultWithdrawYargs.argv
 
 module.exports = async (callback) => {
   try {
     const masterSafe = getSafe(argv.masterSafe)
 
-    const transaction = await prepareWithdraw(argv, true)
+    const transaction = await prepareWithdrawAndTransferFundsToMaster(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
       await signAndSend(await masterSafe, transaction, argv.network)

--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -1,25 +1,15 @@
 const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
-const { defaultWithdrawYargs, prepareWithdraw } = require("./wrapper/withdraw")(web3, artifacts)
+const { defaultWithdrawYargs, prepareRequestWithdraw } = require("./wrapper/withdraw")(web3, artifacts)
 const { promptUser } = require("./utils/user_interface_helpers")
 
-const argv = defaultWithdrawYargs
-  .option("withdraw", {
-    type: "boolean",
-    default: false,
-    describe: "only withdraw from the exchange to the brackets, without transferring to master",
-  })
-  .option("transferFundsToMaster", {
-    type: "boolean",
-    default: false,
-    describe: "do not withdraw from the exchange but only transfer back tokens from the brackets to master",
-  }).argv
+const argv = defaultWithdrawYargs.argv
 
 module.exports = async (callback) => {
   try {
     const masterSafe = getSafe(argv.masterSafe)
 
-    const transaction = await prepareWithdraw(argv, true)
+    const transaction = await prepareRequestWithdraw(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
       await signAndSend(await masterSafe, transaction, argv.network)

--- a/scripts/transfer_funds_to_master.js
+++ b/scripts/transfer_funds_to_master.js
@@ -1,0 +1,23 @@
+const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
+const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { defaultWithdrawYargs, prepareTransferFundsToMaster } = require("./wrapper/withdraw")(web3, artifacts)
+const { promptUser } = require("./utils/user_interface_helpers")
+
+const argv = defaultWithdrawYargs.argv
+
+module.exports = async (callback) => {
+  try {
+    const masterSafe = getSafe(argv.masterSafe)
+
+    const transaction = await prepareTransferFundsToMaster(argv, true)
+    const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
+    if (answer == "y" || answer.toLowerCase() == "yes") {
+      await signAndSend(await masterSafe, transaction, argv.network)
+    }
+
+    callback()
+  } catch (error) {
+    console.log(error.response)
+    callback(error)
+  }
+}

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -2,7 +2,6 @@ module.exports = function (web3, artifacts) {
   const fs = require("fs").promises
   const { getWithdrawableAmount } = require("@gnosis.pm/dex-contracts")
 
-  const { fromErc20Units, shortenedAddress } = require("../utils/printing_tools")
   const {
     getExchange,
     fetchTokenInfoAtAddresses,
@@ -12,16 +11,12 @@ module.exports = function (web3, artifacts) {
     buildTransferFundsToMaster,
     buildWithdrawAndTransferFundsToMaster,
   } = require("../utils/trading_strategy_helpers")(web3, artifacts)
+  const { default_yargs, checkBracketsForDuplicate } = require("../utils/default_yargs")
+  const { fromErc20Units, shortenedAddress } = require("../utils/printing_tools")
   const { MAXUINT256 } = require("../utils/constants")
 
   const assertGoodArguments = function (argv) {
     if (!argv.masterSafe) throw new Error("Argument error: --masterSafe is required")
-
-    if (!argv.requestWithdraw && !argv.withdraw && !argv.transferFundsToMaster) {
-      throw new Error("Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given")
-    } else if (argv.requestWithdraw && (argv.transferFundsToMaster || argv.withdraw)) {
-      throw new Error("Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster")
-    }
 
     if (!argv.withdrawalFile && !argv.brackets) {
       throw new Error("Argument error: one of --withdrawalFile, --brackets must be given")
@@ -42,36 +37,25 @@ module.exports = function (web3, artifacts) {
     }
   }
 
-  const determineAmountToWithdraw = async function (argv, bracketAddress, tokenData, exchange) {
-    let amount
-    const token = tokenData.instance
-    if (argv.requestWithdraw) {
-      amount = MAXUINT256.toString()
-    } else {
-      if (argv.withdraw) {
-        amount = await getWithdrawableAmount(bracketAddress, tokenData.address, exchange, web3)
-      }
-      if (argv.transferFundsToMaster) {
-        amount = amount || (await token.balanceOf(bracketAddress)).toString()
-      }
-    }
-    return amount
-  }
-
-  return async function (argv, printOutput = false) {
+  const getWithdrawalsAndTokenInfo = async function (
+    amountFunction,
+    withdrawalFile,
+    brackets,
+    tokens,
+    tokenIds,
+    printOutput = false
+  ) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
-
-    assertGoodArguments(argv)
 
     let withdrawals
     let tokenInfoPromises
-    if (argv.withdrawalFile) {
-      withdrawals = JSON.parse(await fs.readFile(argv.withdrawalFile, "utf8"))
+    if (withdrawalFile) {
+      withdrawals = JSON.parse(await fs.readFile(withdrawalFile, "utf8"))
       tokenInfoPromises = fetchTokenInfoForFlux(withdrawals)
     } else {
       const exchangePromise = getExchange(web3)
       const tokenAddresses =
-        argv.tokens || (await Promise.all(argv.tokenIds.map(async (id) => (await exchangePromise).tokenIdToAddressMap(id))))
+        tokens || (await Promise.all(tokenIds.map(async (id) => (await exchangePromise).tokenIdToAddressMap(id))))
       tokenInfoPromises = fetchTokenInfoAtAddresses(tokenAddresses)
       const exchange = await exchangePromise
 
@@ -79,11 +63,9 @@ module.exports = function (web3, artifacts) {
       const tokenDataList = await Promise.all(Object.entries(tokenInfoPromises).map(([, tokenDataPromise]) => tokenDataPromise))
       const tokenBracketPairs = []
       for (const tokenData of tokenDataList)
-        for (const bracketAddress of argv.brackets) tokenBracketPairs.push([bracketAddress, tokenData])
+        for (const bracketAddress of brackets) tokenBracketPairs.push([bracketAddress, tokenData])
       const maxWithdrawableAmounts = await Promise.all(
-        tokenBracketPairs.map(([bracketAddress, tokenData]) =>
-          determineAmountToWithdraw(argv, bracketAddress, tokenData, exchange)
-        )
+        tokenBracketPairs.map(([bracketAddress, tokenData]) => amountFunction(bracketAddress, tokenData, exchange))
       )
       withdrawals = []
       maxWithdrawableAmounts.forEach((amount, index) => {
@@ -96,48 +78,187 @@ module.exports = function (web3, artifacts) {
       })
     }
 
-    log("Started building withdraw transaction.")
-    let transactionPromise
-    if (argv.requestWithdraw) transactionPromise = buildRequestWithdraw(argv.masterSafe, withdrawals)
-    else if (argv.withdraw && !argv.transferFundsToMaster) transactionPromise = buildWithdraw(argv.masterSafe, withdrawals)
-    else if (!argv.withdraw && argv.transferFundsToMaster)
-      transactionPromise = buildTransferFundsToMaster(argv.masterSafe, withdrawals, true)
-    else if (argv.withdraw && argv.transferFundsToMaster)
-      transactionPromise = buildWithdrawAndTransferFundsToMaster(argv.masterSafe, withdrawals)
-    else {
-      throw new Error("No operation specified")
+    return {
+      withdrawals,
+      tokenInfoPromises,
     }
+  }
+
+  const prepareRequestWithdraw = async function (argv, printOutput = false) {
+    const log = printOutput ? (...a) => console.log(...a) : () => {}
+
+    assertGoodArguments(argv)
+
+    const amountFunction = function () {
+      return MAXUINT256.toString()
+    }
+    const { withdrawals, tokenInfoPromises } = await getWithdrawalsAndTokenInfo(
+      amountFunction,
+      argv.withdrawalFile,
+      argv.brackets,
+      argv.tokens,
+      argv.tokenIds,
+      printOutput
+    )
+
+    log("Started building withdraw transaction.")
+    const transactionPromise = buildRequestWithdraw(argv.masterSafe, withdrawals)
+
+    for (const withdrawal of withdrawals) {
+      const { symbol: tokenSymbol } = await tokenInfoPromises[withdrawal.tokenAddress]
+
+      log(`Requesting withdrawal of all ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`)
+    }
+
+    return transactionPromise
+  }
+  const prepareDirectWithdraw = async function (argv, printOutput = false) {
+    const log = printOutput ? (...a) => console.log(...a) : () => {}
+
+    assertGoodArguments(argv)
+
+    const amountFunction = function (bracketAddress, tokenData, exchange) {
+      return getWithdrawableAmount(bracketAddress, tokenData.address, exchange, web3)
+    }
+    const { withdrawals, tokenInfoPromises } = await getWithdrawalsAndTokenInfo(
+      amountFunction,
+      argv.withdrawalFile,
+      argv.brackets,
+      argv.tokens,
+      argv.tokenIds,
+      printOutput
+    )
+
+    log("Started building withdraw transaction.")
+    const transactionPromise = buildWithdraw(argv.masterSafe, withdrawals)
+
+    for (const withdrawal of withdrawals) {
+      const { symbol: tokenSymbol, decimals: tokenDecimals } = await tokenInfoPromises[withdrawal.tokenAddress]
+
+      const userAmount = fromErc20Units(withdrawal.amount, tokenDecimals)
+      log(`Withdrawing ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`)
+    }
+
+    return transactionPromise
+  }
+  const prepareTransferFundsToMaster = async function (argv, printOutput = false) {
+    const log = printOutput ? (...a) => console.log(...a) : () => {}
+
+    assertGoodArguments(argv)
+
+    const amountFunction = async function (bracketAddress, tokenData) {
+      return (await tokenData.instance.balanceOf(bracketAddress)).toString()
+    }
+    const { withdrawals, tokenInfoPromises } = await getWithdrawalsAndTokenInfo(
+      amountFunction,
+      argv.withdrawalFile,
+      argv.brackets,
+      argv.tokens,
+      argv.tokenIds,
+      printOutput
+    )
+
+    log("Started building withdraw transaction.")
+    const transactionPromise = buildTransferFundsToMaster(argv.masterSafe, withdrawals, true)
 
     for (const withdrawal of withdrawals) {
       const { symbol: tokenSymbol, decimals: tokenDecimals } = await tokenInfoPromises[withdrawal.tokenAddress]
 
       const userAmount = fromErc20Units(withdrawal.amount, tokenDecimals)
 
-      if (argv.requestWithdraw)
-        log(
-          `Requesting withdrawal of ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`
-        )
-      else if (argv.withdraw && !argv.transferFundsToMaster)
-        log(`Withdrawing ${userAmount} ${tokenSymbol} from BatchExchange in behalf of Safe ${withdrawal.bracketAddress}`)
-      else if (!argv.withdraw && argv.transferFundsToMaster)
-        log(
-          `Transferring ${userAmount} ${tokenSymbol} from Safe ${withdrawal.bracketAddress} into master Safe ${shortenedAddress(
-            argv.masterSafe
-          )}`
-        )
-      else if (argv.withdraw && argv.transferFundsToMaster)
-        log(
-          `Safe ${
-            withdrawal.bracketAddress
-          } withdrawing ${userAmount} ${tokenSymbol} from BatchExchange and forwarding the whole amount into master Safe ${shortenedAddress(
-            argv.masterSafe
-          )})`
-        )
-      else {
-        throw new Error("No operation specified")
-      }
+      log(
+        `Transferring ${userAmount} ${tokenSymbol} from Safe ${withdrawal.bracketAddress} into master Safe ${shortenedAddress(
+          argv.masterSafe
+        )}`
+      )
     }
 
     return transactionPromise
+  }
+  const prepareWithdrawAndTransferFundsToMaster = async function (argv, printOutput = false) {
+    const log = printOutput ? (...a) => console.log(...a) : () => {}
+
+    assertGoodArguments(argv)
+
+    const amountFunction = function (bracketAddress, tokenData, exchange) {
+      return getWithdrawableAmount(bracketAddress, tokenData.address, exchange, web3)
+    }
+    const { withdrawals, tokenInfoPromises } = await getWithdrawalsAndTokenInfo(
+      amountFunction,
+      argv.withdrawalFile,
+      argv.brackets,
+      argv.tokens,
+      argv.tokenIds,
+      printOutput
+    )
+
+    log("Started building withdraw transaction.")
+    const transactionPromise = buildWithdrawAndTransferFundsToMaster(argv.masterSafe, withdrawals)
+
+    for (const withdrawal of withdrawals) {
+      const { symbol: tokenSymbol, decimals: tokenDecimals } = await tokenInfoPromises[withdrawal.tokenAddress]
+
+      const userAmount = fromErc20Units(withdrawal.amount, tokenDecimals)
+      log(
+        `Safe ${
+          withdrawal.bracketAddress
+        } withdrawing ${userAmount} ${tokenSymbol} from BatchExchange and forwarding the whole amount into master Safe ${shortenedAddress(
+          argv.masterSafe
+        )})`
+      )
+    }
+
+    return transactionPromise
+  }
+
+  const prepareWithdraw = function (argv, printOutput = false) {
+    // if both options are unset, wa assume the user wants to withdraw and transfer funds to master
+    if (argv.withdraw == argv.transferFundsToMaster) {
+      return prepareWithdrawAndTransferFundsToMaster(argv, printOutput)
+    } else if (argv.withdraw) {
+      return prepareDirectWithdraw(argv, printOutput)
+    } else {
+      return prepareTransferFundsToMaster(argv, printOutput)
+    }
+  }
+
+  const defaultWithdrawYargs = default_yargs
+    .option("masterSafe", {
+      type: "string",
+      describe: "address of Gnosis Safe owning bracketSafes",
+      demandOption: true,
+    })
+    .option("withdrawalFile", {
+      type: "string",
+      describe: "file name (and path) to the list of withdrawals",
+    })
+    .option("brackets", {
+      type: "string",
+      describe:
+        "comma-separated list of brackets from which to withdraw the entire balance. Compatible with all valid combinations of --requestWithdraw, --withdraw, --transferFundsToMaster",
+      coerce: (str) => {
+        return str.split(",")
+      },
+    })
+    .option("tokens", {
+      type: "string",
+      describe: "comma separated address list of tokens to withdraw, to use in combination with --brackets",
+      coerce: (str) => {
+        return str.split(",")
+      },
+    })
+    .option("tokenIds", {
+      type: "string",
+      describe: "comma separated list of exchange ids for the tokens to withdraw, to use in combination with --brackets",
+      coerce: (str) => {
+        return str.split(",")
+      },
+    })
+    .check(checkBracketsForDuplicate)
+
+  return {
+    prepareRequestWithdraw,
+    prepareWithdraw,
+    defaultWithdrawYargs,
   }
 }

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -112,7 +112,7 @@ module.exports = function (web3, artifacts) {
 
     return transactionPromise
   }
-  const prepareDirectWithdraw = async function (argv, printOutput = false) {
+  const prepareWithdraw = async function (argv, printOutput = false) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
 
     assertGoodArguments(argv)
@@ -211,17 +211,6 @@ module.exports = function (web3, artifacts) {
     return transactionPromise
   }
 
-  const prepareWithdraw = function (argv, printOutput = false) {
-    // if both options are unset, wa assume the user wants to withdraw and transfer funds to master
-    if (argv.withdraw == argv.transferFundsToMaster) {
-      return prepareWithdrawAndTransferFundsToMaster(argv, printOutput)
-    } else if (argv.withdraw) {
-      return prepareDirectWithdraw(argv, printOutput)
-    } else {
-      return prepareTransferFundsToMaster(argv, printOutput)
-    }
-  }
-
   const defaultWithdrawYargs = default_yargs
     .option("masterSafe", {
       type: "string",
@@ -259,6 +248,8 @@ module.exports = function (web3, artifacts) {
   return {
     prepareRequestWithdraw,
     prepareWithdraw,
+    prepareWithdrawAndTransferFundsToMaster,
+    prepareTransferFundsToMaster,
     defaultWithdrawYargs,
   }
 }

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -15,7 +15,12 @@ const { deployFleetOfSafes, buildTransferApproveDepositFromList } = require("../
   web3,
   artifacts
 )
-const { prepareRequestWithdraw, prepareWithdraw } = require("../../scripts/wrapper/withdraw")(web3, artifacts)
+const {
+  prepareRequestWithdraw,
+  prepareWithdraw,
+  prepareTransferFundsToMaster,
+  prepareWithdrawAndTransferFundsToMaster,
+} = require("../../scripts/wrapper/withdraw")(web3, artifacts)
 const { waitForNSeconds, execTransaction } = require("../../scripts/utils/internals")(web3, artifacts)
 const { toErc20Units, fromErc20Units } = require("../../scripts/utils/printing_tools")
 
@@ -177,7 +182,6 @@ contract("Withdraw script", function (accounts) {
       const argv2 = {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
-        withdraw: true,
       }
       const transaction2 = await prepareWithdraw(argv2)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction2)
@@ -185,9 +189,8 @@ contract("Withdraw script", function (accounts) {
       const argv3 = {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
-        transferFundsToMaster: true,
       }
-      const transaction3 = await prepareWithdraw(argv3)
+      const transaction3 = await prepareTransferFundsToMaster(argv3)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction3)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -222,7 +225,7 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
       }
-      const transaction2 = await prepareWithdraw(argv2)
+      const transaction2 = await prepareWithdrawAndTransferFundsToMaster(argv2)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction2)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -317,7 +320,6 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
-        withdraw: true,
       }
       const transaction2 = await prepareWithdraw(argv2)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction2)
@@ -356,7 +358,6 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
-        withdraw: true,
       }
       const transaction2 = await prepareWithdraw(argv2)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction2)
@@ -365,9 +366,8 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
-        transferFundsToMaster: true,
       }
-      const transaction3 = await prepareWithdraw(argv3)
+      const transaction3 = await prepareTransferFundsToMaster(argv3)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction3)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -409,7 +409,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction2 = await prepareWithdraw(argv2)
+      const transaction2 = await prepareWithdrawAndTransferFundsToMaster(argv2)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction2)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -435,7 +435,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address],
       }
-      const transaction = await prepareWithdraw(argv)
+      const transaction = await prepareWithdrawAndTransferFundsToMaster(argv)
       // if the built transaction used the token balance of the bracket instead of zero, then
       // the following transaction would fail.
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -15,8 +15,8 @@ const { deployFleetOfSafes, buildTransferApproveDepositFromList } = require("../
   web3,
   artifacts
 )
+const { prepareRequestWithdraw, prepareWithdraw } = require("../../scripts/wrapper/withdraw")(web3, artifacts)
 const { waitForNSeconds, execTransaction } = require("../../scripts/utils/internals")(web3, artifacts)
-const prepareWithdraw = require("../../scripts/wrapper/withdraw")(web3, artifacts)
 const { toErc20Units, fromErc20Units } = require("../../scripts/utils/printing_tools")
 
 const bnMaxUint256 = new BN(2).pow(new BN(256)).subn(1)
@@ -111,9 +111,8 @@ contract("Withdraw script", function (accounts) {
       const argv = {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
-        requestWithdraw: true,
       }
-      const transaction = await prepareWithdraw(argv)
+      const transaction = await prepareRequestWithdraw(argv)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)
 
       for (const { amount, tokenAddress, bracketAddress } of deposits) {
@@ -136,9 +135,8 @@ contract("Withdraw script", function (accounts) {
       const argv1 = {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
-        requestWithdraw: true,
       }
-      const transaction1 = await prepareWithdraw(argv1)
+      const transaction1 = await prepareRequestWithdraw(argv1)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction1)
       await waitForNSeconds(301)
 
@@ -171,9 +169,8 @@ contract("Withdraw script", function (accounts) {
       const argv1 = {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
-        requestWithdraw: true,
       }
-      const transaction1 = await prepareWithdraw(argv1)
+      const transaction1 = await prepareRequestWithdraw(argv1)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction1)
       await waitForNSeconds(301)
 
@@ -216,17 +213,14 @@ contract("Withdraw script", function (accounts) {
       const argv1 = {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
-        requestWithdraw: true,
       }
-      const transaction1 = await prepareWithdraw(argv1)
+      const transaction1 = await prepareRequestWithdraw(argv1)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction1)
       await waitForNSeconds(301)
 
       const argv2 = {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
-        withdraw: true,
-        transferFundsToMaster: true,
       }
       const transaction2 = await prepareWithdraw(argv2)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction2)
@@ -260,9 +254,8 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
-        requestWithdraw: true,
       }
-      const transaction = await prepareWithdraw(argv)
+      const transaction = await prepareRequestWithdraw(argv)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -289,9 +282,8 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokenIds: [usdcId, wethId],
-        requestWithdraw: true,
       }
-      const transaction = await prepareWithdraw(argv)
+      const transaction = await prepareRequestWithdraw(argv)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -316,9 +308,8 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
-        requestWithdraw: true,
       }
-      const transaction1 = await prepareWithdraw(argv1)
+      const transaction1 = await prepareRequestWithdraw(argv1)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction1)
       await waitForNSeconds(301)
 
@@ -356,9 +347,8 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
-        requestWithdraw: true,
       }
-      const transaction1 = await prepareWithdraw(argv1)
+      const transaction1 = await prepareRequestWithdraw(argv1)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction1)
       await waitForNSeconds(301)
 
@@ -409,9 +399,8 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
-        requestWithdraw: true,
       }
-      const transaction1 = await prepareWithdraw(argv1)
+      const transaction1 = await prepareRequestWithdraw(argv1)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction1)
       await waitForNSeconds(301)
 
@@ -419,8 +408,6 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
-        withdraw: true,
-        transferFundsToMaster: true,
       }
       const transaction2 = await prepareWithdraw(argv2)
       await execTransaction(masterSafe, safeOwner.privateKey, transaction2)
@@ -447,8 +434,6 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address],
-        withdraw: true,
-        transferFundsToMaster: true,
       }
       const transaction = await prepareWithdraw(argv)
       // if the built transaction used the token balance of the bracket instead of zero, then
@@ -462,41 +447,6 @@ contract("Withdraw script", function (accounts) {
       {
         argv: {},
         error: "Argument error: --masterSafe is required",
-      },
-      {
-        argv: {
-          masterSafe: masterSafe.address,
-          withdrawalFile: "/dev/null",
-          requestWithdraw: true,
-          withdraw: true,
-        },
-        error: "Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster",
-      },
-      {
-        argv: {
-          masterSafe: masterSafe.address,
-          withdrawalFile: "/dev/null",
-          requestWithdraw: true,
-          transferFundsToMaster: true,
-        },
-        error: "Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster",
-      },
-      {
-        argv: {
-          masterSafe: masterSafe.address,
-          withdrawalFile: "/dev/null",
-          requestWithdraw: true,
-          withdraw: true,
-          transferFundsToMaster: true,
-        },
-        error: "Argument error: --requestWithdraw cannot be used with any of --withdraw, --transferFundsToMaster",
-      },
-      {
-        argv: {
-          masterSafe: masterSafe.address,
-          withdrawalFile: "/dev/zero",
-        },
-        error: "Argument error: one of --requestWithdraw, --withdraw, --transferFundsToMaster must be given",
       },
       {
         argv: {


### PR DESCRIPTION
Split the withdraw script into two scripts: `request_withdraw.js` and `withdraw.js`.
All four logical steps in the script have now their own function. They are:
1. requesting a withdrawal
2. withdrawing from the exchange to the brackets
3. transferring ERC20 tokens from the brackets to master
4. simultaneous 2 and 3

Since I had to work on it anyway, I also changed the focus of the documentation from a deposit file to `--brackets` and `--tokenIds`.

PR is relevant to @josojo because it changes the tutorial on how to use the scripts.

Closes #222.