### PR TITLE
Parallelize checks for complete liquidity provision

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -55,7 +55,7 @@ const argv = default_yargs
 module.exports = async (callback) => {
   try {
     const masterSafePromise = getSafe(argv.masterSafe)
-    const exchange = await getExchange(web3)
+    const exchange = await getExchange()
 
     // check price against dex.ag's API
     const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [argv.baseTokenId, argv.quoteTokenId])

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -93,6 +93,7 @@ const findBracketsWithExistingOrders = async function (bracketAddresses, exchang
 
 module.exports = async (callback) => {
   try {
+    // initialize promises that will be used later in the code to speed up execution
     const exchangePromise = getExchange()
     const masterSafePromise = getSafe(argv.masterSafe)
     const signerPromise = web3.eth.getAccounts().then((accounts) => accounts[0])

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -1,5 +1,4 @@
 const assert = require("assert")
-const Contract = require("@truffle/contract")
 
 const {
   deployFleetOfSafes,
@@ -8,6 +7,8 @@ const {
   buildOrders,
   checkSufficiencyOfBalance,
   hasExistingOrders,
+  getSafe,
+  getExchange,
 } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { signAndSend } = require("./utils/sign_and_send")(web3, artifacts)
 const { verifyBracketsWellFormed } = require("./utils/verify_scripts")(web3, artifacts)
@@ -81,42 +82,62 @@ const argv = default_yargs
   })
   .check(checkBracketsForDuplicate).argv
 
+const findBracketsWithExistingOrders = async function (bracketAddresses, exchange) {
+  const existingOrders = await Promise.all(
+    bracketAddresses.map(async (safeAddr) => {
+      return hasExistingOrders(safeAddr, exchange)
+    })
+  )
+  return bracketAddresses.filter((_, i) => existingOrders[i])
+}
+
 module.exports = async (callback) => {
   try {
-    const signer = (await web3.eth.getAccounts())[0]
-    console.log("Using account:", signer)
-    // Init params
-    const GnosisSafe = artifacts.require("GnosisSafe")
-    const masterSafe = await GnosisSafe.at(argv.masterSafe)
-    const BatchExchange = Contract(require("@gnosis.pm/dex-contracts/build/contracts/BatchExchange"))
-    BatchExchange.setProvider(web3.currentProvider)
-    const exchange = await BatchExchange.deployed()
+    const exchangePromise = getExchange()
+    const masterSafePromise = getSafe(argv.masterSafe)
+    const signerPromise = web3.eth.getAccounts().then((accounts) => accounts[0])
+    const masterOwnersPromise = masterSafePromise.then((masterSafe) => masterSafe.getOwners())
+    let assertBracketsWellFormedPromise
+    let bracketsWithExistingOrdersPromise
+    let bracketAddresses
+    if (argv.brackets) {
+      bracketAddresses = argv.brackets
+      assertBracketsWellFormedPromise = verifyBracketsWellFormed(argv.masterSafe, bracketAddresses, null, null, true)
+      bracketsWithExistingOrdersPromise = exchangePromise.then((exchange) =>
+        findBracketsWithExistingOrders(bracketAddresses, exchange)
+      )
+    }
 
+    const exchange = await exchangePromise
     const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [argv.baseTokenId, argv.quoteTokenId])
     const baseTokenData = await tokenInfoPromises[argv.baseTokenId]
     const quoteTokenData = await tokenInfoPromises[argv.quoteTokenId]
     const { instance: baseToken, decimals: baseTokenDecimals } = baseTokenData
     const { instance: quoteToken, decimals: quoteTokenDecimals } = quoteTokenData
-
     const depositBaseToken = toErc20Units(argv.depositBaseToken, baseTokenDecimals)
     const depositQuoteToken = toErc20Units(argv.depositQuoteToken, quoteTokenDecimals)
+    const isBaseTokenBalanceSufficientPromise = checkSufficiencyOfBalance(baseToken, argv.masterSafe, depositBaseToken)
+    const isQuoteTokenBalanceSufficientPromise = checkSufficiencyOfBalance(quoteToken, argv.masterSafe, depositQuoteToken)
+    const priceCheckPromise = isPriceReasonable(baseTokenData, quoteTokenData, argv.currentPrice)
 
-    assert((await masterSafe.getOwners()).includes(signer), `Please ensure signer account ${signer} is an owner of masterSafe`)
+    const signer = await signerPromise
+    console.log("Using account:", signer)
+    assert((await masterOwnersPromise).includes(signer), `Please ensure signer account ${signer} is an owner of masterSafe`)
 
     if (argv.brackets) {
       assert(argv.numBrackets === argv.brackets.length, "Please ensure numBrackets equals number of brackets")
     }
 
     console.log("==> Performing safety checks")
-    if (!(await checkSufficiencyOfBalance(baseToken, masterSafe.address, depositBaseToken))) {
-      callback(`Error: MasterSafe ${masterSafe.address} has insufficient balance for base token ${baseToken.address}`)
+    if (!(await isBaseTokenBalanceSufficientPromise)) {
+      callback(`Error: MasterSafe ${argv.masterSafe} has insufficient balance for base token ${baseToken.address}`)
     }
-    if (!(await checkSufficiencyOfBalance(quoteToken, masterSafe.address, depositQuoteToken))) {
-      callback(`Error: MasterSafe ${masterSafe.address} has insufficient balance for quote token ${quoteToken.address}`)
+    if (!(await isQuoteTokenBalanceSufficientPromise)) {
+      callback(`Error: MasterSafe ${argv.masterSafe} has insufficient balance for quote token ${quoteToken.address}`)
     }
+
     // check price against dex.ag's API
-    const priceCheck = await isPriceReasonable(baseTokenData, quoteTokenData, argv.currentPrice)
-    if (!priceCheck) {
+    if (!(await priceCheckPromise)) {
       if (!(await proceedAnyways("Price check failed!"))) {
         callback("Error: Price checks did not pass")
       }
@@ -131,20 +152,13 @@ module.exports = async (callback) => {
       callback("Error: Choose a smaller numBrackets, otherwise your payload will be to big for Infura nodes")
     }
 
-    let bracketAddresses
     if (argv.brackets) {
-      console.log("==> Skipping safe deployment and using brackets safeOwners")
+      console.log("==> Skipping safe deployment and using brackets")
       bracketAddresses = argv.brackets
-      await verifyBracketsWellFormed(masterSafe.address, bracketAddresses, null, null, true)
-      // Detect if provided brackets have existing orders.
-      const existingOrders = await Promise.all(
-        bracketAddresses.map(async (safeAddr) => {
-          return hasExistingOrders(safeAddr, exchange)
-        })
-      )
-      const dirtyBrackets = bracketAddresses.filter((_, i) => existingOrders[i] == true)
+      await assertBracketsWellFormedPromise
+      const dirtyBrackets = await bracketsWithExistingOrdersPromise
       if (
-        existingOrders.some((t) => t) &&
+        dirtyBrackets.length !== 0 &&
         !(await proceedAnyways(`The following brackets have existing orders:\n  ${dirtyBrackets.join()}\n`))
       ) {
         callback("Error: Existing order verification failed.")
@@ -152,7 +166,7 @@ module.exports = async (callback) => {
     } else {
       assert(!argv.verify, "Trading Brackets need to be provided via --brackets when verifying a transaction")
       console.log(`==> Deploying ${argv.numBrackets} trading brackets`)
-      bracketAddresses = await deployFleetOfSafes(masterSafe.address, argv.numBrackets)
+      bracketAddresses = await deployFleetOfSafes(argv.masterSafe, argv.numBrackets)
       console.log("List of deployed brackets:", bracketAddresses.join())
       // Sleeping for 3 seconds to make sure Infura nodes have processed
       // all newly deployed contracts so they can be awaited.
@@ -161,7 +175,7 @@ module.exports = async (callback) => {
 
     console.log("==> Building orders and deposits")
     const orderTransaction = await buildOrders(
-      masterSafe.address,
+      argv.masterSafe,
       bracketAddresses,
       argv.baseTokenId,
       argv.quoteTokenId,
@@ -170,7 +184,7 @@ module.exports = async (callback) => {
       true
     )
     const bundledFundingTransaction = await buildTransferApproveDepositFromOrders(
-      masterSafe.address,
+      argv.masterSafe,
       bracketAddresses,
       baseToken.address,
       quoteToken.address,
@@ -190,6 +204,7 @@ module.exports = async (callback) => {
       console.log("==> Order placing transaction")
     }
     let nonce = argv.nonce
+    const masterSafe = await masterSafePromise
     if (nonce === undefined) {
       nonce = (await masterSafe.nonce()).toNumber()
     }


### PR DESCRIPTION
Makes complete liquidity provision faster by parallelizing things with async/await.
I intentionally avoided `Promise.all` for readability and efficiency.

Running times to the first check, assuming brackets are not given.
- before this PR: 19±1s
- after this PR: 13±1s
Considering that Truffle itself takes 6±1s to initialize, the running time of the logic in this script was reduced by a factor of 2.

If brackets are given the script should be even more efficient in comparison.

Closes #277.

The script can be tried with `npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=4 --lowestLimit=210 --highestLimit=230 --currentPrice=220 --depositBaseToken=0.01 --depositQuoteToken=1 --numBrackets=20 --network=rinkeby  --masterSafe=FILLME`, assuming master has USDC and WETH.
A follow-up test is to try the same command with the extra option ` --brackets=`. 