### PR TITLE
Simplify installation steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ before_install:
   - rm -rf build
   - npm install -g yarn@latest
   - yarn --version
-  - npm install -g ganache-cli@latest
-  - ganache-cli --version
 before_script:
-  - ganache-cli -l 8e6 > /dev/null &
+  - ganache-cli --version
+  - yarn testnet > /dev/null &
 script:
   - yarn lint
   - yarn pretty-check
+  - yarn build
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - npm install -g yarn@latest
   - yarn --version
 before_script:
-  - ganache-cli --version
   - yarn testnet > /dev/null &
 script:
   - yarn lint

--- a/README.md
+++ b/README.md
@@ -17,16 +17,25 @@ yarn install
 Note that the installation might be successful even if errors are shown in the console output.
 In case of doubt, running `echo $?` immediately after `yarn install` should return 0 if the installation was successful.
 
-Run Ganache in the background with an increased gas limit (this is needed to deploy Gnosis Protocol):
-
+Build Truffle artifacts:
 ```
-npx ganache-cli --gasLimit=80000000
+yarn build
 ```
 
-Run test:
+This concludes the setup procedures.
+Any liquidity provision script can be run at this point.
+See `scripts/README.md` for details.
 
+## How to test
+
+Start and keep the test Ethereum network running in the background:
 ```
-npx truffle test
+yarn testnet
+```
+
+Run tests:
+```
+yarn test
 ```
 
 Use scripts as described in `scripts/README.md`.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "truffle test",
     "build": "yarn compile && yarn networks-inject",
     "compile": "truffle compile",
+    "testnet": "ganache-cli --gasLimit 8e6",
     "migrate": "truffle migrate",
     "verify": "truffle run verify",
     "flatten": "export FLATTENED_DIR=\"./build/flattenedContracts\" && mkdir -p $FLATTENED_DIR && npx sol-merger \"contracts/*.sol\" $FLATTENED_DIR && echo \"Flattened contracts stored in $FLATTENED_DIR\" && unset FLATTENED_DIR",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier": "prettier --write './**/*.js'",
     "pretty-check": "prettier --check './**/*.js'",
     "test": "truffle test",
+    "build": "yarn compile && yarn networks-inject",
     "compile": "truffle compile",
     "migrate": "truffle migrate",
     "verify": "truffle run verify",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,12 +8,11 @@ Use at your own risk!
 
 The scripts require the following software installed: [git](https://git-scm.com/), [yarn](https://yarnpkg.com/) and [node](https://nodejs.org/en/).
 
-The Gnosis Protocol contracts must be compiled and the deployment addresses must be injected into built contract-artifacts.
-To do so, run:
 
+Install needed dependencies and build needed artifact:
 ```
-yarn compile
-yarn run networks-inject
+yarn install
+yarn builD
 ```
 
 Create a gnosis-safe wallet [here-mainnet](https://gnosis-safe.io) or [here-rinkeby](https://rinkeby.gnosis-safe.io). This wallet will be called your Master Safe in the following. It is used to bundle the transactions and setup the bracket-traders.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,11 +8,11 @@ Use at your own risk!
 
 The scripts require the following software installed: [git](https://git-scm.com/), [yarn](https://yarnpkg.com/) and [node](https://nodejs.org/en/).
 
-
 Install needed dependencies and build needed artifact:
+
 ```
 yarn install
-yarn builD
+yarn build
 ```
 
 Create a gnosis-safe wallet [here-mainnet](https://gnosis-safe.io) or [here-rinkeby](https://rinkeby.gnosis-safe.io). This wallet will be called your Master Safe in the following. It is used to bundle the transactions and setup the bracket-traders.


### PR DESCRIPTION
Creates more yarn scripts to simplify setting up of the project and adds building artifacts to Travis.
Might be interesting to amend the tutorial with this new procedure, @josojo. (I could also do it instead.)

To test the new commands, check that [Travis is working as expected](https://travis-ci.com/github/gnosis/dex-liquidity-provision/builds/169430145) and try to reinstall this repo from scratch:
```
git clone https://github.com/gnosis/dex-liquidity-provision.git
cd dex-liquidity-provision
yarn install
yarn build
```
and then try to run any of the scripts in Rinkeby.