### PR TITLE
Fix bytecode check

### DIFF
--- a/scripts/utils/verify_scripts.js
+++ b/scripts/utils/verify_scripts.js
@@ -27,6 +27,19 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     const master = await getSafe(masterAddress)
     const brackets = await Promise.all(bracketAddresses.map((bracketAddress) => getSafe(bracketAddress)))
 
+    // TODO - enable this verification according to discussion in
+    // https://github.com/gnosis/dex-liquidity-provision/issues/217
+    // log("- Verify proxy bytecode")
+    // await Promise.all(
+    //   bracketAddresses.map(async (bracketAddress) => {
+    //     assert.equal(
+    //       await web3.eth.getCode(bracketAddress),
+    //       GnosisSafeProxy.deployedBytecode,
+    //       `Bytecode at bracket ${bracketAddress} does not agree with that GnosisSafeProxy v1.1.1`
+    //     )
+    //   })
+    // )
+
     if (!masterOwners || !masterThreshold) log("Warning: master safe owner verification skipped")
     else {
       log("- Verify owners of masterSafe")
@@ -43,18 +56,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
         "Master owners are different than expected"
       )
     }
-    // TODO - enable this verification according to discussion in
-    // https://github.com/gnosis/dex-liquidity-provision/issues/217
-    // log("- Verify proxy bytecode")
-    // await Promise.all(
-    //   bracketAddresses.map(async (bracketAddress) => {
-    //     assert.equal(
-    //       await web3.eth.getCode(bracketAddress),
-    //       GnosisSafeProxy.deployedBytecode,
-    //       `Bytecode at bracket ${bracketAddress} does not agree with that GnosisSafeProxy v1.1.1`
-    //     )
-    //   })
-    // )
 
     log("- Verify that brackets are owned solely by masterSafe")
     await Promise.all(

--- a/scripts/utils/verify_scripts.js
+++ b/scripts/utils/verify_scripts.js
@@ -13,8 +13,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const GnosisSafe = artifacts.require("GnosisSafe.sol")
   const GnosisSafeProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
   const gnosisSafeMasterCopy = GnosisSafe.deployed()
-  const expectedBytecodePromise = GnosisSafeProxyFactory.deployed().then(proxyFactory => proxyFactory.proxyRuntimeCode())
-
+  const expectedBytecodePromise = GnosisSafeProxyFactory.deployed().then((proxyFactory) => proxyFactory.proxyRuntimeCode())
 
   const verifyBracketsWellFormed = async function (
     masterAddress,

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -172,7 +172,6 @@ contract("Verification checks", function (accounts) {
       await assert.rejects(verifyCorrectSetup([evilProxy.address], masterSafe.address), {
         message: `Bytecode at bracket ${evilProxy.address} does not agree with that of a Gnosis Safe Proxy v1.1.1`,
       })
-      // TODO - this test only checks against bad proxy, but not against a bad safe.
     })
   })
   describe("No modules are installed", async () => {

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -170,7 +170,7 @@ contract("Verification checks", function (accounts) {
       const evilSafe = await GnosisSafe.at(evilProxy.address)
       await evilSafe.setup([masterSafe.address], "1", ZERO_ADDRESS, "0x", ZERO_ADDRESS, ZERO_ADDRESS, "0", ZERO_ADDRESS)
       await assert.rejects(verifyCorrectSetup([evilProxy.address], masterSafe.address), {
-        message: `Bytecode at bracket ${evilProxy.address} does not agree with that of a GnosisSafeProxy v1.1.1`,
+        message: `Bytecode at bracket ${evilProxy.address} does not agree with that of a Gnosis Safe Proxy v1.1.1`,
       })
       // TODO - this test only checks against bad proxy, but not against a bad safe.
     })

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -170,7 +170,7 @@ contract("Verification checks", function (accounts) {
       const evilSafe = await GnosisSafe.at(evilProxy.address)
       await evilSafe.setup([masterSafe.address], "1", ZERO_ADDRESS, "0x", ZERO_ADDRESS, ZERO_ADDRESS, "0", ZERO_ADDRESS)
       await assert.rejects(verifyCorrectSetup([evilProxy.address], masterSafe.address), {
-        message: `Bytecode at bracket ${evilProxy.address} does not agree with that of a GnosisSafeProxy v1.1.1`
+        message: `Bytecode at bracket ${evilProxy.address} does not agree with that of a GnosisSafeProxy v1.1.1`,
       })
       // TODO - this test only checks against bad proxy, but not against a bad safe.
     })

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -5,7 +5,7 @@ const { getUnlimitedOrderAmounts } = require("@gnosis.pm/dex-contracts")
 
 const GnosisSafe = artifacts.require("GnosisSafe")
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
-// const EvilGnosisSafeProxy = artifacts.require("EvilGnosisSafeProxy")
+const EvilGnosisSafeProxy = artifacts.require("EvilGnosisSafeProxy")
 
 const { verifyCorrectSetup } = require("../scripts/utils/verify_scripts")(web3, artifacts)
 const { addCustomMintableTokenToExchange, createTokenAndGetData, deploySafe } = require("./test_utils")
@@ -18,7 +18,7 @@ const {
   buildTransferApproveDepositFromOrders,
 } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
 const { buildExecTransaction } = require("../scripts/utils/internals")(web3, artifacts)
-const { DEFAULT_ORDER_EXPIRY, CALL /*, ZERO_ADDRESS*/ } = require("../scripts/utils/constants")
+const { DEFAULT_ORDER_EXPIRY, CALL, ZERO_ADDRESS } = require("../scripts/utils/constants")
 
 contract("verification checks - for allowances", async (accounts) => {
   describe("allowances", async () => {
@@ -163,18 +163,18 @@ contract("Verification checks", function (accounts) {
       })
     })
   })
-  // describe("Brackets' deployed bytecode coincides with that of a Gnosis Safe proxy", async () => {
-  //   it("throws if bytecode differs", async () => {
-  //     const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner], 1))
-  //     const evilProxy = await EvilGnosisSafeProxy.new(GnosisSafe.address)
-  //     const evilSafe = await GnosisSafe.at(evilProxy.address)
-  //     await evilSafe.setup([masterSafe.address], "1", ZERO_ADDRESS, "0x", ZERO_ADDRESS, ZERO_ADDRESS, "0", ZERO_ADDRESS)
-  //     await assert.rejects(verifyCorrectSetup([evilProxy.address], masterSafe.address), {
-  //       message: `Bytecode at bracket ${evilProxy.address} does not agree with that GnosisSafeProxy v1.1.1`
-  //     })
-  //     // TODO - this test only checks against bad proxy, but not agains bad safe.
-  //   })
-  // })
+  describe("Brackets' deployed bytecode coincides with that of a Gnosis Safe proxy", async () => {
+    it("throws if bytecode differs", async () => {
+      const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner], 1))
+      const evilProxy = await EvilGnosisSafeProxy.new(GnosisSafe.address)
+      const evilSafe = await GnosisSafe.at(evilProxy.address)
+      await evilSafe.setup([masterSafe.address], "1", ZERO_ADDRESS, "0x", ZERO_ADDRESS, ZERO_ADDRESS, "0", ZERO_ADDRESS)
+      await assert.rejects(verifyCorrectSetup([evilProxy.address], masterSafe.address), {
+        message: `Bytecode at bracket ${evilProxy.address} does not agree with that of a GnosisSafeProxy v1.1.1`
+      })
+      // TODO - this test only checks against bad proxy, but not against a bad safe.
+    })
+  })
   describe("No modules are installed", async () => {
     it("throws if module is present in master", async () => {
       const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner], 1))


### PR DESCRIPTION
Reintroduces proxy bytecode verification. See discussion in issue #217.

Unrelated to this PR, but note that the verification script could be made much faster with the same simple tricks used in PR #286.

Closes #217.

Test plan: unit test for bytecode changes was restored.
On mainnet, this should be successful:
```
npx truffle exec scripts/verify_correctness.js  --network=mainnet --brackets=0x7c46953a4f0b404e21ebc0d69883adaef5aaa5c5 --masterSafe=0x5CC3a4C846aB8b0B78a729b8B1a50e2E0BB66740
```
and this should fail:
```
npx truffle exec scripts/verify_correctness.js  --network=mainnet --brackets=0xaafd977483df35bc90c27abbf96e6f7df5143013 --masterSafe=0x5CC3a4C846aB8b0B78a729b8B1a50e2E0BB66740
```