### PR TITLE
[Synthetix] Place orders only when likely match

### DIFF
--- a/scripts/synthetix/facilitate_trade.js
+++ b/scripts/synthetix/facilitate_trade.js
@@ -65,6 +65,12 @@ const estimatePrice = async function (buyTokenId, sellTokenId, sellAmount, netwo
 
 const MIN_SELL_USD = 10
 
+/* All prices refered to hear are for sETH in sUSD.
+ * The term "our" referres to prices we are buying and selling for while
+ * the term "their" refers to the buy and sell prices offered by the exchange.
+ * For example, if ourBuyPrice = 100 and theirSellPrice = 90, this means
+ * we are willing to pay 100 sUSD for 1 ETH and the exchange is offering 1 ETH for 90 sUSD
+ */
 module.exports = async (callback) => {
   try {
     const networkId = await web3.eth.net.getId()

--- a/scripts/synthetix/facilitate_trade.js
+++ b/scripts/synthetix/facilitate_trade.js
@@ -134,7 +134,7 @@ module.exports = async (callback) => {
       // If we are willing to sell at a price less than exchange quote.
       console.log(`Placing an order to sell sETH at ${ourSellETHRate}`)
       const { base: sellETHAmount, quote: buySUSDAmount } = getUnlimitedOrderAmounts(
-        formatedRate * (1 + sETHTosUSDFee),
+        ourSellETHRate,
         sUSD.decimals,
         sETH.decimals
       )

--- a/scripts/synthetix/facilitate_trade.js
+++ b/scripts/synthetix/facilitate_trade.js
@@ -65,11 +65,12 @@ const estimatePrice = async function (buyTokenId, sellTokenId, sellAmount, netwo
 
 const MIN_SELL_USD = 10
 
-/* All prices refered to hear are for sETH in sUSD.
- * The term "our" referres to prices we are buying and selling for while
- * the term "their" refers to the buy and sell prices offered by the exchange.
- * For example, if ourBuyPrice = 100 and theirSellPrice = 90, this means
- * we are willing to pay 100 sUSD for 1 ETH and the exchange is offering 1 ETH for 90 sUSD
+/* All prices, except those explicitly named with "inverted" refer to the price of sETH in sUSD.
+ * The term "our" is with regards to prices we, the synthetix bot, are buying and selling for while
+ * the term "their" refers to the buy and sell prices offered by the Gnosis Protocol.
+ * For example, if ourBuyPrice = 100 and theirSellPrice = 90, this means that
+ * the synthetix platform is willing to spend 100 sUSD for 1 sETH
+ * and the Gnosis Protocol is currently offering 1 sETH for 90 sUSD.
  */
 module.exports = async (callback) => {
   try {

--- a/scripts/utils/printing_tools.js
+++ b/scripts/utils/printing_tools.js
@@ -1,3 +1,4 @@
+const assert = require("assert")
 const BN = require("bn.js")
 
 const { ZERO, BN256, MAXUINT256, TEN } = require("./constants")
@@ -40,6 +41,9 @@ const toErc20Units = function (amount, decimals) {
  * @returns {BN} number of token units corresponding to the input amount
  */
 const floatToErc20Units = function (amount, decimals) {
+  // TODO - This method is expected to fail for amounts > 10^20 so we impose a temporary bandaid "assertion"
+  // Please refer to https://github.com/gnosis/dex-liquidity-provision/issues/302
+  assert(amount <= 10 ** 20)
   return toErc20Units(amount.toString(), decimals)
 }
 

--- a/scripts/utils/printing_tools.js
+++ b/scripts/utils/printing_tools.js
@@ -32,6 +32,18 @@ const toErc20Units = function (amount, decimals) {
 }
 
 /**
+ * A generalized version of "toWei" for tokens with an arbitrary amount of decimals.
+ * If the decimal representation has more decimals than the maximum amount possible, then the extra decimals are truncated.
+ *
+ * @param {number} amount Float representation for the amount of some ERC20 token
+ * @param {(number|string|BN)} decimals Maximum number of decimals of the token
+ * @returns {BN} number of token units corresponding to the input amount
+ */
+const floatToErc20Units = function (amount, decimals) {
+  return toErc20Units(amount.toString(), decimals)
+}
+
+/**
  * A generalized version of "fromWei" for tokens with an arbitrary amount of decimals.
  *
  * @param {(string|BN)} amount Decimal representation of the (integer) number of token units
@@ -66,6 +78,7 @@ const shortenedAddress = function (address) {
 
 module.exports = {
   toErc20Units,
+  floatToErc20Units,
   fromErc20Units,
   shortenedAddress,
 }


### PR DESCRIPTION
Closes #282. 

This PR improves the synthetix script to only place order when there is a likely match according to the query from price estimation service. 

**Test Plan:**

Run

```sh
truffle exec scripts/synthetix/facilitate_trade.js --network mainnet
```
and observe the logs:

```
Using network 'mainnet'.

Using account 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1
Oracle sETH Price (in sUSD) 243.3257626212688802
Exchange buy  sETH price (in sUSD) 246.6144973941891
Exchange sell sETH price (in sUSD) 233.72582778494302
Not placing buy  sETH order, our rate of 242.60 is too low  for exchange.
Not placing sell sETH order, our rate of 244.06 is too high for exchange.
```

On Rinkeby (i.e. where there is no s-liquidity), 

```sh
truffle exec scripts/synthetix/facilitate_trade.js --network rinkeby
```
with log output:

```
Using network 'rinkeby'.

Using account 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1
Oracle sETH Price (in sUSD) 243.19490611887486801
Exchange buy  sETH price (in sUSD) Infinity
Exchange sell sETH price (in sUSD) 0
Not placing buy  sETH order, our rate of 241.98 is too low  for exchange.
Not placing sell sETH order, our rate of 244.41 is too high for exchange.
```


**Update Test Plan** @fleupold  mentioned it would be nice to have an example in which there is actually a matching order:


After placing an order to sell 15 sUSD for sETH at a price of 250.xx (much more than the current rate) and running this script we find:

<img width="495" alt="Screenshot 2020-06-10 at 11 28 58 AM" src="https://user-images.githubusercontent.com/11778116/84251588-db46db80-ab0d-11ea-8021-b7e87d86753f.png">


```
➜  dex-liquidity-provision git:(282/synth_gas_savings) truffle exec scripts/synthetix/facilitate_trade.js --network mainnet
Using network 'mainnet'.

Using account 0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1
Oracle sETH Price (in sUSD) 242.74183486202928576
Exchange sell sETH price (in sUSD) 251.75399416750443
Exchange buy  sETH price (in sUSD) 249.74803241942786
Not placing buy  sETH order, our rate of 242.01 is too low  for exchange.
Placing an order to sell sETH at 242.8632057794603
Using current "standard" gas price scaled by 1: 36000000001
```

Unfortunately, we cannot test that this bot will actually place the orders until there is a match (and rinkeby does not contain any liquidity. 