### PR TITLE
Improve fetching token info for non-standard ERC20

### DIFF
--- a/scripts/utils/hardcoded_tokens.json
+++ b/scripts/utils/hardcoded_tokens.json
@@ -1,0 +1,15 @@
+{
+  "1": {
+    "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359": {
+      "name": "Sai Stablecoin v1.0",
+      "symbol": "SAI",
+      "decimals": 18
+    },
+    "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2": {
+      "name": "Maker",
+      "symbol": "MKR",
+      "decimals": 18
+    }
+  },
+  "4": {} 
+}

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -79,7 +79,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
   /**
    * Returns the symbol of the ERC20 token in input.
-   * Returns the velue from a list if present, otherwise executes a contract call.
+   * Returns the value from a list if present, otherwise executes a contract call.
    *
    * @param {string} method the name of the methods that (can be "symbol", "decimals", or "name")
    * @param {SmartContract} tokenInstance instance of the token at the previous address

--- a/test/fetch_token_info.js
+++ b/test/fetch_token_info.js
@@ -1,0 +1,26 @@
+const TestToken = artifacts.require("DetailedMintableToken")
+
+const { tokenDetail } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
+
+contract("FetchTokenInfo", () => {
+  describe("tokenDetail", () => {
+    it("relies on network for tokens outside list", async () => {
+      const token = await TestToken.new("DAI", 18)
+      assert.strictEqual(await tokenDetail("symbol", token), "DAI")
+      assert.strictEqual(await tokenDetail("decimals", token), 18)
+    })
+    it("relies on list if token is present there", async () => {
+      const saiToken = { constructor: { network_id: 1 }, address: "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359" }
+      assert.strictEqual(await tokenDetail("symbol", saiToken), "SAI")
+      assert.strictEqual(await tokenDetail("decimals", saiToken), 18)
+    })
+    it("ignores list if token is present but on another network", async () => {
+      const notSaiToken = {
+        constructor: { network_id: 4 },
+        address: "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
+        symbol: () => "not SAI",
+      }
+      assert.strictEqual(await tokenDetail("symbol", notSaiToken), "not SAI")
+    })
+  })
+})


### PR DESCRIPTION
Closes #226.

Some tokens don't define their symbol or number of decimals, or have an output type that is not that of the functions as defined by `ERC20Detailed`.
This PR handles these exceptions as follows:
- check if token is in whitelist, if so return values from list.
- perform network request, if successful return result.
- if request fails for any reason, return a more helpful error message.

Note that the script still fails if the symbol or number of decimals is not known after a network request. This is because decimals are needed by the script, and a missing symbol could be telling the user that at the chosen address there is no ERC20 token.

### Test plan

I added tests for the newly introduced function.

I also tried out the command that appears in the linked issue (using WETH to make the tokens fail the price check), but only after removing the checks that the proposed is an owner. Then I ran the script with the default Ganache address and saw that the execution was successful until the WETH balance check.
```
# remove ownership check from complete_liquidity_provision!
npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=23 --quoteTokenId=1 --lowestLimit=320 --highestLimit=720 --currentPrice=503 --masterSafe=0x5CC3a4C846aB8b0B78a729b8B1a50e2E0BB66740 --depositBaseToken=156.25 --depositQuoteToken=65000 --numBrackets=14 --network=mainnet
```
Expected result:
```
Using network 'mainnet'.

Using account: 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
==> Performing safety checks
Warning: the chosen price differs by more than 2 percent from the price found on dex.ag.
         chosen price: 503 WETH bought for 1 MKR
         dex.ag price: 2.08282529334201945798 WETH bought for 1 MKR
Error: MasterSafe 0x5CC3a4C846aB8b0B78a729b8B1a50e2E0BB66740 has insufficient balance for quote token 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
Truffle v5.1.31 (core: 5.1.31)
Node v12.16.3
```