### PR TITLE
Replace dex.ag exchange with 1inch

### DIFF
--- a/scripts/typedef.js
+++ b/scripts/typedef.js
@@ -76,7 +76,7 @@
  * @property {string} symbol symbol representing the token
  * @property {(number|BN)} decimals number of decimals of the token
  * @property {Address} address address of the token contract on the EVM
- * @property {object} instance an instance of the token contract
+ * @property {SmartContract} instance an instance of the token contract
  */
 
 /**

--- a/test/price_utils.js
+++ b/test/price_utils.js
@@ -18,8 +18,16 @@ contract("PriceOracle", function (accounts) {
       //the following test especially checks that the price p is not inverted (1/p) and is not below 1
       const acceptedPriceDeviationInPercentage = 99
       const price = 1000
-      const baseTokenData = { symbol: "WETH" }
-      const quoteTokenData = { symbol: "DAI" }
+      const baseTokenData = { symbol: "WETH", decimals: 18 }
+      const quoteTokenData = { symbol: "DAI", decimals: 18 }
+      assert(await isPriceReasonable(baseTokenData, quoteTokenData, price, acceptedPriceDeviationInPercentage))
+    })
+    it("checks that price is within reasonable range (10 ≤ price ≤ 1990) for tokens with different decimals", async () => {
+      //the following test especially checks that the price p is not inverted (1/p) and is not below 1
+      const acceptedPriceDeviationInPercentage = 99
+      const price = 1000
+      const baseTokenData = { symbol: "WETH", decimals: 18 }
+      const quoteTokenData = { symbol: "USDC", decimals: 6 }
       assert(await isPriceReasonable(baseTokenData, quoteTokenData, price, acceptedPriceDeviationInPercentage))
     })
     it("checks that bracket traders does not sell unprofitable for tokens with the same decimals", async () => {


### PR DESCRIPTION
Closes #328.

Basic implementation of the 1inch API, which is used to replace dex.ag to make the price ckeck available for more tokens. Note that the price we compute from 1inch is however less reliable from that of dex.ag because 1inch returns an exact selling/buying price for a specific amount, while we want a price that gives a general overview of the value of the token like dex.ag does.

### Test plan
See the price check failing with this command deploying brackets for the pair OWL/USDC at an unrealistic price of 100 and see that the suggested price is right (a bit more than 1 OWL per USDC). (Note the two tokens have different decimals.)
```
npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=4 --quoteTokenId=0 --lowestLimit=210 --highestLimit=230 --currentPrice=100 --depositBaseToken=0.01 --depositQuoteToken=1 --numBrackets=20  --masterSafe=0xd9395aeE9141a3Efeb6d16057c8f67fBE296734c --network=rinkeby
```
```
<snip>
Warning: the chosen price differs by more than 2 percent from the price found on dex.ag.
         chosen price: 100 OWL bought for 1 USDC
         dex.ag price: 1.0660178208889928 OWL bought for 1 USDC
```