### PR TITLE
Add function to retrieve output of quickest promise

### DIFF
--- a/scripts/utils/js_helpers.js
+++ b/scripts/utils/js_helpers.js
@@ -19,44 +19,6 @@ const sleep = function (milliseconds) {
 }
 
 /**
- * Helper function for returnFirstNotErroring. Returns a promise that
- * resolves to the value of the earliest input promise to resolve, or
- * rejects with a combined error if both promises reject.
- *
- * @param {Promise} combinedPromises promise combining other promises
- * with the same logic as in this function
- * @param {Promise} appendedPromise promise to add to combinedPromises
- * @returns {Promise} timeout
- */
-const appendPromise = (combinedPromises, appendedPromise) =>
-  new Promise((resolve, reject) => {
-    let combinedIsCaught = false
-    let combinedErrors
-    let appendedIsCaught = false
-    let appendedError
-    appendedPromise
-      .then((result) => resolve(result))
-      .catch((error) => {
-        appendedError = error.message || error
-        if (combinedIsCaught) {
-          reject(new Error(appendedError + " && " + combinedErrors))
-        } else {
-          appendedIsCaught = true
-        }
-      })
-    combinedPromises
-      .then((result) => resolve(result))
-      .catch((error) => {
-        combinedErrors = error.message || error
-        if (appendedIsCaught) {
-          reject(new Error(appendedError + " && " + combinedErrors))
-        } else {
-          combinedIsCaught = true
-        }
-      })
-  })
-
-/**
  * Given an array of promises, returns a promise resolving to the
  * output of the first resolving promise of the array. If any promise
  * has been rejected in the meantime, this failure is ignored. If all
@@ -69,33 +31,41 @@ const appendPromise = (combinedPromises, appendedPromise) =>
  * which is not yet availeble on Node.js.
  * https://tc39.es/proposal-promise-any/#sec-promise.any
  *
- * Behaviors that might be unexpected:
- * 1. Unlike Promise.any, if all input promises reject then the return
- *    value is a rejected promise returning an error with a message that
- *    concatenates all promise error messages (or output values, if
- *    message is not available) in the order they appear in the input
- *    array. (Promise.any returns an AggregateError.)
- * 2. Even if all input promises are already resolved, the output is
- *    a pending promise
+ * Unlike Promise.any, if all input promises reject then the return
+ * value is a rejected promise returning an error with a message that
+ * concatenates all promise error messages (or output values, if
+ * message is not available) in the order they appear in the input
+ * array. (Promise.any returns an AggregateError.)
  *
  * @param {Promise[]} promiseArray array of promises (or values)
  * @returns {Promise} promise returning the value returned by the
  * input promise that is the quickest to resolve
  */
-const returnFirstNotErroring = function (promiseArray) {
-  try {
-    if (promiseArray.length === 0) {
-      return Promise.reject()
+const returnFirstNotErroring = (promiseArray) =>
+  new Promise((resolve, reject) => {
+    let resolved = false
+    const errorPromises = []
+    for (const promise of promiseArray) {
+      errorPromises.push(
+        Promise.resolve(promise).then(
+          (result) => {
+            resolved = true
+            resolve(result)
+          },
+          (error) => error
+        )
+      )
     }
-    let combinedPromises = Promise.resolve(promiseArray[promiseArray.length - 1])
-    for (const promise of promiseArray.slice(0, -1).reverse()) {
-      combinedPromises = appendPromise(combinedPromises, Promise.resolve(promise))
-    }
-    return combinedPromises
-  } catch (error) {
-    return Promise.reject(error)
-  }
-}
+    Promise.all(errorPromises).then((errorArray) => {
+      if (!resolved) {
+        let errorString = ""
+        errorArray.forEach((error) => {
+          errorString += " && " + String(error.message || error)
+        })
+        reject(new Error(errorString.slice(4)))
+      }
+    })
+  })
 
 module.exports = {
   uniqueItems,

--- a/scripts/utils/js_helpers.js
+++ b/scripts/utils/js_helpers.js
@@ -59,11 +59,8 @@ const returnFirstNotErroring = (promiseArray) =>
     }
     Promise.all(errorPromises).then((errorArray) => {
       if (!resolved) {
-        let errorString = ""
-        errorArray.forEach((error) => {
-          errorString += " && " + String(error.message || error)
-        })
-        reject(new Error(errorString.slice(4)))
+        const errorString = errorArray.map((error) => String(error.message || error)).join(" && ")
+        reject(new Error(errorString))
       }
     })
   })

--- a/scripts/utils/js_helpers.js
+++ b/scripts/utils/js_helpers.js
@@ -18,7 +18,87 @@ const sleep = function (milliseconds) {
   return new Promise((r) => setTimeout(r, milliseconds))
 }
 
+/**
+ * Helper function for returnFirstNotErroring. Returns a promise that
+ * resolves to the value of the earliest input promise to resolve, or
+ * rejects with a combined error if both promises reject.
+ *
+ * @param {Promise} combinedPromises promise combining other promises
+ * with the same logic as in this function
+ * @param {Promise} appendedPromise promise to add to combinedPromises
+ * @returns {Promise} timeout
+ */
+const appendPromise = (combinedPromises, appendedPromise) =>
+  new Promise((resolve, reject) => {
+    let combinedIsCaught = false
+    let combinedErrors
+    let appendedIsCaught = false
+    let appendedError
+    appendedPromise
+      .then((result) => resolve(result))
+      .catch((error) => {
+        appendedError = error.message || error
+        if (combinedIsCaught) {
+          reject(new Error(appendedError + " && " + combinedErrors))
+        } else {
+          appendedIsCaught = true
+        }
+      })
+    combinedPromises
+      .then((result) => resolve(result))
+      .catch((error) => {
+        combinedErrors = error.message || error
+        if (appendedIsCaught) {
+          reject(new Error(appendedError + " && " + combinedErrors))
+        } else {
+          combinedIsCaught = true
+        }
+      })
+  })
+
+/**
+ * Given an array of promises, returns a promise resolving to the
+ * output of the first resolving promise of the array. If any promise
+ * has been rejected in the meantime, this failure is ignored. If all
+ * promises are rejected, returns a rejecting promise returning an
+ * error containing all error messages concatenated with "&&".
+ * If entries of the input array are not promises, they will be treated
+ * as promises resolving to the input value.
+ *
+ * This function is meant to be replaced in the future by Promise.any,
+ * which is not yet availeble on Node.js.
+ * https://tc39.es/proposal-promise-any/#sec-promise.any
+ *
+ * Behaviors that might be unexpected:
+ * 1. Unlike Promise.any, if all input promises reject then the return
+ *    value is a rejected promise returning an error with a message that
+ *    concatenates all promise error messages (or output values, if
+ *    message is not available) in the order they appear in the input
+ *    array. (Promise.any returns an AggregateError.)
+ * 2. Even if all input promises are already resolved, the output is
+ *    a pending promise
+ *
+ * @param {Promise[]} promiseArray array of promises (or values)
+ * @returns {Promise} promise returning the value returned by the
+ * input promise that is the quickest to resolve
+ */
+const returnFirstNotErroring = function (promiseArray) {
+  try {
+    if (promiseArray.length === 0) {
+      return Promise.reject()
+    }
+    let combinedPromises = Promise.resolve(promiseArray[promiseArray.length - 1])
+    for (const promise of promiseArray.slice(0, -1).reverse()) {
+      combinedPromises = appendPromise(combinedPromises, Promise.resolve(promise))
+    }
+    return combinedPromises
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
+
 module.exports = {
   uniqueItems,
   sleep,
+  returnFirstNotErroring,
 }

--- a/scripts/utils/js_helpers.js
+++ b/scripts/utils/js_helpers.js
@@ -50,6 +50,7 @@ const returnFirstNotErroring = (promiseArray) =>
         Promise.resolve(promise).then(
           (result) => {
             resolved = true
+            // only the first call to resolve() determines the outer promise output
             resolve(result)
           },
           (error) => error

--- a/test/scripts/utils/js_helpers.js
+++ b/test/scripts/utils/js_helpers.js
@@ -1,0 +1,127 @@
+// For faster execution, this test can be run directly using mocha:
+// $ npx mocha path/to/test/file.js
+
+const assert = require("assert")
+
+const { sleep, returnFirstNotErroring } = require("../../../scripts/utils/js_helpers")
+
+describe("returnFirstNotErroring", () => {
+  const sleepForAndReturn = async (ms) => {
+    await sleep(ms)
+    return ms
+  }
+  const sleepForAndError = async (ms) => {
+    await sleep(ms)
+    throw new Error(ms)
+  }
+  const sleepForAndReject = async (ms) => {
+    await sleep(ms)
+    throw ms
+  }
+  it("resolves returning first resolved promise", async () => {
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(10), sleepForAndReturn(20), sleepForAndReturn(30)]), 10)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(10), sleepForAndReturn(30), sleepForAndReturn(20)]), 10)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(20), sleepForAndReturn(10), sleepForAndReturn(30)]), 10)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(20), sleepForAndReturn(30), sleepForAndReturn(10)]), 10)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndReturn(10), sleepForAndReturn(20)]), 10)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndReturn(20), sleepForAndReturn(10)]), 10)
+  })
+  it("fails with empty array", async () => {
+    // it would be nice to also test that the returned promise is already fulfilled, as per specifications of Promise.any
+    // however it's apparently not possible to check the promise state from the code:
+    // https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise#Debugging
+    const result = returnFirstNotErroring([])
+    assert(result instanceof Promise)
+    await assert.rejects(result)
+  })
+  it("resolves even if some promises error out", async () => {
+    // one error
+    assert.equal(await returnFirstNotErroring([sleepForAndError(10), sleepForAndReturn(20), sleepForAndReturn(30)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndError(10), sleepForAndReturn(30), sleepForAndReturn(20)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(20), sleepForAndError(10), sleepForAndReturn(30)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(20), sleepForAndReturn(30), sleepForAndError(10)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndError(10), sleepForAndReturn(20)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndReturn(20), sleepForAndError(10)]), 20)
+    // two errors
+    assert.equal(await returnFirstNotErroring([sleepForAndError(10), sleepForAndError(20), sleepForAndReturn(30)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndError(10), sleepForAndReturn(30), sleepForAndError(20)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndError(20), sleepForAndError(10), sleepForAndReturn(30)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndError(20), sleepForAndReturn(30), sleepForAndError(10)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndError(10), sleepForAndError(20)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndError(20), sleepForAndError(10)]), 30)
+  })
+  it("resolves even if some promises reject", async () => {
+    // one error
+    assert.equal(await returnFirstNotErroring([sleepForAndReject(10), sleepForAndReturn(20), sleepForAndReturn(30)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReject(10), sleepForAndReturn(30), sleepForAndReturn(20)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(20), sleepForAndReject(10), sleepForAndReturn(30)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(20), sleepForAndReturn(30), sleepForAndReject(10)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndReject(10), sleepForAndReturn(20)]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndReturn(20), sleepForAndReject(10)]), 20)
+    // two errors
+    assert.equal(await returnFirstNotErroring([sleepForAndReject(10), sleepForAndReject(20), sleepForAndReturn(30)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndReject(10), sleepForAndReturn(30), sleepForAndReject(20)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndReject(20), sleepForAndReject(10), sleepForAndReturn(30)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndReject(20), sleepForAndReturn(30), sleepForAndReject(10)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndReject(10), sleepForAndReject(20)]), 30)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(30), sleepForAndReject(20), sleepForAndReject(10)]), 30)
+  })
+  it("rejects with right error message if everything errors out", async () => {
+    await assert.rejects(returnFirstNotErroring([sleepForAndError(10), sleepForAndError(20), sleepForAndError(30)]), {
+      message: "10 && 20 && 30",
+    })
+    await assert.rejects(returnFirstNotErroring([sleepForAndError(10), sleepForAndError(30), sleepForAndError(20)]), {
+      message: "10 && 30 && 20",
+    })
+    await assert.rejects(returnFirstNotErroring([sleepForAndError(20), sleepForAndError(10), sleepForAndError(30)]), {
+      message: "20 && 10 && 30",
+    })
+    await assert.rejects(returnFirstNotErroring([sleepForAndError(20), sleepForAndError(30), sleepForAndError(10)]), {
+      message: "20 && 30 && 10",
+    })
+    await assert.rejects(returnFirstNotErroring([sleepForAndError(30), sleepForAndError(10), sleepForAndError(20)]), {
+      message: "30 && 10 && 20",
+    })
+    await assert.rejects(returnFirstNotErroring([sleepForAndError(30), sleepForAndError(20), sleepForAndError(10)]), {
+      message: "30 && 20 && 10",
+    })
+  })
+  it("if more promises are already resolved, resolves returning the first in the array", async () => {
+    const resolvedTen = Promise.resolve(10)
+    const resolvedTwenty = Promise.resolve(20)
+    const resolvedThirty = Promise.resolve(30)
+    // all already resolved
+    assert.equal(await returnFirstNotErroring([resolvedTen, resolvedTwenty, resolvedThirty]), 10)
+    assert.equal(await returnFirstNotErroring([resolvedTen, resolvedThirty, resolvedTwenty]), 10)
+    assert.equal(await returnFirstNotErroring([resolvedTwenty, resolvedTen, resolvedThirty]), 20)
+    assert.equal(await returnFirstNotErroring([resolvedTwenty, resolvedThirty, resolvedTen]), 20)
+    assert.equal(await returnFirstNotErroring([resolvedThirty, resolvedTen, resolvedTwenty]), 30)
+    assert.equal(await returnFirstNotErroring([resolvedThirty, resolvedTwenty, resolvedTen]), 30)
+    // one not yet resolved
+    assert.equal(await returnFirstNotErroring([sleepForAndReject(10), resolvedTwenty, resolvedThirty]), 20)
+    assert.equal(await returnFirstNotErroring([sleepForAndReject(10), resolvedThirty, resolvedTwenty]), 30)
+    assert.equal(await returnFirstNotErroring([resolvedTwenty, sleepForAndReject(10), resolvedThirty]), 20)
+    assert.equal(await returnFirstNotErroring([resolvedTwenty, resolvedThirty, sleepForAndReject(10)]), 20)
+    assert.equal(await returnFirstNotErroring([resolvedThirty, sleepForAndReject(10), resolvedTwenty]), 30)
+    assert.equal(await returnFirstNotErroring([resolvedThirty, resolvedTwenty, sleepForAndReject(10)]), 30)
+  })
+  it("if input is not an iterator, returns a promise rejecting with internal error", async () => {
+    const resolvedTen = Promise.resolve(10)
+    const resolvedTwenty = Promise.resolve(20)
+    const resolvedThirty = Promise.resolve(30)
+    //  good call: returnFirstNotErroring([resolvedTen, resolvedTwenty, resolvedThirty])
+    const badCall = returnFirstNotErroring(resolvedTen, resolvedTwenty, resolvedThirty)
+    assert(badCall instanceof Promise)
+    await assert.rejects(badCall, {
+      message: "promiseArray.slice is not a function",
+    })
+  })
+  it("works if some array entries are not promises", async () => {
+    assert.equal(await returnFirstNotErroring([sleepForAndError(10), sleepForAndReturn(20), 0]), 0)
+    assert.equal(await returnFirstNotErroring([sleepForAndError(10), 0, sleepForAndReturn(20)]), 0)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(20), sleepForAndError(10), 0]), 0)
+    assert.equal(await returnFirstNotErroring([sleepForAndReturn(20), 0, sleepForAndError(10)]), 0)
+    assert.equal(await returnFirstNotErroring([0, sleepForAndError(10), sleepForAndReturn(20)]), 0)
+    assert.equal(await returnFirstNotErroring([0, sleepForAndReturn(20), sleepForAndError(10)]), 0)
+  })
+})

--- a/test/scripts/utils/js_helpers.js
+++ b/test/scripts/utils/js_helpers.js
@@ -113,7 +113,7 @@ describe("returnFirstNotErroring", () => {
     const badCall = returnFirstNotErroring(resolvedTen, resolvedTwenty, resolvedThirty)
     assert(badCall instanceof Promise)
     await assert.rejects(badCall, {
-      message: "promiseArray.slice is not a function",
+      message: "promiseArray is not iterable",
     })
   })
   it("works if some array entries are not promises", async () => {


### PR DESCRIPTION
Introduces the function `returnFirstNotErroring`. Given an array of promises as input, it resolves to the output of the input promise that resolves first (ignoring errors in other promises). If all promises fail, it rejects with an error.

This function is to be used when retrieving prices from aggregators like 1inch or dex.ag: Instead of choosing a single aggregator, we will be able to request prices from any aggregator and return the price of the fastest. Errors, which correspond to failing to retrieve prices from an exchange (for example because the token is not listed), can be safely ignored as long as at least one aggregator returns a price.

This function behaves similarly to the JS method `Promise.any`, which is however currently [not supported](https://kangax.github.io/compat-table/esnext/) by any version of Node.js. It is supposed to be replaced by `Promise.any` as soon as it becomes available.

The new tests should cover most use cases of this function.