### PR TITLE
[README] Move Token Distribution Instructions to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn test
 
 Use scripts as described in [scripts/README.md](scripts/README.md)`.
 
-## Synthetix Spread Orders
+## Synthetix Liquidity Provision
 
 This service requires a service that runs a script every 5 minutes. We have configured this to run inside a Docker container that can be interacted with as follows:
 
@@ -51,3 +51,32 @@ This service requires a service that runs a script every 5 minutes. We have conf
 docker build -t gnosispm/dex-liquidity-provision .
 docker run -e PK=$YOUR_PRIVATE_KEY -t gnosispm/dex-liquidity-provision:latest "truffle exec scripts/synthetix/facilitate_trade.js --network rinkeby"
 ```
+
+## Safe Token Distribution
+
+Create your own transferFile, or use our sample [examples/sampleTransferFile.json](examples/sampleTransferFile.json).
+With a fundAccount (aka Gnosis Safe) containg sufficient funds that you own execute:
+
+```sh
+ export PK=<your private key>
+export INFURA_KEY=<your infura key>
+export FUND_ACCOUNT=<your gnosis safe>
+export TRANSFER_FILE=<path to your transfer file>
+```
+
+Alternatively, there is a sample [.sample_env](.sample_env) file that is not tracked by the project where you can paste these values, rename to `.env` (i.e. `mv .sample_env .env`) source via `source .sample_env`
+
+With all configuration in place, we are ready to run the script.
+
+```sh
+npx truffle exec scripts/airdrop.js --fundAccount=$FUND_ACCOUNT --transferFile=$TRANSFER_FILE --network=$NETWORK_NAME
+
+```
+
+Then, you will be provided with logs containing all the transfer details followed by a prompt asking "Are you sure you want to send this transaction to the EVM?"
+
+Selecting yes yields a link to the Gnosis Safe interface where the transaction can be signed and executed.
+
+To do a "verification" run simply add the argument `--verify` and observe the difference in the last two lines of the logs emitted.
+
+Note that, the gas costs for such transactions can vary based on the tokens you are transfering (since each token could potentially implement their transfer's differently).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,35 +66,6 @@ The fleet size should be smaller than or equal to 20, in order to ensure that th
 Please document the displayed bracket-trader addresses. They are required for future withdrawals.
 They can also be retrieved from the created transactions. However, since this is a manual process, it is quite cumbersome to extract them right now.
 
-### Safe Token Distribution
-
-Create your own transferFile, or use our sample [examples/sampleTransferFile.json](examples/sampleTransferFile.json).
-With a fundAccount (aka Gnosis Safe) containg sufficient funds that you own execute:
-
-```sh
- export PK=<your private key>
-export INFURA_KEY=<your infura key>
-export FUND_ACCOUNT=<your gnosis safe>
-export TRANSFER_FILE=<path to your transfer file>
-```
-
-Alternatively, there is a sample [.sample_env](.sample_env) file that is not tracked by the project where you can paste these values and `source .sample_env`
-
-With all configuration in place, we are ready to run the script.
-
-```sh
-npx truffle exec scripts/airdrop.js --fundAccount=$FUND_ACCOUNT --transferFile=$TRANSFER_FILE --network=$NETWORK_NAME
-
-```
-
-Then, you will be provided with logs containing all the transfer details followed by a prompt asking "Are you sure you want to send this transaction to the EVM?"
-
-Selecting yes yields a link to the Gnosis Safe interface where the transaction can be signed and executed.
-
-To do a "verification" run simply add the argument `--verify` and observe the difference in the last two lines of the logs emitted.
-
-Note that, the gas costs for such transactions can vary based on the tokens you are transfering (since each token could potentially implement their transfer's differently)
-
 ## Running Functions Individually
 
 Instead of doing all the steps with one script, the different steps can also be done individually, as explained in the next section.


### PR DESCRIPTION
The Token Distributor guide was sitting right in the middle of the CMM scripts. This moves it out at least temporarily before it is migrated into its own repo.