### PR TITLE
Error on missing Infura key

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,5 +1,9 @@
 const truffleConfig = require("@gnosis.pm/util-contracts/src/util/truffleConfig")
 
+const argv = require("yargs").help(false).version(false).option("network", {
+  type: "string",
+}).argv
+
 const DEFAULT_GAS_LIMIT = 6e6
 const DEFAULT_GAS_PRICE_GWEI = 5
 const DEFAULT_MNEMONIC = "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
@@ -32,7 +36,7 @@ const urlDevelopment = process.env.GANACHE_HOST || "localhost"
 
 // network key
 const infuraKey = process.env.INFURA_KEY
-if (!infuraKey) {
+if ((argv.network === "rinkeby" || argv.network === "mainnet") && !infuraKey) {
   console.log("Error: no Infura key found! You can create a new project key after registering an account at https://infura.io/")
   process.exit(1)
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -31,7 +31,11 @@ let additionalNetwork = process.env.NETWORK ? JSON.parse(process.env.NETWORK) : 
 const urlDevelopment = process.env.GANACHE_HOST || "localhost"
 
 // network key
-const infuraKey = process.env.INFURA_KEY || "9408f47dedf04716a03ef994182cf150"
+const infuraKey = process.env.INFURA_KEY
+if (!infuraKey) {
+  console.log("Error: no Infura key found! You can create a new project key after registering an account at https://infura.io/")
+  process.exit(1)
+}
 
 const { gas: gasLog } = require("minimist")(process.argv.slice(2), { alias: { gas: "g" } })
 


### PR DESCRIPTION
Fixes #326.

Makes all scripts fail if no Infura key is specified.

Note that the current default Infura key is invalid, and an user trying the scripts without a key would see only a network error.

## Test plan
```
unset INFURA_KEY # and comment out INFURA_KEY from .env if present 
npx truffle exec scripts/claim_withdraw.js --masterSafe=0x0
```
Expected output:
```
$ npx truffle exec scripts/claim_withdraw.js --masterSafe=0x0
> Warning: possible unsupported (undocumented in help) command line option: --masterSafe
Error: no Infura key found! You can create a new project key after registering an account at https://infura.io/
```

Note that the extra yargs doesn't break the help:
```
npx truffle exec scripts/claim_withdraw.js --help --network=mainnet
```
(It also works without `--network=mainnet`, but there needs to be Ganache running.)