### PR TITLE
 Fix owner verification for addresses with no checksum

### DIFF
--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -61,7 +61,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const isOnlySafeOwner = async function (masterAddress, owned) {
     const ownedSafe = typeof owned === "string" ? await getSafe(owned) : owned
     const ownerAddresses = await ownedSafe.getOwners()
-    return ownerAddresses.length == 1 && ownerAddresses[0] == masterAddress
+    return ownerAddresses.length == 1 && ownerAddresses[0].toLowerCase() == masterAddress.toLowerCase()
   }
 
   /**

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -61,7 +61,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const isOnlySafeOwner = async function (masterAddress, owned) {
     const ownedSafe = typeof owned === "string" ? await getSafe(owned) : owned
     const ownerAddresses = await ownedSafe.getOwners()
-    return ownerAddresses.length == 1 && ownerAddresses[0].toLowerCase() == masterAddress.toLowerCase()
+    return ownerAddresses.length === 1 && ownerAddresses[0].toLowerCase() === masterAddress.toLowerCase()
   }
 
   /**

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -16,6 +16,7 @@ const {
   deployFleetOfSafes,
   buildOrders,
   buildTransferApproveDepositFromOrders,
+  isOnlySafeOwner,
 } = require("../scripts/utils/trading_strategy_helpers")(web3, artifacts)
 const { buildExecTransaction } = require("../scripts/utils/internals")(web3, artifacts)
 const { DEFAULT_ORDER_EXPIRY, CALL, ZERO_ADDRESS } = require("../scripts/utils/constants")
@@ -122,6 +123,13 @@ contract("Verification checks", function (accounts) {
     baseToken = (await addCustomMintableTokenToExchange(exchange, "WETH", 18, accounts[0])).id
     quoteToken = (await addCustomMintableTokenToExchange(exchange, "DAI", 18, accounts[0])).id
     await exchange.placeOrder(baseToken, quoteToken, 1234124, 11241234, 11234234, { from: accounts[0] })
+  })
+  describe("isOnlySafeOwner", async function () {
+    it("is successful if owner address is lowercase", async () => {
+      const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner], 1))
+      const [bracketAddress] = await deployFleetOfSafes(masterSafe.address, 1)
+      assert(await isOnlySafeOwner(masterSafe.address.toLowerCase(), bracketAddress))
+    })
   })
   describe("Owner is master safe", async () => {
     it("throws if the masterSafe is not the only owner", async () => {


### PR DESCRIPTION
If a user uses a non-checksummed address as its master Safe, then the complete liquidity provision script fails on owner verification.

This PR makes the owner verification succeed if master address is not checksummed.

### Test plan

Create a script `scripts/check_owners.js` with the following content:
```
const { isOnlySafeOwner, getDeployedBrackets, getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
const { default_yargs } = require("./utils/default_yargs")

const argv = default_yargs.option("masterSafe", {
  type: "string",
  describe: "address of Gnosis Safe whose brackets will be retrieved",
}).argv

module.exports = async (callback) => {
  try {
    const bracketAddresses = await getDeployedBrackets(argv.masterSafe)

    const safe = await getSafe(bracketAddresses[0])
    const ownerAddresses = await safe.getOwners()
    console.log(`Bracket ${bracketAddresses[0]} is owned by ${ownerAddresses}`)
    console.log(`Is bracket only owned by master? ${await isOnlySafeOwner(argv.masterSafe, safe)}`)

    callback()
  } catch (error) {
    console.log(error.response)
    callback(error)
  }
}
```

Run the script both on master and on this PR:
```
npx truffle exec scripts/check_owners.js --network=mainnet --masterSafe=0x5cc3a4c846ab8b0b78a729b8b1a50e2e0bb66740
```

Expected output on master:

```
Bracket 0x7c46953a4f0b404e21EBC0d69883aDAef5AAa5C5 is owned by 0x5CC3a4C846aB8b0B78a729b8B1a50e2E0BB66740
Is bracket only owned by master? false
```
Expected output on this PR:
```
Bracket 0x7c46953a4f0b404e21EBC0d69883aDAef5AAa5C5 is owned by 0x5CC3a4C846aB8b0B78a729b8B1a50e2E0BB66740
Is bracket only owned by master? true
```