### PR TITLE
Fix USDC decimals in verification script

### DIFF
--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -237,7 +237,7 @@ const checkNoProfitableOffer = async (order, exchange, tokenInfo, globalPriceSto
 
 const orderSellValueInUSD = async (order, tokenInfo, globalPriceStorage = null) => {
   const currentMarketPrice = await getOneinchPrice(
-    { symbol: "USDC", decimals: 18 },
+    { symbol: "USDC", decimals: 6 },
     await tokenInfo[order.sellToken],
     globalPriceStorage
   )

--- a/scripts/utils/verify_scripts.js
+++ b/scripts/utils/verify_scripts.js
@@ -132,7 +132,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     // update globalPriceStorage to include all tokens involved in an order and those needed to compute USD prices
     for (const order of relevantOrders) {
       await getOneinchPrice(await tokenInfo[order.sellToken], await tokenInfo[order.buyToken], globalPriceStorage)
-      await getOneinchPrice(await tokenInfo[order.sellToken], { symbol: "USDC", decimals: 18 }, globalPriceStorage)
+      await getOneinchPrice(await tokenInfo[order.sellToken], { symbol: "USDC", decimals: 6 }, globalPriceStorage)
     }
 
     await verifyBracketsWellFormed(masterSafe, brackets, masterThreshold, masterOwners, logActivated)


### PR DESCRIPTION
Fixes bug introduced in #332.
This bug involves the verification script and had two effects:
- All orders were considered "negligible" because of their low USD value, so all profitability check failure would have been ignored.
- Under some uncommon circumstances, it would make the profitability check to fail incorrectly.

Not sure how to properly test for this issue, since it's caused by the interaction between 1inch and our standard token format.