### PR TITLE
Do not retrieve prices online if not needed in the test

### DIFF
--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -53,9 +53,36 @@ const createTokenAndGetData = async function (symbol, decimals) {
   return { address: token.address, tokenData: tokenData }
 }
 
+/**
+ * Creates a price storage with dummy prices for the input tokens.
+ * Used to make less network requests during testing.
+ *
+ * @returns {object} a price storage that assigns a dummy price (-1) to every pair of input tokens
+ */
+const populatePriceStorage = function () {
+  const DUMMY_PRICE = -1
+  const DEFAULT_USD_REFERENCE_TOKEN = "USDC"
+
+  const priceStorage = {}
+  for (let firstTokenIndex = 0; firstTokenIndex < arguments.length; firstTokenIndex++) {
+    for (let secondTokenIndex = firstTokenIndex + 1; secondTokenIndex < arguments.length; secondTokenIndex++) {
+      priceStorage[arguments[firstTokenIndex] + "-" + arguments[secondTokenIndex]] = DUMMY_PRICE
+    }
+  }
+
+  if (!(DEFAULT_USD_REFERENCE_TOKEN in arguments)) {
+    for (const token of arguments) {
+      priceStorage[token + "-" + DEFAULT_USD_REFERENCE_TOKEN] = DUMMY_PRICE
+    }
+  }
+
+  return priceStorage
+}
+
 module.exports = {
   deploySafe,
   createTokenAndGetData,
   prepareTokenRegistration,
   addCustomMintableTokenToExchange,
+  populatePriceStorage,
 }

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -8,7 +8,7 @@ const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const EvilGnosisSafeProxy = artifacts.require("EvilGnosisSafeProxy")
 
 const { verifyCorrectSetup } = require("../scripts/utils/verify_scripts")(web3, artifacts)
-const { addCustomMintableTokenToExchange, createTokenAndGetData, deploySafe } = require("./test_utils")
+const { addCustomMintableTokenToExchange, createTokenAndGetData, deploySafe, populatePriceStorage } = require("./test_utils")
 const { execTransaction, waitForNSeconds } = require("../scripts/utils/internals")(web3, artifacts)
 const {
   getAllowances,
@@ -296,7 +296,8 @@ contract("Verification checks", function (accounts) {
 
       const transaction = await buildExecTransaction(masterSafe.address, bracketAddress, orderTransaction)
       await execTransaction(masterSafe, safeOwner, transaction)
-      await assert.rejects(verifyCorrectSetup([bracketAddress], masterSafe.address, []), {
+      const globalPriceStorage = populatePriceStorage("WETH", "DAI")
+      await assert.rejects(verifyCorrectSetup([bracketAddress], masterSafe.address, null, null, [], globalPriceStorage), {
         message: "The two orders are not set up to trade back and forth on the same token pair",
       })
     })
@@ -333,7 +334,8 @@ contract("Verification checks", function (accounts) {
       }
       const transaction = await buildExecTransaction(masterSafe.address, bracketAddress, orderTransaction)
       await execTransaction(masterSafe, safeOwner, transaction)
-      await assert.rejects(verifyCorrectSetup([bracketAddress], masterSafe.address), {
+      const globalPriceStorage = populatePriceStorage("WETH", "DAI")
+      await assert.rejects(verifyCorrectSetup([bracketAddress], masterSafe.address, null, null, [], globalPriceStorage), {
         message: "Brackets do not gain money when trading",
       })
     })


### PR DESCRIPTION
Some tests fetch prices online even when not needed. This PR reduces the amount of network requests in tests. The running time of the tests goes down by about 30 seconds each.

### Test plan
Compare running times of the [current master Travis build](https://travis-ci.com/github/gnosis/dex-liquidity-provision/builds/174594521) with the Travis build of this PR for the tests:
1. throws if orders do not buy and sell the same tokens in a loop
2. throws if orders of one bracket are not profitable