### PR TITLE
Remove hardcoded dex.ag from log output

### DIFF
--- a/scripts/bracket_orders.js
+++ b/scripts/bracket_orders.js
@@ -57,7 +57,7 @@ module.exports = async (callback) => {
     const masterSafePromise = getSafe(argv.masterSafe)
     const exchange = await getExchange()
 
-    // check price against dex.ag's API
+    // check price against external price API
     const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [argv.baseTokenId, argv.quoteTokenId])
     const baseTokenData = await tokenInfoPromises[argv.baseTokenId]
     const quoteTokenData = await tokenInfoPromises[argv.quoteTokenId]

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -120,7 +120,7 @@ module.exports = async (callback) => {
 
     const hasSufficientBaseTokenPromise = checkSufficiencyOfBalance(baseToken, argv.masterSafe, depositBaseToken)
     const hasSufficientQuoteTokenPromise = checkSufficiencyOfBalance(quoteToken, argv.masterSafe, depositQuoteToken)
-    const isPriceCloseToDexagsPromise = isPriceReasonable(baseTokenData, quoteTokenData, argv.currentPrice)
+    const isPriceCloseToOnlineSourcePromise = isPriceReasonable(baseTokenData, quoteTokenData, argv.currentPrice)
 
     const signer = await signerPromise
     console.log("Using account:", signer)
@@ -139,8 +139,8 @@ module.exports = async (callback) => {
       callback(`Error: MasterSafe ${argv.masterSafe} has insufficient balance for quote token ${quoteToken.address}`)
     }
 
-    // check price against dex.ag's API
-    if (!(await isPriceCloseToDexagsPromise)) {
+    // check price against external price API
+    if (!(await isPriceCloseToOnlineSourcePromise)) {
       if (!(await proceedAnyways("Price check failed!"))) {
         callback("Error: Price checks did not pass")
       }

--- a/scripts/typedef.js
+++ b/scripts/typedef.js
@@ -94,3 +94,16 @@
  * @property {number|string|BN} value Amount of ETH transferred
  * @property {string} data Data sent along with the transaction
  */
+
+/**
+ * Example:
+ * {
+ *   source: "dex.ag",
+ *   price: 250.0
+ * }
+ *
+ * @typedef PriceFeedSlice
+ * @type {object}
+ * @property {string} source human-readable name of the source price feed
+ * @property {number|undefined} price for the token pair involved
+ */

--- a/test/price_utils.js
+++ b/test/price_utils.js
@@ -56,9 +56,9 @@ contract("PriceOracle", function (accounts) {
       ]
 
       const globalPriceStorage = {}
-      globalPriceStorage["DAI-USDC"] = 1.0
-      globalPriceStorage["WETH-DAI"] = 1 / 120.0
-      globalPriceStorage["WETH-USDC"] = 1 / 120.0
+      globalPriceStorage["DAI-USDC"] = { price: 1.0 }
+      globalPriceStorage["WETH-DAI"] = { price: 1 / 120.0 }
+      globalPriceStorage["WETH-USDC"] = { price: 1 / 120.0 }
 
       const tokenInfo = fetchTokenInfoFromExchange(exchange, [DAItokenId, WETHtokenId])
       assert.equal(
@@ -94,8 +94,8 @@ contract("PriceOracle", function (accounts) {
       ]
 
       const globalPriceStorage = {}
-      globalPriceStorage["USDC-USDC"] = 1.0
-      globalPriceStorage["DAI-USDC"] = 1.0
+      globalPriceStorage["USDC-USDC"] = { price: 1.0 }
+      globalPriceStorage["DAI-USDC"] = { price: 1.0 }
       const tokenInfo = fetchTokenInfoFromExchange(exchange, [DAItokenId, USDCtokenId])
       assert.equal(await checkNoProfitableOffer(orders[0], exchange, tokenInfo, globalPriceStorage), true)
       assert.equal(
@@ -130,8 +130,8 @@ contract("PriceOracle", function (accounts) {
       ]
 
       const globalPriceStorage = {}
-      globalPriceStorage["USDC-USDC"] = 1.0
-      globalPriceStorage["DAI-USDC"] = 1.0
+      globalPriceStorage["USDC-USDC"] = { price: 1.0 }
+      globalPriceStorage["DAI-USDC"] = { price: 1.0 }
 
       const tokenInfo = fetchTokenInfoFromExchange(exchange, [DAItokenId, USDCtokenId])
       assert.equal(

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -62,17 +62,21 @@ const createTokenAndGetData = async function (symbol, decimals) {
 const populatePriceStorage = function () {
   const DUMMY_PRICE = -1
   const DEFAULT_USD_REFERENCE_TOKEN = "USDC"
+  const MOCK_SLICE = {
+    price: DUMMY_PRICE,
+    source: "mocked in test",
+  }
 
   const priceStorage = {}
   for (let firstTokenIndex = 0; firstTokenIndex < arguments.length; firstTokenIndex++) {
     for (let secondTokenIndex = firstTokenIndex + 1; secondTokenIndex < arguments.length; secondTokenIndex++) {
-      priceStorage[arguments[firstTokenIndex] + "-" + arguments[secondTokenIndex]] = DUMMY_PRICE
+      priceStorage[arguments[firstTokenIndex] + "-" + arguments[secondTokenIndex]] = { ...MOCK_SLICE }
     }
   }
 
   if (!(DEFAULT_USD_REFERENCE_TOKEN in arguments)) {
     for (const token of arguments) {
-      priceStorage[token + "-" + DEFAULT_USD_REFERENCE_TOKEN] = DUMMY_PRICE
+      priceStorage[token + "-" + DEFAULT_USD_REFERENCE_TOKEN] = { ...MOCK_SLICE }
     }
   }
 

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -383,18 +383,18 @@ contract("Verification checks", function (accounts) {
       await waitForNSeconds(301)
 
       const globalPriceStorage = {}
-      globalPriceStorage["DAI-USDC"] = 1.0
-      globalPriceStorage["WETH-USDC"] = 1
-      globalPriceStorage["DAI-WETH"] = 100 //<-- price is correct
+      globalPriceStorage["DAI-USDC"] = { price: 1.0 }
+      globalPriceStorage["WETH-USDC"] = { price: 1 }
+      globalPriceStorage["DAI-WETH"] = { price: 100 } //<-- price is correct
       await verifyCorrectSetup([bracketAddresses[0]], masterSafe.address, null, null, [], globalPriceStorage)
       await verifyCorrectSetup([bracketAddresses[1]], masterSafe.address, null, null, [], globalPriceStorage)
 
-      globalPriceStorage["DAI-WETH"] = 121 //<-- price is off, hence orders are profitable
+      globalPriceStorage["DAI-WETH"] = { price: 121 } //<-- price is off, hence orders are profitable
       await assert.rejects(verifyCorrectSetup([bracketAddresses[1]], masterSafe.address, null, null, [], globalPriceStorage), {
         message: `The order of the bracket ${bracketAddresses[1].toLowerCase()} is profitable`,
       })
 
-      globalPriceStorage["DAI-WETH"] = 70 //<-- price is off, hence orders are profitable
+      globalPriceStorage["DAI-WETH"] = { price: 70 } //<-- price is off, hence orders are profitable
       await assert.rejects(verifyCorrectSetup([bracketAddresses[0]], masterSafe.address, null, null, [], globalPriceStorage), {
         message: `The order of the bracket ${bracketAddresses[0].toLowerCase()} is profitable`,
       })


### PR DESCRIPTION
The log output of our script explicitly references to dex.ag as our price source. This PR changes this.

The output of the external price feed now includes information on the exchange from which the price was retrieved. This is what is then used for the log output.

I also removed some leftover code in the 1inch API that comes from the implementation of the dex.ag API. This code was supposed to change "WETH" to "ETH", but
1. this is not needed for 1inch, and
2. as currently implemented, it has no effect.