### PR TITLE
[Claim Withdraw] Exclude Dust amounts 

### DIFF
--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -258,7 +258,7 @@ const orderSellValueInUSD = async (order, tokenInfo, globalPriceStorage = null) 
 }
 
 const amountUSDValue = async function (amount, tokenInfo, globalPriceStorage = null) {
-  const currentMarketPriceSlice = await getOneinchPrice({ symbol: "USDC", decimals: 6 }, tokenInfo, globalPriceStorage)
+  const currentMarketPriceSlice = await getOneinchPrice(tokenInfo, { symbol: "USDC", decimals: 6 }, globalPriceStorage)
   const currentMarketPrice = currentMarketPriceSlice.price
 
   return Fraction.fromNumber(parseFloat(currentMarketPrice))

--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -257,7 +257,17 @@ const orderSellValueInUSD = async (order, tokenInfo, globalPriceStorage = null) 
     .toBN()
 }
 
+const amountUSDValue = async function (amount, tokenInfo, globalPriceStorage = null) {
+  const currentMarketPriceSlice = await getOneinchPrice({ symbol: "USDC", decimals: 6 }, tokenInfo, globalPriceStorage)
+  const currentMarketPrice = currentMarketPriceSlice.price
+
+  return Fraction.fromNumber(parseFloat(currentMarketPrice))
+    .mul(new Fraction(new BN(amount), new BN(10).pow(new BN(tokenInfo.decimals))))
+    .toBN()
+}
+
 module.exports = {
+  amountUSDValue,
   isPriceReasonable,
   areBoundsReasonable,
   checkCorrectnessOfDeposits,

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -70,16 +70,21 @@ module.exports = function (web3, artifacts) {
         tokenBracketPairs.map(([bracketAddress, tokenData]) => amountFunction(bracketAddress, tokenData, exchange))
       )
       withdrawals = []
-      maxWithdrawableAmounts.forEach(async (amount, index) => {
-        const tokenData = tokenBracketPairs[index][1]
-        const usdValue = await amountUSDValue(amount, tokenData, globalPriceStorage)
-        if (usdValue.gte(ONE))
+      for (const [index, amount] of maxWithdrawableAmounts.entries()) {
+        const token = tokenBracketPairs[index][1]
+        const bracketAddress = tokenBracketPairs[index][0]
+        const usdValue = await amountUSDValue(amount, token, globalPriceStorage)
+        if (usdValue.gte(ONE)) {
           withdrawals.push({
-            bracketAddress: tokenBracketPairs[index][0],
-            tokenAddress: tokenData.address,
-            amount: amount,
+            bracketAddress,
+            tokenAddress: token.address,
+            amount,
+            usdValue,
           })
-      })
+        } else {
+          log(`Skipping request for ${token.symbol} on bracket ${bracketAddress} since USD value < 1`)
+        }
+      }
     }
 
     return {
@@ -116,7 +121,7 @@ module.exports = function (web3, artifacts) {
 
     return transactionPromise
   }
-  const prepareWithdraw = async function (argv, printOutput = false) {
+  const prepareWithdraw = async function (argv, printOutput = false, globalPriceStorage = {}) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
 
     assertGoodArguments(argv)
@@ -130,7 +135,8 @@ module.exports = function (web3, artifacts) {
       argv.brackets,
       argv.tokens,
       argv.tokenIds,
-      printOutput
+      printOutput,
+      globalPriceStorage
     )
 
     log("Started building withdraw transaction.")
@@ -145,7 +151,7 @@ module.exports = function (web3, artifacts) {
 
     return transactionPromise
   }
-  const prepareTransferFundsToMaster = async function (argv, printOutput = false) {
+  const prepareTransferFundsToMaster = async function (argv, printOutput = false, globalPriceStorage = {}) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
 
     assertGoodArguments(argv)
@@ -159,7 +165,8 @@ module.exports = function (web3, artifacts) {
       argv.brackets,
       argv.tokens,
       argv.tokenIds,
-      printOutput
+      printOutput,
+      globalPriceStorage
     )
 
     log("Started building withdraw transaction.")
@@ -179,7 +186,7 @@ module.exports = function (web3, artifacts) {
 
     return transactionPromise
   }
-  const prepareWithdrawAndTransferFundsToMaster = async function (argv, printOutput = false) {
+  const prepareWithdrawAndTransferFundsToMaster = async function (argv, printOutput = false, globalPriceStorage = {}) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
 
     assertGoodArguments(argv)
@@ -193,7 +200,8 @@ module.exports = function (web3, artifacts) {
       argv.brackets,
       argv.tokens,
       argv.tokenIds,
-      printOutput
+      printOutput,
+      globalPriceStorage
     )
 
     log("Started building withdraw transaction.")

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -79,7 +79,6 @@ module.exports = function (web3, artifacts) {
             bracketAddress,
             tokenAddress: token.address,
             amount,
-            usdValue,
           })
         } else {
           log(`Skipping request for ${token.symbol} on bracket ${bracketAddress} since USD value < 1`)

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -411,7 +411,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction2 = await prepareWithdraw(argv2, true, globalPriceStorage)
+      const transaction2 = await prepareWithdraw(argv2, false, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, transaction2)
 
       const argv3 = {
@@ -419,7 +419,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction3 = await prepareTransferFundsToMaster(argv3, true, globalPriceStorage)
+      const transaction3 = await prepareTransferFundsToMaster(argv3, false, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, transaction3)
 
       for (const { tokenAddress, bracketAddress } of deposits) {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -465,7 +465,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction2 = await prepareWithdrawAndTransferFundsToMaster(argv2)
+      const transaction2 = await prepareWithdrawAndTransferFundsToMaster(argv2, false, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, transaction2)
 
       for (const { tokenAddress, bracketAddress } of deposits) {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -199,8 +199,11 @@ contract("Withdraw script", function (accounts) {
 
       depositFile.cleanup()
     })
-    it("withdraws and transfers simultaneously", async () => {
+    it("withdraws and transfers simultaneously from file", async () => {
       const amounts = [{ tokenData: { decimals: 18, symbol: "DAI" }, amount: "1000" }]
+      const globalPriceStorage = {}
+      globalPriceStorage["DAI-USDC"] = { price: 1.0 }
+
       const [masterSafe, bracketAddresses, tokenInfo] = await setup(2, amounts)
       const token = tokenInfo[0].token
       const deposits = evenDeposits(bracketAddresses, tokenInfo[0], "1000")
@@ -220,7 +223,7 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
       }
-      const transaction2 = await prepareWithdrawAndTransferFundsToMaster(argv2)
+      const transaction2 = await prepareWithdrawAndTransferFundsToMaster(argv2, false, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, transaction2)
 
       for (const { tokenAddress, bracketAddress } of deposits) {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -123,7 +123,7 @@ contract("Withdraw script", function (accounts) {
 
       depositFile.cleanup()
     })
-    it("withdraws", async () => {
+    it("claim withdraw", async () => {
       const amounts = [{ tokenData: { decimals: 18, symbol: "DAI" }, amount: "1000" }]
       const [masterSafe, bracketAddresses, tokenInfo] = await setup(2, amounts)
       const token = tokenInfo[0].token
@@ -290,14 +290,18 @@ contract("Withdraw script", function (accounts) {
         assert.equal(requestedWithdrawal, bnMaxUint256.toString(), "Bad amount requested to withdraw")
       }
     })
-    it("withdraws", async () => {
+    it("claim withdraw", async () => {
       const amounts = [
         { tokenData: { decimals: 6, symbol: "USDC" }, amount: "10000" },
         { tokenData: { decimals: 18, symbol: "WETH" }, amount: "50" },
       ]
+      const globalPriceStorage = {}
+      globalPriceStorage["USDC-USDC"] = { price: 1.0 }
+      globalPriceStorage["WETH-USDC"] = { price: 250.0 }
+
       const [masterSafe, bracketAddresses, tokenInfo] = await setup(4, amounts)
       // deposits: brackets 0,1,2 have USDC, brackets 2,3 have ETH
-      const depositsUsdc = evenDeposits(bracketAddresses.slice(0, 3), tokenInfo[0], "8000")
+      const depositsUsdc = evenDeposits(bracketAddresses.slice(0, 3), tokenInfo[0], "9000")
       const depositsWeth = evenDeposits(bracketAddresses.slice(2, 4), tokenInfo[1], "40")
       const deposits = depositsUsdc.concat(depositsWeth)
       await deposit(masterSafe, deposits)
@@ -316,7 +320,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction2 = await prepareWithdraw(argv2)
+      const transaction2 = await prepareWithdraw(argv2, false, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, transaction2)
 
       for (const { amount, tokenAddress, bracketAddress } of deposits) {
@@ -331,6 +335,10 @@ contract("Withdraw script", function (accounts) {
         { tokenData: { decimals: 6, symbol: "USDC" }, amount: "10000" },
         { tokenData: { decimals: 18, symbol: "WETH" }, amount: "50" },
       ]
+      const globalPriceStorage = {}
+      globalPriceStorage["USDC-USDC"] = { price: 1.0 }
+      globalPriceStorage["WETH-USDC"] = { price: 250.0 }
+
       const [masterSafe, bracketAddresses, tokenInfo] = await setup(4, amounts)
       const usdcToken = await ERC20.at(tokenInfo[0].address)
       const wethToken = await ERC20.at(tokenInfo[1].address)
@@ -354,7 +362,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction2 = await prepareWithdraw(argv2)
+      const transaction2 = await prepareWithdraw(argv2, true, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, transaction2)
 
       const argv3 = {
@@ -362,7 +370,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction3 = await prepareTransferFundsToMaster(argv3)
+      const transaction3 = await prepareTransferFundsToMaster(argv3, true, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, transaction3)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -381,6 +389,10 @@ contract("Withdraw script", function (accounts) {
         { tokenData: { decimals: 6, symbol: "USDC" }, amount: "10000" },
         { tokenData: { decimals: 18, symbol: "WETH" }, amount: "50" },
       ]
+      const globalPriceStorage = {}
+      globalPriceStorage["USDC-USDC"] = { price: 1.0 }
+      globalPriceStorage["WETH-USDC"] = { price: 250.0 }
+
       const [masterSafe, bracketAddresses, tokenInfo] = await setup(4, amounts)
       const usdcToken = await ERC20.at(tokenInfo[0].address)
       const wethToken = await ERC20.at(tokenInfo[1].address)

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -23,7 +23,6 @@ const {
 } = require("../../scripts/wrapper/withdraw")(web3, artifacts)
 const { waitForNSeconds, execTransaction } = require("../../scripts/utils/internals")(web3, artifacts)
 const { toErc20Units, fromErc20Units } = require("../../scripts/utils/printing_tools")
-const { assert } = require("console")
 
 const bnMaxUint256 = new BN(2).pow(new BN(256)).subn(1)
 


### PR DESCRIPTION
This script update excludes withdraw claims valuing less than 1 USD (i.e. those costing more in transaction fees than the value itself).

There a couple new unit tests showing that the script works as desired.

Closes #345 