### PR TITLE
[Synthetix] Increase Min Trade Size

### DIFF
--- a/scripts/synthetix/facilitate_trade.js
+++ b/scripts/synthetix/facilitate_trade.js
@@ -52,7 +52,7 @@ const estimatePrice = async function (buyTokenId, sellTokenId, sellAmount, netwo
   return estimationData.buyAmountInBase / estimationData.sellAmountInQuote
 }
 
-const MIN_SELL_USD = 10
+const MIN_SELL_USD = 100
 
 /* All prices, except those explicitly named with "inverted" refer to the price of sETH in sUSD.
  * The term "our" is with regards to prices we, the synthetix bot, are buying and selling for while


### PR DESCRIPTION
This PR is a HOTFIX. Since the bot is now attempting to fill an order worth about 35 USD and it is not being matched. It appears solvers are not picking up orders with the current 10 USD min trade size. It would be much more likely that they would include a min trade of 100. Should we make it more?

The new docker image related to this change has already been pushed.