### PR TITLE
[Easy] More expresive and correct method names

### DIFF
--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -1,6 +1,6 @@
 const { signAndSend } = require("./utils/gnosis_safe_server_interactions")(web3, artifacts)
 const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
-const { defaultWithdrawYargs, prepareRequestWithdraw } = require("./wrapper/withdraw")(web3, artifacts)
+const { defaultWithdrawYargs, prepareWithdrawRequest } = require("./wrapper/withdraw")(web3, artifacts)
 const { promptUser } = require("./utils/user_interface_helpers")
 
 const argv = defaultWithdrawYargs.argv
@@ -9,7 +9,7 @@ module.exports = async (callback) => {
   try {
     const masterSafe = getSafe(argv.masterSafe)
 
-    const transaction = await prepareRequestWithdraw(argv, true)
+    const transaction = await prepareWithdrawRequest(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
       await signAndSend(await masterSafe, transaction, argv.network)

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -638,7 +638,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
    * @returns {Transaction} Multisend transaction requesting withdraw that must sent from masterAddress
    */
-  const buildRequestWithdraw = function (masterAddress, withdrawals) {
+  const buildWithdrawRequest = function (masterAddress, withdrawals) {
     return buildGenericFundMovement(masterAddress, withdrawals, "requestWithdraw")
   }
 
@@ -653,7 +653,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {Withdrawal[]} withdrawals List of {@link Withdrawal} that are to be bundled together
    * @returns {Transaction} Multisend transaction that has to be sent from the master address to withdraw the desired funds
    */
-  const buildWithdraw = function (masterAddress, withdrawals) {
+  const buildWithdrawClaim = function (masterAddress, withdrawals) {
     return buildGenericFundMovement(masterAddress, withdrawals, "withdraw")
   }
 
@@ -705,7 +705,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @returns {Transaction} Multisend transaction that has to be sent from the master address to transfer back the fubnds stored in the exchange
    */
   const buildWithdrawAndTransferFundsToMaster = async function (masterAddress, withdrawals) {
-    const withdrawalTransaction = await buildWithdraw(masterAddress, withdrawals)
+    const withdrawalTransaction = await buildWithdrawClaim(masterAddress, withdrawals)
     const transferFundsToMasterTransaction = await buildTransferFundsToMaster(masterAddress, withdrawals, false)
     return buildBundledTransaction([withdrawalTransaction, transferFundsToMasterTransaction])
   }
@@ -752,29 +752,28 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   }
 
   return {
-    getSafe,
-    getExchange,
-    deployFleetOfSafes,
-    buildOrders,
-    buildBundledTransaction,
+    assertNoAllowances,
+    buildBracketTransactionForTransferApproveDeposit,
     buildDepositFromList,
+    buildOrders,
+    buildTransferApproveDepositFromOrders,
     buildTransferApproveDepositFromList,
     buildTransferDataFromList,
     buildTransferFundsToMaster,
     buildWithdrawAndTransferFundsToMaster,
-    buildBracketTransactionForTransferApproveDeposit,
-    buildTransferApproveDepositFromOrders,
+    buildWithdrawClaim,
+    buildWithdrawRequest,
     checkSufficiencyOfBalance,
-    buildRequestWithdraw,
-    buildWithdraw,
-    tokenDetail,
+    deployFleetOfSafes,
     fetchTokenInfoAtAddresses,
     fetchTokenInfoFromExchange,
     fetchTokenInfoForFlux,
-    getDeployedBrackets,
-    isOnlySafeOwner,
     getAllowances,
-    assertNoAllowances,
+    getDeployedBrackets,
+    getExchange,
+    getSafe,
     hasExistingOrders,
+    isOnlySafeOwner,
+    tokenDetail,
   }
 }

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -6,8 +6,8 @@ module.exports = function (web3, artifacts) {
     getExchange,
     fetchTokenInfoAtAddresses,
     fetchTokenInfoForFlux,
-    buildRequestWithdraw,
-    buildWithdraw,
+    buildWithdrawRequest,
+    buildWithdrawClaim,
     buildTransferFundsToMaster,
     buildWithdrawAndTransferFundsToMaster,
   } = require("../utils/trading_strategy_helpers")(web3, artifacts)
@@ -92,7 +92,7 @@ module.exports = function (web3, artifacts) {
     }
   }
 
-  const prepareRequestWithdraw = async function (argv, printOutput = false) {
+  const prepareWithdrawRequest = async function (argv, printOutput = false) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
 
     assertGoodArguments(argv)
@@ -110,7 +110,7 @@ module.exports = function (web3, artifacts) {
     )
 
     log("Started building withdraw transaction.")
-    const transactionPromise = buildRequestWithdraw(argv.masterSafe, withdrawals)
+    const transactionPromise = buildWithdrawRequest(argv.masterSafe, withdrawals)
 
     for (const withdrawal of withdrawals) {
       const { symbol: tokenSymbol } = await tokenInfoPromises[withdrawal.tokenAddress]
@@ -139,7 +139,7 @@ module.exports = function (web3, artifacts) {
     )
 
     log("Started building withdraw transaction.")
-    const transactionPromise = buildWithdraw(argv.masterSafe, withdrawals)
+    const transactionPromise = buildWithdrawClaim(argv.masterSafe, withdrawals)
 
     for (const withdrawal of withdrawals) {
       const { symbol: tokenSymbol, decimals: tokenDecimals } = await tokenInfoPromises[withdrawal.tokenAddress]
@@ -257,7 +257,7 @@ module.exports = function (web3, artifacts) {
     .check(checkBracketsForDuplicate)
 
   return {
-    prepareRequestWithdraw,
+    prepareWithdrawRequest,
     prepareWithdraw,
     prepareWithdrawAndTransferFundsToMaster,
     prepareTransferFundsToMaster,

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -18,8 +18,8 @@ const {
   buildOrders,
   buildTransferApproveDepositFromList,
   buildTransferApproveDepositFromOrders,
-  buildRequestWithdraw,
-  buildWithdraw,
+  buildWithdrawRequest,
+  buildWithdrawClaim,
   buildTransferFundsToMaster,
   buildWithdrawAndTransferFundsToMaster,
   isOnlySafeOwner,
@@ -773,7 +773,7 @@ contract("GnosisSafe", function (accounts) {
         )
       }
 
-      const requestWithdrawalTransaction = await buildRequestWithdraw(masterSafe.address, withdrawals)
+      const requestWithdrawalTransaction = await buildWithdrawRequest(masterSafe.address, withdrawals)
       await execTransaction(masterSafe, safeOwner, requestWithdrawalTransaction)
       await waitForNSeconds(301)
 
@@ -837,7 +837,7 @@ contract("GnosisSafe", function (accounts) {
         withdraw.amount = withdraw.amount.add(toErc20Units(1, 18))
         withdraw
       })
-      const withdrawalTransaction = await buildWithdraw(masterSafe.address, withdrawalsModified)
+      const withdrawalTransaction = await buildWithdrawClaim(masterSafe.address, withdrawalsModified)
 
       await execTransaction(masterSafe, safeOwner, withdrawalTransaction, "withdraw for all brackets")
 

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -16,7 +16,7 @@ const { deployFleetOfSafes, buildTransferApproveDepositFromList } = require("../
   artifacts
 )
 const {
-  prepareRequestWithdraw,
+  prepareWithdrawRequest,
   prepareWithdraw,
   prepareTransferFundsToMaster,
   prepareWithdrawAndTransferFundsToMaster,
@@ -112,7 +112,7 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
       }
-      const transaction = await prepareRequestWithdraw(argv)
+      const transaction = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, transaction)
 
       for (const { amount, tokenAddress, bracketAddress } of deposits) {
@@ -136,7 +136,7 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
       }
-      const requestTx = await prepareRequestWithdraw(argv1)
+      const requestTx = await prepareWithdrawRequest(argv1)
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
@@ -170,7 +170,7 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
       }
-      const requestTx = await prepareRequestWithdraw(argv)
+      const requestTx = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
@@ -207,7 +207,7 @@ contract("Withdraw script", function (accounts) {
         masterSafe: masterSafe.address,
         withdrawalFile: depositFile.path,
       }
-      const requestTx = await prepareRequestWithdraw(argv)
+      const requestTx = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
@@ -244,7 +244,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction = await prepareRequestWithdraw(argv)
+      const transaction = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, transaction)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -272,7 +272,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokenIds: [usdcId, wethId],
       }
-      const transaction = await prepareRequestWithdraw(argv)
+      const transaction = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, transaction)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -302,7 +302,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const transaction1 = await prepareRequestWithdraw(argv)
+      const transaction1 = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, transaction1)
       await waitForNSeconds(301)
 
@@ -338,7 +338,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const requestTransaction = await prepareRequestWithdraw(argv)
+      const requestTransaction = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, requestTransaction)
       await waitForNSeconds(301)
 
@@ -381,7 +381,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const requestTransaction = await prepareRequestWithdraw(argv)
+      const requestTransaction = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, requestTransaction)
       await waitForNSeconds(301)
 
@@ -425,7 +425,7 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
-      const requestTx = await prepareRequestWithdraw(argv)
+      const requestTx = await prepareWithdrawRequest(argv)
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 


### PR DESCRIPTION
changes `buildRequestWithdraw` to  `buildWithdrawRequest` (because that's what it is) and `buildWithdraw` to `buildWithdrawClaim`. I think we should also move all "transaction builders" into their own file call `transaction_builders.js` but will save this for another time since a lot of import statements need to be moved as well.