### PR TITLE
Dataforgraph

### DIFF
--- a/scripts/ganache/create-batchexchange-api.js
+++ b/scripts/ganache/create-batchexchange-api.js
@@ -1,0 +1,19 @@
+module.exports = async (callback, accounts) => {
+  try {
+    const fs = require("fs")
+    console.log("current ganache network id: ", await web3.eth.net.getId())
+    // destination.txt will be created or overwritten by default.
+    fs.copyFile(
+      "node_modules/@gnosis.pm/dex-contracts/build/contracts/BatchExchange.json",
+      "build/contracts/BatchExchange.json",
+      (err) => {
+        if (err) throw err
+        console.log("Created BatchExchange.json")
+      }
+    )
+    callback()
+  } catch (error) {
+    console.log(error.response)
+    callback(error)
+  }
+}

--- a/scripts/ganache/create-batchexchange-api.js
+++ b/scripts/ganache/create-batchexchange-api.js
@@ -3,14 +3,14 @@ module.exports = async (callback, accounts) => {
     const fs = require("fs")
     console.log("current ganache network id: ", await web3.eth.net.getId())
     // destination.txt will be created or overwritten by default.
-    fs.copyFile(
-      "node_modules/@gnosis.pm/dex-contracts/build/contracts/BatchExchange.json",
-      "build/contracts/BatchExchange.json",
-      (err) => {
-        if (err) throw err
-        console.log("Created BatchExchange.json")
-      }
-    )
+    // fs.copyFile(
+    //   "node_modules/@gnosis.pm/dex-contracts/build/contracts/BatchExchange.json",
+    //   "build/contracts/BatchExchange.json",
+    //   (err) => {
+    //     if (err) throw err
+    //     console.log("Created BatchExchange.json")
+    //   }
+    // )
     callback()
   } catch (error) {
     console.log(error.response)

--- a/scripts/ganache/setup_thegraph_data.js
+++ b/scripts/ganache/setup_thegraph_data.js
@@ -1,0 +1,125 @@
+const Contract = require("@truffle/contract")
+const fs = require("fs")
+
+const {
+  deployFleetOfSafes,
+  fetchTokenInfoFromExchange,
+  buildTransferApproveDepositFromOrders,
+  buildOrders,
+  getSafe,
+  getExchange,
+} = require("../utils/trading_strategy_helpers")(web3, artifacts)
+const { toErc20Units } = require("../utils/printing_tools")
+const { execTransaction } = require("../utils/internals")(web3, artifacts)
+
+const BatchExchange = artifacts.require("BatchExchange")
+const ERC20 = artifacts.require("ERC20Detailed")
+const MintableToken = artifacts.require("DetailedMintableToken")
+const { addCustomMintableTokenToExchange, deploySafe } = require("../../test/test_utils")
+
+const testAutomaticDeposits = async function (tradeInfo, safeOwner, artifacts = artifacts) {
+  const {
+    numBrackets,
+    lowestLimit,
+    highestLimit,
+    currentPrice,
+    amountQuoteToken,
+    amountbaseToken,
+    quoteTokenInfo,
+    baseTokenInfo,
+  } = tradeInfo
+  const { decimals: quoteTokenDecimals, symbol: quoteTokenSymbol } = quoteTokenInfo
+  const { decimals: baseTokenDecimals, symbol: baseTokenSymbol } = baseTokenInfo
+  const GnosisSafe = artifacts.require("GnosisSafe")
+  const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
+  const gnosisSafeMasterCopy = await GnosisSafe.new()
+  const proxyFactory = await ProxyFactory.new()
+  const exchange = await BatchExchange.deployed()
+  const masterSafe = await GnosisSafe.at(await deploySafe(gnosisSafeMasterCopy, proxyFactory, [safeOwner], 1))
+  const bracketAddresses = await deployFleetOfSafes(masterSafe.address, numBrackets)
+  //Create  quoteToken and add it to the exchange
+  const { id: quoteTokenId, token: quoteToken } = await addCustomMintableTokenToExchange(
+    exchange,
+    quoteTokenSymbol,
+    quoteTokenDecimals,
+    safeOwner,
+    artifacts
+  )
+
+  console.log(exchange.address)
+  console.log(await exchange.feeToken())
+  const depositAmountQuoteToken = toErc20Units(amountQuoteToken, quoteTokenDecimals)
+  await quoteToken.mint(masterSafe.address, depositAmountQuoteToken, { from: safeOwner })
+
+  //Create  baseToken and add it to the exchange
+  const { id: baseTokenId, token: baseToken } = await addCustomMintableTokenToExchange(
+    exchange,
+    baseTokenSymbol,
+    baseTokenDecimals,
+    safeOwner,
+    artifacts
+  )
+  const depositAmountbaseToken = toErc20Units(amountbaseToken, baseTokenDecimals)
+  await baseToken.mint(masterSafe.address, depositAmountbaseToken, { from: safeOwner })
+
+  console.log(exchange.address)
+  console.log(await exchange.feeToken())
+  // copy networks also into nodemodule files:
+  fs.copyFile(
+    "build/contracts/BatchExchange.json",
+    "node_modules/@gnosis.pm/dex-contracts/build/contracts/BatchExchange.json",
+    (err) => {
+      if (err) throw err
+      console.log("Created BatchExchange.json")
+    }
+  )
+  // Build orders
+  const orderTransaction = await buildOrders(
+    masterSafe.address,
+    bracketAddresses,
+    baseTokenId,
+    quoteTokenId,
+    lowestLimit,
+    highestLimit,
+    exchange
+  )
+  await execTransaction(masterSafe, safeOwner, orderTransaction)
+
+  console.log(exchange.address)
+  console.log(await exchange.feeToken())
+  // Make transfers
+  const batchTransaction = await buildTransferApproveDepositFromOrders(
+    masterSafe.address,
+    bracketAddresses,
+    baseToken.address,
+    quoteToken.address,
+    lowestLimit,
+    highestLimit,
+    currentPrice,
+    depositAmountQuoteToken,
+    depositAmountbaseToken,
+    exchange
+  )
+  await execTransaction(masterSafe, safeOwner, batchTransaction)
+}
+
+module.exports = async (callback, accounts) => {
+  const tradeInfo = {
+    numBrackets: 2,
+    lowestLimit: 100,
+    highestLimit: 300,
+    currentPrice: 200,
+    amountQuoteToken: 10,
+    amountbaseToken: 10,
+    quoteTokenInfo: { symbol: "DAI", decimals: 18 },
+    baseTokenInfo: { symbol: "WETH", decimals: 18 },
+  }
+  try {
+    await testAutomaticDeposits(tradeInfo, await web3.eth.getAccounts().then((accounts) => accounts[0]), artifacts)
+
+    callback()
+  } catch (error) {
+    console.log(error.response)
+    callback(error)
+  }
+}

--- a/scripts/ganache/setup_thegraph_data.js
+++ b/scripts/ganache/setup_thegraph_data.js
@@ -62,15 +62,6 @@ const testAutomaticDeposits = async function (tradeInfo, safeOwner, artifacts = 
   const depositAmountbaseToken = toErc20Units(amountbaseToken, baseTokenDecimals)
   await baseToken.mint(masterSafe.address, depositAmountbaseToken, { from: safeOwner })
 
-  // copy networks also into nodemodule files:
-  fs.copyFile(
-    "build/contracts/BatchExchange.json",
-    "node_modules/@gnosis.pm/dex-contracts/build/contracts/BatchExchange.json",
-    (err) => {
-      if (err) throw err
-      console.log("Created BatchExchange.json")
-    }
-  )
   // Build orders
   const orderTransaction = await buildOrders(
     masterSafe.address,

--- a/scripts/ganache/setup_thegraph_data.js
+++ b/scripts/ganache/setup_thegraph_data.js
@@ -62,8 +62,6 @@ const testAutomaticDeposits = async function (tradeInfo, safeOwner, artifacts = 
   const depositAmountbaseToken = toErc20Units(amountbaseToken, baseTokenDecimals)
   await baseToken.mint(masterSafe.address, depositAmountbaseToken, { from: safeOwner })
 
-  console.log(exchange.address)
-  console.log(await exchange.feeToken())
   // copy networks also into nodemodule files:
   fs.copyFile(
     "build/contracts/BatchExchange.json",
@@ -85,8 +83,6 @@ const testAutomaticDeposits = async function (tradeInfo, safeOwner, artifacts = 
   )
   await execTransaction(masterSafe, safeOwner, orderTransaction)
 
-  console.log(exchange.address)
-  console.log(await exchange.feeToken())
   // Make transfers
   const batchTransaction = await buildTransferApproveDepositFromOrders(
     masterSafe.address,


### PR DESCRIPTION
[Don't consider this as a regular PR, it is only here to share code for demonstrating a challenge]

This PR highlights the following challenge:

- Currently, the network information during the deployment of the BatchExchange are not written into any BatchExchange.json abi file. E.g. I want to run the new script ./setup_thegraph_data.js against ganache.
- Hence, it is impossible to run scripts against ganache, which want to use a previously deployed BatchExchange, unless the abi file is manipulated by hand.

Hence, I think we should export the BatchExchange contract in the BatchExchange npm package, instead of just exporting its artifacts