### PR TITLE
Remove unused dependency @gnosis.pm/mock-contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "networks-extract": "CONF_FILE=$(pwd)'/migration_conf.js'  node node_modules/@gnosis.pm/util-contracts/src/extract_network_info.js"
   },
   "devDependencies": {
-    "@gnosis.pm/mock-contract": "^3.0.0",
     "eslint": "^7.6.0",
     "eslint-plugin-jsdoc": "^30.2.1",
     "eslint-plugin-no-only-tests": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,13 +205,6 @@
   dependencies:
     "@gnosis.pm/util-contracts" "2.0.0"
 
-"@gnosis.pm/mock-contract@^3.0.0":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/mock-contract/-/mock-contract-3.0.8.tgz#3794226161965396710ee0bec5cd809f60ca8d72"
-  integrity sha512-ZsLXSxbKwhEVR4t1CQ1Wxv3g9Q3YHlO0BQcH6XWpoeOcM8pND0ZTPz99ExnR4XCn2o5GlQT5ffNcMD+NAmibBg==
-  dependencies:
-    ethereumjs-abi "^0.6.5"
-
 "@gnosis.pm/owl-token@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/owl-token/-/owl-token-3.1.0.tgz#f7da8c43cd6bbcc8c871a44eaef767c86ac23458"
@@ -3274,7 +3267,7 @@ ethereum-protocol@^1.0.1:
   resolved "https://registry.yarnpkg.com/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz#b7d68142f4105e0ae7b5e178cf42f8d4dc4b93cf"
   integrity sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg==
 
-ethereumjs-abi@^0.6.5, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+"ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b"
   dependencies:


### PR DESCRIPTION
I was surprised that the major update of `@gnosis.pm/mock-contract` in PR #407 didn't cause any failure and checked where this package is used. It seems it's not used anywhere in the JS code and I don't see any NPM script that would need it.

Let me know if you know why this package should stay, otherwise you can approve this PR.