### PR TITLE
[do-not-merge] List old brackets

### DIFF
--- a/scripts/get_old_deployed_brackets.js
+++ b/scripts/get_old_deployed_brackets.js
@@ -1,0 +1,89 @@
+const createCsvWriter = require("csv-writer").createObjectCsvWriter
+const { sleep } = require("./utils/js_helpers")
+const { decodeOrders } = require("@gnosis.pm/dex-contracts")
+const { fetchTokenInfoFromExchange, getExchange, getSafe, isOnlySafeOwner } = require("./utils/trading_strategy_helpers")(
+  web3,
+  artifacts
+)
+const { default_yargs } = require("./utils/default_yargs")
+
+const GnosisSafeProxyFactory = artifacts.require("GnosisSafeProxyFactory")
+
+const argv = default_yargs
+  .option("masterSafe", {
+    type: "string",
+    describe: "Address of Gnosis Safe owning every bracket",
+    demandOption: true,
+  })
+  .option("outputFile", {
+    type: "string",
+    describe: "Path and file name for the output of the script",
+    demandOption: false,
+  }).argv
+
+module.exports = async (callback) => {
+  try {
+    const proxyFactory = await GnosisSafeProxyFactory.deployed()
+
+    const events = await proxyFactory.getPastEvents("ProxyCreation", {
+      fromBlock: 0,
+      toBlock: "latest",
+    })
+    const allDeployedGnosisProxies = events.map((object) => object.returnValues.proxy)
+
+    const bracketAddresses = []
+    const totalProxies = allDeployedGnosisProxies.length
+    let step = 0
+    for (const proxy of allDeployedGnosisProxies) {
+      if (await isOnlySafeOwner(argv.masterSafe, proxy)) {
+        console.log(step, "out of", totalProxies, "owned by master safe, added to list")
+        bracketAddresses.push(proxy)
+      } else {
+        console.log(step, "out of", totalProxies, "not owned by master safe")
+      }
+      step++
+    }
+
+    console.log("The following addresses have been deployed from your MASTER SAFE: ", bracketAddresses.join())
+
+    // writing the brackets into a csv file
+    const csvWriter = createCsvWriter({
+      path: argv.outputFile || "./bracket-addresses.csv",
+      header: [
+        { id: "Address", title: "Address" },
+        { id: "Type", title: "Type" },
+        { id: "Description", title: "Description" },
+        { id: "Tags", title: "Tags" },
+      ],
+    })
+
+    const exchange = await getExchange(web3)
+    const records = []
+    const totalBrackets = bracketAddresses.length
+    step = 0
+    for (const bracketAddress of bracketAddresses) {
+      sleep(1000) // sleep 1s to avoid Infura rate limit
+      console.log("Reading orders of bracket", step, "out of", totalBrackets)
+      const orders = decodeOrders(await exchange.getEncodedUserOrders.call(bracketAddress))
+      let tradingPair
+      if (orders.length > 0) {
+        const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [orders[0].buyToken, orders[0].sellToken])
+        tradingPair =
+          (await tokenInfoPromises[orders[0].sellToken]).symbol + " - " + (await tokenInfoPromises[orders[0].buyToken]).symbol
+      } else {
+        tradingPair = " - not yet defined -"
+      }
+      return {
+        Address: bracketAddress,
+        Type: "liquidity",
+        Description: "bracket-strategy on the pair " + tradingPair + " controlled by master safe: " + argv.masterSafe,
+        Tags: "bracket-strategy",
+      }
+    }
+    await csvWriter.writeRecords(records)
+
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/scripts/get_old_deployed_brackets.js
+++ b/scripts/get_old_deployed_brackets.js
@@ -1,13 +1,13 @@
 const createCsvWriter = require("csv-writer").createObjectCsvWriter
-const { sleep } = require("./utils/js_helpers")
+const { sleep, uniqueItems } = require("./utils/js_helpers")
 const { decodeOrders } = require("@gnosis.pm/dex-contracts")
-const { fetchTokenInfoFromExchange, getExchange, getSafe, isOnlySafeOwner } = require("./utils/trading_strategy_helpers")(
-  web3,
-  artifacts
-)
+const { fetchTokenInfoFromExchange, getExchange } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const BatchRequest = require("./utils/batch_request")(web3)
+
 const { default_yargs } = require("./utils/default_yargs")
 
 const GnosisSafeProxyFactory = artifacts.require("GnosisSafeProxyFactory")
+const GnosisSafe = artifacts.require("GnosisSafe")
 
 const argv = default_yargs
   .option("masterSafe", {
@@ -21,27 +21,99 @@ const argv = default_yargs
     demandOption: false,
   }).argv
 
+const findOwnedBracketsAmong = async function (proxies, debug = false) {
+  const log = debug ? (...a) => console.log(...a) : () => {}
+  const errorLog = debug ? (...a) => console.error(...a) : () => {}
+
+  log("Creating batch request")
+  const batch = new BatchRequest()
+  const bracketAddresses = []
+
+  let i = 0
+  for (const proxy of proxies) {
+    i++
+    log("Adding proxy", i, "out of", proxies.length, "to batch, address", proxy)
+    // can't use Truffle's GnosisSafe.deployed().contract because the .deployed() step is an extra request
+    const safe = new web3.eth.Contract(GnosisSafe.abi, proxy)
+    batch.add(safe.methods.getOwners().call)
+  }
+  log("Executing batch request")
+  const responses = await Promise.allSettled(batch.execute())
+  log("Batch request executed")
+
+  let errorCount = 0
+  for (const [i, proxy] of Object.entries(proxies)) {
+    if (responses[i].status === "fulfilled") {
+      const owners = responses[i].value
+      log(proxy, owners)
+      if (owners.length === 1 && owners[0].toLowerCase() === argv.masterSafe.toLowerCase()) {
+        log("Proxy", i, "(", proxy, ")", "is owned.")
+        bracketAddresses.push(proxy)
+      }
+    } else {
+      errorCount += 1
+      console.error(responses[i].reason)
+    }
+  }
+
+  if (errorCount !== 0) {
+    errorLog("Error count:", errorCount)
+  }
+
+  return bracketAddresses
+}
+
+const ordersOf = async function (brackets, exchange, debug = false) {
+  const log = debug ? (...a) => console.log(...a) : () => {}
+  //const errorLog = debug ? (...a) => console.error(...a) : () => {}
+
+  log("Creating batch request")
+  const batch = new BatchRequest()
+  const ordersPerBracket = []
+
+  let i = 0
+  for (const bracket of brackets) {
+    i++
+    log("Adding bracket", i, "out of", brackets.length, "to batch, address", bracket)
+    batch.add(exchange.contract.methods.getEncodedUserOrders(bracket).call)
+  }
+  log("Executing batch request")
+  const responses = await Promise.all(batch.execute())
+  log("Batch request executed")
+
+  for (const response of responses) {
+    ordersPerBracket.push(decodeOrders(response))
+  }
+
+  return ordersPerBracket
+}
+
 module.exports = async (callback) => {
   try {
+    const latestBlock = await web3.eth.getBlockNumber()
     const proxyFactory = await GnosisSafeProxyFactory.deployed()
 
+    // NOTE: the events captured by the following line are only those created
+    // in a direct interaction with the contract. The addresses created with
+    // FleetFactory do not appear here.
     const events = await proxyFactory.getPastEvents("ProxyCreation", {
       fromBlock: 0,
-      toBlock: "latest",
+      toBlock: latestBlock,
     })
     const allDeployedGnosisProxies = events.map((object) => object.returnValues.proxy)
 
     const bracketAddresses = []
-    const totalProxies = allDeployedGnosisProxies.length
-    let step = 0
-    for (const proxy of allDeployedGnosisProxies) {
-      if (await isOnlySafeOwner(argv.masterSafe, proxy)) {
-        console.log(step, "out of", totalProxies, "owned by master safe, added to list")
-        bracketAddresses.push(proxy)
-      } else {
-        console.log(step, "out of", totalProxies, "not owned by master safe")
-      }
-      step++
+
+    // Infura can't handle too many bundled requests
+    let bundleSize = 500
+    let bundleStart = 0
+    // Intentionally inefficient to pound less harshly on Infura
+    while (bundleStart < allDeployedGnosisProxies.length) {
+      sleep(10000)
+      bracketAddresses.push(
+        ...(await findOwnedBracketsAmong(allDeployedGnosisProxies.slice(bundleStart, bundleStart + bundleSize)))
+      )
+      bundleStart += bundleSize
     }
 
     console.log("The following addresses have been deployed from your MASTER SAFE: ", bracketAddresses.join())
@@ -58,13 +130,35 @@ module.exports = async (callback) => {
     })
 
     const exchange = await getExchange(web3)
+    const bracketOrders = []
+
+    bundleSize = 50
+    bundleStart = 0
+    while (bundleStart < bracketAddresses.length) {
+      sleep(10000)
+      bracketOrders.push(...(await ordersOf(bracketAddresses.slice(bundleStart, bundleStart + bundleSize), exchange)))
+      bundleStart += bundleSize
+    }
+
+    let tokensInvolved = []
+    bracketOrders.forEach((orders) => {
+      if (orders && orders.length > 1) {
+        tokensInvolved.push(orders[0].buyToken, orders[0].sellToken)
+      }
+    })
+    tokensInvolved = uniqueItems(tokensInvolved)
+    console.log("Tokens used in some brackets:", tokensInvolved)
+
+    sleep(10000)
+    fetchTokenInfoFromExchange(exchange, tokensInvolved)
+
     const records = []
     const totalBrackets = bracketAddresses.length
-    step = 0
-    for (const bracketAddress of bracketAddresses) {
-      sleep(1000) // sleep 1s to avoid Infura rate limit
+    let step = 0
+    for (const [i, bracketAddress] of Object.entries(bracketAddresses)) {
+      step++
       console.log("Reading orders of bracket", step, "out of", totalBrackets)
-      const orders = decodeOrders(await exchange.getEncodedUserOrders.call(bracketAddress))
+      const orders = bracketOrders[i]
       let tradingPair
       if (orders.length > 0) {
         const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [orders[0].buyToken, orders[0].sellToken])
@@ -73,13 +167,14 @@ module.exports = async (callback) => {
       } else {
         tradingPair = " - not yet defined -"
       }
-      return {
+      records.push({
         Address: bracketAddress,
         Type: "liquidity",
         Description: "bracket-strategy on the pair " + tradingPair + " controlled by master safe: " + argv.masterSafe,
         Tags: "bracket-strategy",
-      }
+      })
     }
+
     await csvWriter.writeRecords(records)
 
     callback()

--- a/scripts/utils/batch_request.js
+++ b/scripts/utils/batch_request.js
@@ -1,0 +1,32 @@
+// https://github.com/ethereum/web3.js/issues/1446
+
+module.exports = function (web3) {
+  class BatchRequest {
+    constructor() {
+      this.promises = []
+      this.batch = new web3.BatchRequest()
+    }
+
+    add(call, ...params) {
+      this.promises.push(
+        new Promise((resolve, reject) => {
+          const request = call.request(...params, (error, data) => {
+            if (error) {
+              reject(error)
+            } else {
+              resolve(data)
+            }
+          })
+          this.batch.add(request)
+        })
+      )
+    }
+
+    execute() {
+      this.batch.execute()
+      return this.promises
+    }
+  }
+
+  return BatchRequest
+}


### PR DESCRIPTION
This PR creates a modified version of the script `get_deployed_brackets` that works with brackets created using `GnosisSafeProxyFactory` directly.

This is more of a test bench than production code, but could be used to get information on the old brackets for Dune.

I also notice that the brackets obtained by this script are more than those available in our list of old brackets, and in general the existing list of old brackets contains many inconsistencies.

@josojo, this PR might be of interest to you, it's a first attempt to use batch requests.
I fear that batch requests are not going to solve our issues with `Error: Invalid JSON RPC response: {}` however, I encountered this error many times and inconsistently when trying out this script.

Test plan
```
npx truffle exec scripts/get_old_deployed_brackets.js --masterSafe=0x583788f490a278DB2a8d6D7226264b4985f75678 --outputFile=test.csv --network=mainnet
```
Sample output:
```
<snip>
The following addresses have been deployed from your MASTER SAFE: <snip>
Records written to file.
Number of owned brackets: 426.
Number of errors when retrieving proxy owner info: 225 out of a total of 3224.
Tokens traded by the brackets: [
   1,  7, 15,  9, 16,  4,
   8, 18, 11, 13,  3, 10,
  19,  2,  0
]
```

Note that the error count that is printed on screen when searching for the owned brackets does not necessarily mean that there is an error in the retrieved information, since some Safe proxies do not use the right templates or their owners cannot be retrieved for other legitimate reasons.