### PR TITLE
Remove ownership check from transaction builder functions

### DIFF
--- a/scripts/deposit.js
+++ b/scripts/deposit.js
@@ -1,8 +1,7 @@
 const fs = require("fs").promises
-const assert = require("assert")
 
 const { signAndSend, transactionExistsOnSafeServer } = require("./utils/gnosis_safe_server_interactions")(web3, artifacts)
-const { buildDepositFromList, isOnlyFleetOwner } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { buildDepositFromList, assertIsOnlyFleetOwner } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { promptUser } = require("./utils/user_interface_helpers")
 const { default_yargs } = require("./utils/default_yargs")
 const argv = default_yargs
@@ -32,12 +31,9 @@ module.exports = async (callback) => {
     console.log("Preparing transaction data...")
     const transaction = await buildDepositFromList(masterSafe.address, deposits, true)
 
-    assert(
-      await isOnlyFleetOwner(
-        masterSafe.address,
-        deposits.map(({ bracketAddress }) => bracketAddress)
-      ),
-      "All depositors must be owned only by the master Safe"
+    await assertIsOnlyFleetOwner(
+      masterSafe.address,
+      deposits.map(({ bracketAddress }) => bracketAddress)
     )
 
     if (!argv.verify) {

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -1,8 +1,10 @@
 const fs = require("fs").promises
-const assert = require("assert")
 
 const { signAndSend } = require("./utils/gnosis_safe_server_interactions")(web3, artifacts)
-const { buildTransferApproveDepositFromList, isOnlyFleetOwner } = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { buildTransferApproveDepositFromList, assertIsOnlyFleetOwner } = require("./utils/trading_strategy_helpers")(
+  web3,
+  artifacts
+)
 const { promptUser } = require("./utils/user_interface_helpers")
 const { default_yargs } = require("./utils/default_yargs")
 const argv = default_yargs
@@ -24,12 +26,9 @@ module.exports = async (callback) => {
 
     const deposits = JSON.parse(await fs.readFile(argv.depositFile, "utf8"))
 
-    assert(
-      await isOnlyFleetOwner(
-        masterSafe.address,
-        deposits.map(({ bracketAddress }) => bracketAddress)
-      ),
-      "All depositors must be owned only by the master Safe"
+    await assertIsOnlyFleetOwner(
+      masterSafe.address,
+      deposits.map(({ bracketAddress }) => bracketAddress)
     )
 
     console.log("Preparing transaction data...")

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -62,6 +62,17 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   }
 
   /**
+   * Fail if the address used as the first argument is not the only owner of all the Safes
+   * specified in the given array.
+   *
+   * @param {Address} masterAddress address pointing to the candidate only owner of the Safe
+   * @param {(SmartContract|Address)[]} fleet array of Safes that might be owned by master
+   */
+  const assertIsOnlyFleetOwner = async function (masterAddress, fleet) {
+    assert(await isOnlyFleetOwner(masterAddress, fleet), "All depositors must be owned only by the master Safe")
+  }
+
+  /**
    * Checks that the address used as the first argument is the only owner of all the Safes
    * specified in the given array.
    *
@@ -756,6 +767,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
   return {
     assertNoAllowances,
+    assertIsOnlyFleetOwner,
     buildBracketTransactionForTransferApproveDeposit,
     buildDepositFromList,
     buildOrders,


### PR DESCRIPTION
Remove ownership checks from all transaction bundling functions.
The checks are instead performed in the scripts using these functions. 
Note that the check in `complete_liquidity_provision.js` doesn't need to be included since it's already performed in the execution of the script.

See #438 for motivation.

### Test plan

Success: unit tests.
Failure:
```
npx truffle exec scripts/deposit.js --masterSafe=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636 --depositFile=examples/exampleDepositList.json --network=rinkeby --verify
npx truffle exec scripts/transfer_approve_deposit.js --masterSafe=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636 --depositFile=examples/exampleDepositList.json --network=rinkeby
```