### PR TITLE
Remove Math.random() from FleetFactoryDeterministic tests

### DIFF
--- a/test/fleet_factory_deterministic.js
+++ b/test/fleet_factory_deterministic.js
@@ -61,7 +61,7 @@ contract("FleetFactoryDeterministic", function (accounts) {
 
     it("are owned by master", async () => {
       const numberOfSafes = 13
-      const randomInt = Math.round(Math.random() * 1e12)
+      const randomInt = 12345
       const transcript = await fleetFactory.deployFleetWithNonce(
         master.address,
         numberOfSafes,
@@ -81,7 +81,7 @@ contract("FleetFactoryDeterministic", function (accounts) {
     it("have the right template", async () => {
       const numberOfSafes = 13
       const templateAddress = gnosisSafeMasterCopy.address
-      const randomInt = Math.round(Math.random() * 1e12)
+      const randomInt = 12345
       const transcript = await fleetFactory.deployFleetWithNonce(
         master.address,
         numberOfSafes,


### PR DESCRIPTION
Apply best practices! :)

Tests for FleetFactoryDeterministic are more reproducible after removing explicit use of randomness.

### Test plan

Run `yarn test test/fleet_factory_deterministic.js` twice and observe that all tests are passing in both runs.