### PR TITLE
More efficient request withdraw

### DIFF
--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -3,7 +3,12 @@ const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { defaultWithdrawYargs, prepareWithdrawRequest } = require("./wrapper/withdraw")(web3, artifacts)
 const { promptUser } = require("./utils/user_interface_helpers")
 
-const argv = defaultWithdrawYargs.argv
+const argv = defaultWithdrawYargs.option("noBalanceCheck", {
+  type: "boolean",
+  default: false,
+  describe:
+    "Request withdraw for tokens without checking if the token has no balance. Useful to account for trading that might be happening during the withdraw request",
+}).argv
 
 module.exports = async (callback) => {
   try {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -343,6 +343,7 @@ contract("Withdraw script", function (accounts) {
       const argv = {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
+        noBalanceCheck: true,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
       const requestTransaction = await prepareWithdrawRequest(argv, false, globalPriceStorage)


### PR DESCRIPTION
Requesting a withdraw with this PR is faster and more gas efficient.

Withdraw requests are not performed if the balance held by the brackets is below 1 USD.
The old behavior is still available: it's enough to specify the flag `--noBalanceCheck`.

### Test plan

Same behavior as current master with the flag `--noBalanceCheck`:
```
npx truffle exec scripts/request_withdraw.js --network=mainnet --brackets=0x002184C787c58638D41D7b6F35B38b2A967E5033,0x00Adb0E4c11BBe10A694678647A2076f62c12e11,0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025,0x013DC982fEe3d7f4f8149BE53cDaD3dA4aDad162,0x01ef26514b9275CFe4EC4cb9552611F29C845963,0x024db5796C3CaAB34e9c0995A1DF17A91EECA6cC,0x026617a003616C8F4a660DB526Ac068c7bd12490,0x02CcD30740867976Cc42049275A82392fC91eA26,0x0394626f556f772D67c928bb42760c091fF60804,0x052253771E92a5Ff3c31163492b7e9101e0FC62f,0x068183e2057651a1C124c994489236447f9a5030,0x069741B2fFC5b1Af74ABbC8f8573bA70e3808409,0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1,0x07442F52C92152dE8A8A3984de7A999770809E57,0x077b3B2DD6C0a0004d1eA775D8983Bd2E4CbBb67,0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F,0x087Dc2C109a14b5Aa07Da01B6326DC1c20fb44e5,0x0F27680805e50Fa0ab0dDAEa026ec3Da292a24DF,0x0b631108E1603697b88ddd615A085DED7Ff5925c,0x0c4bBfAa02b14924554715145f83560843E249b9,0x0d655471115590137cE3986A111CC5db1c2714EA,0x1039EDd1d100185Eaf45141C99227D1B994CE11F,0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6,0x164dbA559A5273b05E98fdf2d50d87CA65C5BFD5,0x167460E04fa7f08AB2470dDdeDe0D57c4d5F0883,0x18A4F048a42674105F00700017C8098ed62dF4d9,0x19601E6825D2715CBD22B6AEC9B2528eDEe974A6,0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf,0x1DB4597389199F8851B53eD48aE90bF451C564Fe,0x1E800A7E4b103cA2C270e162E66d1B099eC8C1A7 --tokenIds 1,4,7 --masterSafe=0x583788f490a278DB2a8d6D7226264b4985f75678 --noBalanceCheck
```
New behavior. First check current bracket balances for USDC, DAI, and WETH:
```
npx truffle exec scripts/balance_viewer.js --network=mainnet --brackets=0x002184C787c58638D41D7b6F35B38b2A967E5033,0x00Adb0E4c11BBe10A694678647A2076f62c12e11,0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025,0x013DC982fEe3d7f4f8149BE53cDaD3dA4aDad162,0x01ef26514b9275CFe4EC4cb9552611F29C845963,0x024db5796C3CaAB34e9c0995A1DF17A91EECA6cC,0x026617a003616C8F4a660DB526Ac068c7bd12490,0x02CcD30740867976Cc42049275A82392fC91eA26,0x0394626f556f772D67c928bb42760c091fF60804,0x052253771E92a5Ff3c31163492b7e9101e0FC62f,0x068183e2057651a1C124c994489236447f9a5030,0x069741B2fFC5b1Af74ABbC8f8573bA70e3808409,0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1,0x07442F52C92152dE8A8A3984de7A999770809E57,0x077b3B2DD6C0a0004d1eA775D8983Bd2E4CbBb67,0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F,0x087Dc2C109a14b5Aa07Da01B6326DC1c20fb44e5,0x0F27680805e50Fa0ab0dDAEa026ec3Da292a24DF,0x0b631108E1603697b88ddd615A085DED7Ff5925c,0x0c4bBfAa02b14924554715145f83560843E249b9,0x0d655471115590137cE3986A111CC5db1c2714EA,0x1039EDd1d100185Eaf45141C99227D1B994CE11F,0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6,0x164dbA559A5273b05E98fdf2d50d87CA65C5BFD5,0x167460E04fa7f08AB2470dDdeDe0D57c4d5F0883,0x18A4F048a42674105F00700017C8098ed62dF4d9,0x19601E6825D2715CBD22B6AEC9B2528eDEe974A6,0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf,0x1DB4597389199F8851B53eD48aE90bF451C564Fe,0x1E800A7E4b103cA2C270e162E66d1B099eC8C1A7 | grep --extended-regexp "DAI|USDC|WETH"
<only relevant balances printed>
Balance of 0x002184C787c58638D41D7b6F35B38b2A967E5033 for token WETH: 14.723807342244400645
Balance of 0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1 for token DAI: 1511.426583384273544549
Balance of 0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F for token USDC: 5376.881837
Balance of 0x0c4bBfAa02b14924554715145f83560843E249b9 for token USDC: 181.131157
Balance of 0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6 for token USDC: 5294.819307
Balance of 0x18A4F048a42674105F00700017C8098ed62dF4d9 for token DAI: 5755.174733299900193551
Balance of 0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf for token USDC: 151.831511
Balance of 0x1DB4597389199F8851B53eD48aE90bF451C564Fe for token WETH: 14.702287020599660837
```



Then note that only addresses with a non-negligible balance are included in the withdraw request created as:
```
npx truffle exec scripts/request_withdraw.js --network=mainnet --brackets=0x002184C787c58638D41D7b6F35B38b2A967E5033,0x00Adb0E4c11BBe10A694678647A2076f62c12e11,0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025,0x013DC982fEe3d7f4f8149BE53cDaD3dA4aDad162,0x01ef26514b9275CFe4EC4cb9552611F29C845963,0x024db5796C3CaAB34e9c0995A1DF17A91EECA6cC,0x026617a003616C8F4a660DB526Ac068c7bd12490,0x02CcD30740867976Cc42049275A82392fC91eA26,0x0394626f556f772D67c928bb42760c091fF60804,0x052253771E92a5Ff3c31163492b7e9101e0FC62f,0x068183e2057651a1C124c994489236447f9a5030,0x069741B2fFC5b1Af74ABbC8f8573bA70e3808409,0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1,0x07442F52C92152dE8A8A3984de7A999770809E57,0x077b3B2DD6C0a0004d1eA775D8983Bd2E4CbBb67,0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F,0x087Dc2C109a14b5Aa07Da01B6326DC1c20fb44e5,0x0F27680805e50Fa0ab0dDAEa026ec3Da292a24DF,0x0b631108E1603697b88ddd615A085DED7Ff5925c,0x0c4bBfAa02b14924554715145f83560843E249b9,0x0d655471115590137cE3986A111CC5db1c2714EA,0x1039EDd1d100185Eaf45141C99227D1B994CE11F,0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6,0x164dbA559A5273b05E98fdf2d50d87CA65C5BFD5,0x167460E04fa7f08AB2470dDdeDe0D57c4d5F0883,0x18A4F048a42674105F00700017C8098ed62dF4d9,0x19601E6825D2715CBD22B6AEC9B2528eDEe974A6,0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf,0x1DB4597389199F8851B53eD48aE90bF451C564Fe,0x1E800A7E4b103cA2C270e162E66d1B099eC8C1A7 --tokenIds 1,4,7 --masterSafe=0x583788f490a278DB2a8d6D7226264b4985f75678
<snip>
Started building withdraw transaction.
Requesting withdrawal of all WETH from BatchExchange on behalf of Safe 0x1DB4597389199F8851B53eD48aE90bF451C564Fe
Requesting withdrawal of all WETH from BatchExchange on behalf of Safe 0x002184C787c58638D41D7b6F35B38b2A967E5033
Requesting withdrawal of all USDC from BatchExchange on behalf of Safe 0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf
Requesting withdrawal of all DAI from BatchExchange on behalf of Safe 0x18A4F048a42674105F00700017C8098ed62dF4d9
Requesting withdrawal of all DAI from BatchExchange on behalf of Safe 0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1
Requesting withdrawal of all USDC from BatchExchange on behalf of Safe 0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F
Requesting withdrawal of all USDC from BatchExchange on behalf of Safe 0x0c4bBfAa02b14924554715145f83560843E249b9
Requesting withdrawal of all USDC from BatchExchange on behalf of Safe 0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6
```