### PR TITLE
Automatically retrieve tokens to withdraw

### DIFF
--- a/scripts/balance_viewer.js
+++ b/scripts/balance_viewer.js
@@ -1,10 +1,12 @@
 const BN = require("bn.js")
 const { getWithdrawableAmount, decodeOrders } = require("@gnosis.pm/dex-contracts")
 
-const { getExchange, getDeployedBrackets, fetchTokenInfoFromExchange } = require("./utils/trading_strategy_helpers")(
-  web3,
-  artifacts
-)
+const {
+  getExchange,
+  getDeployedBrackets,
+  fetchTokenInfoFromExchange,
+  retrieveTradedTokensPerBracket,
+} = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { default_yargs, checkBracketsForDuplicate } = require("./utils/default_yargs")
 const { fromErc20Units } = require("./utils/printing_tools")
 const { uniqueItems } = require("./utils/js_helpers")
@@ -61,25 +63,17 @@ module.exports = async (callback) => {
     }
     const exchange = await exchangePromise
 
-    const detailedBrackets = await Promise.all(
-      bracketAddresses.map(async (bracketAddress) => {
-        const orders = decodeOrders(await exchange.getEncodedUserOrders.call(bracketAddress))
-        let tradedTokenIds = []
-        for (const order of orders) {
-          tradedTokenIds.push(order.buyToken, order.sellToken)
-        }
-        tradedTokenIds = uniqueItems(tradedTokenIds)
-        const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, tradedTokenIds)
-        return {
-          bracketAddress,
-          tokenIds: tradedTokenIds,
-          tokenInfoPromises,
-        }
-      })
-    )
+    const detailedBrackets = await retrieveTradedTokensPerBracket(bracketAddresses)
+
+    const tradedTokenIds = []
+    for (const { tokenIds } of detailedBrackets) {
+      tradedTokenIds.push(...tokenIds)
+    }
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, tradedTokenIds)
+
     console.log("Recovering token balances per bracket...")
     const tokenBalancesPerUser = await Promise.all(
-      detailedBrackets.map(async ({ bracketAddress, tokenIds, tokenInfoPromises }) => {
+      detailedBrackets.map(async ({ bracketAddress, tokenIds }) => {
         const tokenBalances = []
         for (const tokenId of tokenIds) {
           const tokenData = await tokenInfoPromises[tokenId]

--- a/scripts/utils/strategy_simulator.js
+++ b/scripts/utils/strategy_simulator.js
@@ -73,7 +73,7 @@ module.exports = function (web3, artifacts) {
       depositAmountbaseToken
     )
     await execTransaction(masterSafe, safeOwner, batchTransaction)
-    return { bracketAddresses: bracketAddresses, quoteToken: quoteToken, baseToken: baseToken }
+    return { bracketAddresses, quoteToken, baseToken, masterSafe }
   }
 
   const prepareTokenRegistration = async function (account, exchange) {

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -10,10 +10,12 @@ module.exports = function (web3, artifacts) {
     buildWithdrawClaim,
     buildTransferFundsToMaster,
     buildWithdrawAndTransferFundsToMaster,
+    retrieveTradedTokensPerBracket,
   } = require("../utils/trading_strategy_helpers")(web3, artifacts)
   const { default_yargs, checkBracketsForDuplicate } = require("../utils/default_yargs")
   const { fromErc20Units, shortenedAddress } = require("../utils/printing_tools")
   const { MAXUINT256, ONE } = require("../utils/constants")
+  const { uniqueItems } = require("../utils/js_helpers")
 
   const assertGoodArguments = function (argv) {
     if (!argv.masterSafe) throw new Error("Argument error: --masterSafe is required")
@@ -25,9 +27,7 @@ module.exports = function (web3, artifacts) {
     }
 
     if (argv.brackets) {
-      if (!argv.tokens && !argv.tokenIds) {
-        throw new Error("Argument error: one of --tokens, --tokenIds must be given when using --brackets")
-      } else if (argv.tokens && argv.tokenIds) {
+      if (argv.tokens && argv.tokenIds) {
         throw new Error("Argument error: only one of --tokens, --tokenIds is required when using --brackets")
       }
     } else {
@@ -48,43 +48,75 @@ module.exports = function (web3, artifacts) {
   ) {
     const log = printOutput ? (...a) => console.log(...a) : () => {}
 
-    let withdrawals
-    let tokenInfoPromises
     if (withdrawalFile) {
-      withdrawals = JSON.parse(await fs.readFile(withdrawalFile, "utf8"))
-      tokenInfoPromises = fetchTokenInfoForFlux(withdrawals)
-    } else {
-      const exchangePromise = getExchange(web3)
-      const tokenAddresses =
-        tokens || (await Promise.all(tokenIds.map(async (id) => (await exchangePromise).tokenIdToAddressMap(id))))
-      tokenInfoPromises = fetchTokenInfoAtAddresses(tokenAddresses)
-      const exchange = await exchangePromise
-
-      log("Retrieving amount of tokens to withdraw.")
-      const tokenDataList = await Promise.all(Object.entries(tokenInfoPromises).map(([, tokenDataPromise]) => tokenDataPromise))
-      const tokenBracketPairs = []
-      for (const tokenData of tokenDataList)
-        for (const bracketAddress of brackets) tokenBracketPairs.push([bracketAddress, tokenData])
-
-      const maxWithdrawableAmounts = await Promise.all(
-        tokenBracketPairs.map(([bracketAddress, tokenData]) => amountFunction(bracketAddress, tokenData, exchange))
-      )
-      withdrawals = []
-      for (const [index, amount] of maxWithdrawableAmounts.entries()) {
-        const token = tokenBracketPairs[index][1]
-        const bracketAddress = tokenBracketPairs[index][0]
-        const usdValue = await amountUSDValue(amount, token, globalPriceStorage)
-        if (usdValue.gte(ONE)) {
-          withdrawals.push({
-            bracketAddress,
-            tokenAddress: token.address,
-            amount,
-          })
-        } else {
-          log(`Skipping request for ${token.symbol} on bracket ${bracketAddress} since USD value < 1`)
-        }
+      const withdrawals = JSON.parse(await fs.readFile(withdrawalFile, "utf8"))
+      const tokenInfoPromises = fetchTokenInfoForFlux(withdrawals)
+      return {
+        withdrawals,
+        tokenInfoPromises,
       }
     }
+
+    const exchangePromise = getExchange(web3)
+
+    let bracketsWithTradedTokenAddresses = []
+    let tradedAddressesses = []
+    if (!tokens && !tokenIds) {
+      const bracketsWithTradedTokenIds = await retrieveTradedTokensPerBracket(brackets)
+      const tradedTokenIds = []
+      for (const { tokenIds } of bracketsWithTradedTokenIds) {
+        tradedTokenIds.push(...tokenIds)
+      }
+      const idToAddress = {}
+      await Promise.all(
+        uniqueItems(tradedTokenIds).map(async (tokenId) => {
+          idToAddress[tokenId] = await (await exchangePromise).tokenIdToAddressMap(tokenId)
+        })
+      )
+      tradedAddressesses = Object.values(idToAddress)
+
+      bracketsWithTradedTokenAddresses = bracketsWithTradedTokenIds.map(({ bracketAddress, tokenIds }) => ({
+        bracketAddress,
+        tokenAddresses: tokenIds.map((id) => idToAddress[id]),
+      }))
+    } else {
+      if (!tokens) {
+        tradedAddressesses = await Promise.all(tokenIds.map(async (id) => (await exchangePromise).tokenIdToAddressMap(id)))
+      } else {
+        tradedAddressesses = tokens
+      }
+      for (const bracketAddress of brackets) {
+        bracketsWithTradedTokenAddresses.push({
+          bracketAddress,
+          tokenAddresses: tradedAddressesses,
+        })
+      }
+    }
+
+    const withdrawals = []
+    const tokenInfoPromises = fetchTokenInfoAtAddresses(tradedAddressesses)
+    log("Retrieving amount of tokens to withdraw.")
+    await Promise.all(
+      bracketsWithTradedTokenAddresses.map(async ({ bracketAddress, tokenAddresses }) => {
+        await Promise.all(
+          tokenAddresses.map(async (tokenAddress) => {
+            const tokenData = await tokenInfoPromises[tokenAddress]
+            const amount = await amountFunction(bracketAddress, tokenData, await exchangePromise)
+            const usdValue = await amountUSDValue(amount, tokenData, globalPriceStorage)
+
+            if (usdValue.gte(ONE)) {
+              withdrawals.push({
+                bracketAddress,
+                tokenAddress,
+                amount,
+              })
+            } else {
+              log(`Skipping request for ${tokenData.symbol} on bracket ${bracketAddress} since USD value < 1`)
+            }
+          })
+        )
+      })
+    )
 
     return {
       withdrawals,

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -9,7 +9,10 @@ const MintableToken = artifacts.require("DetailedMintableToken")
 const GnosisSafe = artifacts.require("GnosisSafe")
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 
-const { deploySafe, addCustomMintableTokenToExchange } = require("../../scripts/utils/strategy_simulator")(web3, artifacts)
+const { deploySafe, addCustomMintableTokenToExchange, deployNewStrategy } = require("../../scripts/utils/strategy_simulator")(
+  web3,
+  artifacts
+)
 const { deployFleetOfSafes, buildTransferApproveDepositFromList } = require("../../scripts/utils/trading_strategy_helpers")(
   web3,
   artifacts
@@ -226,7 +229,47 @@ contract("Withdraw script", function (accounts) {
     })
   })
   describe("using explicit from addresses", () => {
-    it("requests withdrawals", async () => {
+    it("requests withdrawals with automatic token detection", async () => {
+      // tokens are detected based on posted orders
+      const { bracketAddresses, quoteToken, baseToken, masterSafe } = await deployNewStrategy(
+        {
+          numBrackets: 2,
+          lowestLimit: 300,
+          highestLimit: 500,
+          currentPrice: 400,
+          amountQuoteToken: "10000",
+          amountbaseToken: "50",
+          quoteTokenInfo: { decimals: 6, symbol: "USDC" },
+          baseTokenInfo: { decimals: 18, symbol: "WETH" },
+        },
+        gnosisSafeMasterCopy,
+        proxyFactory,
+        safeOwner,
+        exchange,
+        accounts
+      )
+
+      const argv = {
+        masterSafe: masterSafe.address,
+        brackets: bracketAddresses,
+      }
+
+      const globalPriceStorage = {}
+      globalPriceStorage["USDC-USDC"] = { price: 1.0 }
+      globalPriceStorage["WETH-USDC"] = { price: 400.0 }
+
+      const transaction = await prepareWithdrawRequest(argv, false, globalPriceStorage)
+      await execTransaction(masterSafe, safeOwner, transaction)
+
+      for (const bracketAddress of bracketAddresses) {
+        for (const tokenAddress of [quoteToken.address, baseToken.address]) {
+          const requestedWithdrawal = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0].toString()
+          assert.notEqual(requestedWithdrawal, "0", "Withdrawal was not requested")
+          assert.equal(requestedWithdrawal, bnMaxUint256.toString(), "Bad amount requested to withdraw")
+        }
+      }
+    })
+    it("requests withdrawals with addresses", async () => {
       const amounts = [
         { tokenData: { decimals: 6, symbol: "USDC" }, amount: "10000" },
         { tokenData: { decimals: 18, symbol: "WETH" }, amount: "50" },
@@ -492,14 +535,6 @@ contract("Withdraw script", function (accounts) {
           requestWithdraw: true,
         },
         error: "Argument error: one of --withdrawalFile, --brackets must be given",
-      },
-      {
-        argv: {
-          masterSafe: masterSafe.address,
-          requestWithdraw: true,
-          brackets: "0x0,0x1",
-        },
-        error: "Argument error: one of --tokens, --tokenIds must be given when using --brackets",
       },
       {
         argv: {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -270,7 +270,7 @@ contract("Withdraw script", function (accounts) {
       const notRequestedWithdrawalQuote = (
         await exchange.getPendingWithdraw(bracketAddresses[1], quoteToken.address)
       )[0].toString()
-      assert.equal(notRequestedWithdrawalQuote, "0", "Zero quote withdrawal was requested")
+      assert.equal(notRequestedWithdrawalQuote, "0", "Quote withdrawal was requested")
 
       const requestedWithdrawalBase = (await exchange.getPendingWithdraw(bracketAddresses[1], baseToken.address))[0].toString()
       assert.notEqual(requestedWithdrawalBase, "0", "Withdrawal was not requested")
@@ -279,7 +279,7 @@ contract("Withdraw script", function (accounts) {
       const notRequestedWithdrawalBase = (
         await exchange.getPendingWithdraw(bracketAddresses[0], baseToken.address)
       )[0].toString()
-      assert.equal(notRequestedWithdrawalBase, "0", "Zero base withdrawal was requested")
+      assert.equal(notRequestedWithdrawalBase, "0", "Base withdrawal was requested")
     })
     it("requests withdrawals with addresses", async () => {
       const amounts = [


### PR DESCRIPTION
To exit a CMM you need to specify which tokens you want to withdraw. This PR adds the option of detecting automatically from existing orders which tokens to withdraw for each bracket.

### Test plan

See output of `request_withdraw.js` with the new setup for a bunch of addresses that were deployed for very different pairs:
```
npx truffle exec scripts/request_withdraw.js --network=mainnet --brackets=0x002184C787c58638D41D7b6F35B38b2A967E5033,0x00Adb0E4c11BBe10A694678647A2076f62c12e11,0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025,0x013DC982fEe3d7f4f8149BE53cDaD3dA4aDad162,0x01ef26514b9275CFe4EC4cb9552611F29C845963,0x024db5796C3CaAB34e9c0995A1DF17A91EECA6cC,0x026617a003616C8F4a660DB526Ac068c7bd12490,0x02CcD30740867976Cc42049275A82392fC91eA26,0x0394626f556f772D67c928bb42760c091fF60804,0x052253771E92a5Ff3c31163492b7e9101e0FC62f,0x068183e2057651a1C124c994489236447f9a5030,0x069741B2fFC5b1Af74ABbC8f8573bA70e3808409,0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1,0x07442F52C92152dE8A8A3984de7A999770809E57,0x077b3B2DD6C0a0004d1eA775D8983Bd2E4CbBb67,0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F,0x087Dc2C109a14b5Aa07Da01B6326DC1c20fb44e5,0x0F27680805e50Fa0ab0dDAEa026ec3Da292a24DF,0x0b631108E1603697b88ddd615A085DED7Ff5925c,0x0c4bBfAa02b14924554715145f83560843E249b9,0x0d655471115590137cE3986A111CC5db1c2714EA,0x1039EDd1d100185Eaf45141C99227D1B994CE11F,0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6,0x164dbA559A5273b05E98fdf2d50d87CA65C5BFD5,0x167460E04fa7f08AB2470dDdeDe0D57c4d5F0883,0x18A4F048a42674105F00700017C8098ed62dF4d9,0x19601E6825D2715CBD22B6AEC9B2528eDEe974A6,0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf,0x1DB4597389199F8851B53eD48aE90bF451C564Fe,0x1E800A7E4b103cA2C270e162E66d1B099eC8C1A7 --masterSafe=0x583788f490a278DB2a8d6D7226264b4985f75678
<snip>
Requesting withdrawal of all sETH from BatchExchange on behalf of Safe 0x0394626f556f772D67c928bb42760c091fF60804
Requesting withdrawal of all PAN from BatchExchange on behalf of Safe 0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf
Requesting withdrawal of all CHAI from BatchExchange on behalf of Safe 0x052253771E92a5Ff3c31163492b7e9101e0FC62f
Requesting withdrawal of all CHAI from BatchExchange on behalf of Safe 0x069741B2fFC5b1Af74ABbC8f8573bA70e3808409
Requesting withdrawal of all CHAI from BatchExchange on behalf of Safe 0x00Adb0E4c11BBe10A694678647A2076f62c12e11
Requesting withdrawal of all CHAI from BatchExchange on behalf of Safe 0x024db5796C3CaAB34e9c0995A1DF17A91EECA6cC
Requesting withdrawal of all WETH from BatchExchange on behalf of Safe 0x1DB4597389199F8851B53eD48aE90bF451C564Fe
Requesting withdrawal of all CHAI from BatchExchange on behalf of Safe 0x1E800A7E4b103cA2C270e162E66d1B099eC8C1A7
Requesting withdrawal of all DAI from BatchExchange on behalf of Safe 0x18A4F048a42674105F00700017C8098ed62dF4d9
Requesting withdrawal of all USDC from BatchExchange on behalf of Safe 0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf
Requesting withdrawal of all USDC from BatchExchange on behalf of Safe 0x0c4bBfAa02b14924554715145f83560843E249b9
Requesting withdrawal of all USDT from BatchExchange on behalf of Safe 0x0d655471115590137cE3986A111CC5db1c2714EA
Requesting withdrawal of all sBTC from BatchExchange on behalf of Safe 0x164dbA559A5273b05E98fdf2d50d87CA65C5BFD5
Requesting withdrawal of all USDT from BatchExchange on behalf of Safe 0x167460E04fa7f08AB2470dDdeDe0D57c4d5F0883
Requesting withdrawal of all DAI from BatchExchange on behalf of Safe 0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1
Requesting withdrawal of all cDAI from BatchExchange on behalf of Safe 0x026617a003616C8F4a660DB526Ac068c7bd12490
Requesting withdrawal of all USDC from BatchExchange on behalf of Safe 0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6
Requesting withdrawal of all WETH from BatchExchange on behalf of Safe 0x002184C787c58638D41D7b6F35B38b2A967E5033
Requesting withdrawal of all USDC from BatchExchange on behalf of Safe 0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F
```

Compare with the (non-negligible) balances for the same brackets:
```
npx truffle exec scripts/balance_viewer.js --network=mainnet --brackets=0x002184C787c58638D41D7b6F35B38b2A967E5033,0x00Adb0E4c11BBe10A694678647A2076f62c12e11,0x00F0FBDEEa1cDEc029Ba6025ca726Fdcf43E9025,0x013DC982fEe3d7f4f8149BE53cDaD3dA4aDad162,0x01ef26514b9275CFe4EC4cb9552611F29C845963,0x024db5796C3CaAB34e9c0995A1DF17A91EECA6cC,0x026617a003616C8F4a660DB526Ac068c7bd12490,0x02CcD30740867976Cc42049275A82392fC91eA26,0x0394626f556f772D67c928bb42760c091fF60804,0x052253771E92a5Ff3c31163492b7e9101e0FC62f,0x068183e2057651a1C124c994489236447f9a5030,0x069741B2fFC5b1Af74ABbC8f8573bA70e3808409,0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1,0x07442F52C92152dE8A8A3984de7A999770809E57,0x077b3B2DD6C0a0004d1eA775D8983Bd2E4CbBb67,0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F,0x087Dc2C109a14b5Aa07Da01B6326DC1c20fb44e5,0x0F27680805e50Fa0ab0dDAEa026ec3Da292a24DF,0x0b631108E1603697b88ddd615A085DED7Ff5925c,0x0c4bBfAa02b14924554715145f83560843E249b9,0x0d655471115590137cE3986A111CC5db1c2714EA,0x1039EDd1d100185Eaf45141C99227D1B994CE11F,0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6,0x164dbA559A5273b05E98fdf2d50d87CA65C5BFD5,0x167460E04fa7f08AB2470dDdeDe0D57c4d5F0883,0x18A4F048a42674105F00700017C8098ed62dF4d9,0x19601E6825D2715CBD22B6AEC9B2528eDEe974A6,0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf,0x1DB4597389199F8851B53eD48aE90bF451C564Fe,0x1E800A7E4b103cA2C270e162E66d1B099eC8C1A7
<low balances deleted manually>
Balance of 0x002184C787c58638D41D7b6F35B38b2A967E5033 for token WETH: 14.723807342244400645
Balance of 0x00Adb0E4c11BBe10A694678647A2076f62c12e11 for token CHAI: 2722.080923270383750581
Balance of 0x024db5796C3CaAB34e9c0995A1DF17A91EECA6cC for token CHAI: 245.7
Balance of 0x026617a003616C8F4a660DB526Ac068c7bd12490 for token cDAI: 12140
Balance of 0x0394626f556f772D67c928bb42760c091fF60804 for token sETH: 14.869936140784838727
Balance of 0x052253771E92a5Ff3c31163492b7e9101e0FC62f for token CHAI: 3321.845946418835028809
Balance of 0x069741B2fFC5b1Af74ABbC8f8573bA70e3808409 for token CHAI: 2758.527291258496277961
Balance of 0x06e230d45235b071CfDC55e05D78E5E79dc7F1a1 for token DAI: 1511.426583384273544549
Balance of 0x083a8d7C1959b6250278cEaEE183166a79Ce9D7F for token USDC: 5376.881837
Balance of 0x0c4bBfAa02b14924554715145f83560843E249b9 for token USDC: 181.131157
Balance of 0x0d655471115590137cE3986A111CC5db1c2714EA for token USDT: 1098.324197
Balance of 0x1634CB63743C7E360ef6Ef367c5B0C3735F564b6 for token USDC: 5294.819307
Balance of 0x164dbA559A5273b05E98fdf2d50d87CA65C5BFD5 for token sBTC: 0.0368889
Balance of 0x167460E04fa7f08AB2470dDdeDe0D57c4d5F0883 for token USDT: 1063.098398
Balance of 0x18A4F048a42674105F00700017C8098ed62dF4d9 for token DAI: 5755.174733299900193551
Balance of 0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf for token USDC: 151.831511
Balance of 0x1A17D6F6C0676c2a8986f80be81Fff6f4774FAEf for token PAN: 615.220383390546024227
Balance of 0x1DB4597389199F8851B53eD48aE90bF451C564Fe for token WETH: 14.702287020599660837
Balance of 0x1E800A7E4b103cA2C270e162E66d1B099eC8C1A7 for token CHAI: 2706.688580398239098888
```