### PR TITLE
hotfix for parameter handover for order bundling

### DIFF
--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -357,17 +357,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {number} [expiry=DEFAULT_ORDER_EXPIRY] Maximum auction batch for which these orders are valid (e.g. maxU32)
    * @returns {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
    */
-  const buildOrders = async function (
-    masterAddress,
-    bracketAddresses,
-    baseTokenId,
-    quoteTokenId,
-    lowestLimit,
-    highestLimit,
-    debug = false,
-    expiry = DEFAULT_ORDER_EXPIRY
-  ) {
-    return buildBundledTransaction(await transactionsForOrders(...arguments, debug, expiry))
+  const buildOrders = async function () {
+    return buildBundledTransaction(await transactionsForOrders(...arguments))
   }
 
   const checkSufficiencyOfBalance = async function (token, owner, amount) {

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -274,6 +274,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     debug = false,
     expiry = DEFAULT_ORDER_EXPIRY
   ) {
+    console.log(debug)
     const log = debug ? (...a) => console.log(...a) : () => {}
 
     assert(lowestLimit < highestLimit, "Lowest limit must be lower than highest limit")
@@ -465,8 +466,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {boolean} [debug=false] prints log statements when true
    * @returns {Transaction} all the relevant transaction information used for submission to a Gnosis Safe Multi-Sig
    */
-  const buildTransferApproveDepositFromList = async function (masterAddress, depositList, debug = false) {
-    return buildBundledTransaction(await transactionsForTransferApproveDepositFromList(...arguments, debug))
+  const buildTransferApproveDepositFromList = async function () {
+    return buildBundledTransaction(await transactionsForTransferApproveDepositFromList(...arguments))
   }
 
   /**

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -274,7 +274,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     debug = false,
     expiry = DEFAULT_ORDER_EXPIRY
   ) {
-    console.log(debug)
     const log = debug ? (...a) => console.log(...a) : () => {}
 
     assert(lowestLimit < highestLimit, "Lowest limit must be lower than highest limit")


### PR DESCRIPTION
There was a tiny error with the parameter handover.

This PR fixes the issue.

Testplan:

See that a new deployment runs smoothly and no longer creates this error:
`Error: invalid number value (arg="validUntil", coderType="uint32", value=true)`
