### PR TITLE
Add single-transaction deployment script

### DIFF
--- a/scripts/single_transaction_liquidity_provision.js
+++ b/scripts/single_transaction_liquidity_provision.js
@@ -1,17 +1,7 @@
-const assert = require("assert")
-
-const {
-  fetchTokenInfoFromExchange,
-  buildFullLiquidityProvision,
-  checkSufficiencyOfBalance,
-  getSafe,
-  getExchange,
-} = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { buildFullLiquidityProvision } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { signAndSend, transactionExistsOnSafeServer } = require("./utils/gnosis_safe_server_interactions")(web3, artifacts)
+const { sanitizeArguments } = require("./utils/liquidity_provision_sanity_checks")(web3, artifacts)
 
-const { isPriceReasonable, areBoundsReasonable } = require("./utils/price_utils")
-const { proceedAnyways } = require("./utils/user_interface_helpers")
-const { toErc20Units } = require("./utils/printing_tools")
 const { default_yargs, checkBracketsForDuplicate } = require("./utils/default_yargs")
 
 const argv = default_yargs
@@ -74,63 +64,15 @@ const argv = default_yargs
 
 module.exports = async (callback) => {
   try {
-    // initialize promises that will be used later in the code to speed up execution
-    const exchangePromise = getExchange()
-    const masterSafePromise = getSafe(argv.masterSafe)
-    const masterSafeNoncePromise =
-      argv.nonce === undefined
-        ? masterSafePromise.then((masterSafe) => masterSafe.nonce()).then((nonce) => nonce.toNumber())
-        : Promise.resolve(argv.nonce)
-    const signerPromise = web3.eth.getAccounts().then((accounts) => accounts[0])
-    const masterOwnersPromise = masterSafePromise.then((masterSafe) => masterSafe.getOwners())
+    const { masterSafe, masterSafeNonce, signer, depositBaseToken, depositQuoteToken } = await sanitizeArguments({
+      argv,
+      maxBrackets: 10,
+    })
 
-    const exchange = await exchangePromise
-    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [argv.baseTokenId, argv.quoteTokenId])
-    const baseTokenData = await tokenInfoPromises[argv.baseTokenId]
-    const quoteTokenData = await tokenInfoPromises[argv.quoteTokenId]
-    const { instance: baseToken, decimals: baseTokenDecimals } = baseTokenData
-    const { instance: quoteToken, decimals: quoteTokenDecimals } = quoteTokenData
-    const depositBaseToken = toErc20Units(argv.depositBaseToken, baseTokenDecimals)
-    const depositQuoteToken = toErc20Units(argv.depositQuoteToken, quoteTokenDecimals)
-
-    const hasSufficientBaseTokenPromise = checkSufficiencyOfBalance(baseToken, argv.masterSafe, depositBaseToken)
-    const hasSufficientQuoteTokenPromise = checkSufficiencyOfBalance(quoteToken, argv.masterSafe, depositQuoteToken)
-    const isPriceCloseToOnlineSourcePromise = isPriceReasonable(baseTokenData, quoteTokenData, argv.currentPrice)
-
-    const signer = await signerPromise
     console.log("Using account:", signer)
-    if (!argv.verify) {
-      assert((await masterOwnersPromise).includes(signer), `Please ensure signer account ${signer} is an owner of masterSafe`)
-    }
-
-    console.log("==> Performing safety checks")
-    if (!(await hasSufficientBaseTokenPromise)) {
-      callback(`Error: MasterSafe ${argv.masterSafe} has insufficient balance for base token ${baseToken.address}`)
-    }
-    if (!(await hasSufficientQuoteTokenPromise)) {
-      callback(`Error: MasterSafe ${argv.masterSafe} has insufficient balance for quote token ${quoteToken.address}`)
-    }
-
-    // check price against external price API
-    if (!(await isPriceCloseToOnlineSourcePromise)) {
-      if (!(await proceedAnyways("Price check failed!"))) {
-        callback("Error: Price checks did not pass")
-      }
-    }
-    const areBoundsTooSpreadOut = areBoundsReasonable(argv.currentPrice, argv.lowestLimit, argv.highestLimit)
-    if (!areBoundsTooSpreadOut) {
-      if (!(await proceedAnyways("Bound checks failed!"))) {
-        callback("Error: Bound checks did not pass")
-      }
-    }
-    if (argv.numBrackets > 10) {
-      callback("Error: Choose a smaller numBrackets, otherwise your transaction would be too large.")
-    }
 
     console.log(`==> Transaction deploys ${argv.numBrackets} trading brackets`)
 
-    const masterSafe = await masterSafePromise
-    const masterSafeNonce = await masterSafeNoncePromise
     const fullLiquidityProvisionTransaction = await buildFullLiquidityProvision({
       masterAddress: argv.masterSafe,
       fleetSize: argv.numBrackets,
@@ -143,6 +85,7 @@ module.exports = async (callback) => {
       depositQuoteToken,
       masterSafeNonce,
     })
+
     if (!argv.verify) {
       console.log("==> Sending the transaction to the Gnosis-Safe interface.")
       await signAndSend(masterSafe, fullLiquidityProvisionTransaction, argv.network, masterSafeNonce)

--- a/scripts/utils/liquidity_provision_sanity_checks.js
+++ b/scripts/utils/liquidity_provision_sanity_checks.js
@@ -1,0 +1,90 @@
+const assert = require("assert")
+
+const { isPriceReasonable, areBoundsReasonable } = require("./price_utils")
+const { proceedAnyways } = require("./user_interface_helpers")
+const { toErc20Units } = require("./printing_tools")
+
+module.exports = function (web3, artifacts) {
+  const { fetchTokenInfoFromExchange, checkSufficiencyOfBalance, getSafe, getExchange } = require("./trading_strategy_helpers")(
+    web3,
+    artifacts
+  )
+
+  /**
+   * Takes the input argument for liquidity provision, double checks that everything
+   * looks right, and returns values needed to deploy a strategy.
+   *
+   * @param {object} param function parameters
+   * @param {object} param.argv user command-line parameters that define a strategy
+   * @param {number} param.maxBrackets maximum number of bracket that fit into a single deployment
+   * @returns {object} data needed to deploy liquidity on the exchange
+   */
+  async function sanitizeArguments({ argv, maxBrackets }) {
+    // initialize promises that will be used later in the code to speed up execution
+    const exchangePromise = getExchange()
+    const masterSafePromise = getSafe(argv.masterSafe)
+    const masterSafeNoncePromise =
+      argv.nonce === undefined
+        ? masterSafePromise.then((masterSafe) => masterSafe.nonce()).then((nonce) => nonce.toNumber())
+        : Promise.resolve(argv.nonce)
+    const signerPromise = web3.eth.getAccounts().then((accounts) => accounts[0])
+    const masterOwnersPromise = masterSafePromise.then((masterSafe) => masterSafe.getOwners())
+
+    const exchange = await exchangePromise
+    const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [argv.baseTokenId, argv.quoteTokenId])
+    const baseTokenData = await tokenInfoPromises[argv.baseTokenId]
+    const quoteTokenData = await tokenInfoPromises[argv.quoteTokenId]
+    const { instance: baseToken, decimals: baseTokenDecimals } = baseTokenData
+    const { instance: quoteToken, decimals: quoteTokenDecimals } = quoteTokenData
+    const depositBaseToken = toErc20Units(argv.depositBaseToken, baseTokenDecimals)
+    const depositQuoteToken = toErc20Units(argv.depositQuoteToken, quoteTokenDecimals)
+
+    const hasSufficientBaseTokenPromise = checkSufficiencyOfBalance(baseToken, argv.masterSafe, depositBaseToken)
+    const hasSufficientQuoteTokenPromise = checkSufficiencyOfBalance(quoteToken, argv.masterSafe, depositQuoteToken)
+    const isPriceCloseToOnlineSourcePromise = isPriceReasonable(baseTokenData, quoteTokenData, argv.currentPrice)
+
+    const signer = await signerPromise
+    if (!argv.verify) {
+      assert((await masterOwnersPromise).includes(signer), `Please ensure signer account ${signer} is an owner of masterSafe`)
+    }
+
+    console.log("==> Performing safety checks")
+    if (!(await hasSufficientBaseTokenPromise)) {
+      throw new Error(`MasterSafe ${argv.masterSafe} has insufficient balance for base token ${baseToken.address}`)
+    }
+    if (!(await hasSufficientQuoteTokenPromise)) {
+      throw new Error(`MasterSafe ${argv.masterSafe} has insufficient balance for quote token ${quoteToken.address}`)
+    }
+
+    // check price against external price API
+    if (!(await isPriceCloseToOnlineSourcePromise)) {
+      if (!(await proceedAnyways("Price check failed!"))) {
+        throw new Error("Price checks did not pass")
+      }
+    }
+    const areBoundsTooSpreadOut = areBoundsReasonable(argv.currentPrice, argv.lowestLimit, argv.highestLimit)
+    if (!areBoundsTooSpreadOut) {
+      if (!(await proceedAnyways("Bound checks failed!"))) {
+        throw new Error("Bound checks did not pass")
+      }
+    }
+    if (argv.numBrackets > maxBrackets) {
+      throw new Error("Error: Choose a smaller numBrackets, otherwise your transaction would be too large.")
+    }
+
+    return {
+      exchange,
+      masterSafe: await masterSafePromise,
+      masterSafeNonce: await masterSafeNoncePromise,
+      signer,
+      depositBaseToken,
+      depositQuoteToken,
+      baseTokenData,
+      quoteTokenData,
+    }
+  }
+
+  return {
+    sanitizeArguments,
+  }
+}

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -288,7 +288,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {Address|SmartContract} masterSafe Gnosis Safe smart contract (or its address) that
    * will own the fleet for which the nonce is created.
    * @param {string} [gnosisSafeNonce=null] If set, the function uses the given nonce instead of
-   * retieving the current transaction nonce of the master safe.
+   * retrieving the current transaction nonce of the master safe.
    * @returns {string} Nonce to be used on a deterministic fleet deployment.
    */
   const uniqueNonce = async function (masterSafe, gnosisSafeNonce = null) {

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -16,6 +16,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const fs = require("fs")
   const { getUnlimitedOrderAmounts } = require("@gnosis.pm/dex-contracts")
   const { buildBundledTransaction, buildExecTransaction } = require("./internals")(web3, artifacts)
+  const { calcSafeAddresses } = require("./calculate_fleet_addresses")(web3, artifacts)
   const { shortenedAddress, toErc20Units, fromErc20Units } = require("./printing_tools")
   const { uniqueItems } = require("./js_helpers")
   const { DEFAULT_ORDER_EXPIRY, CALL } = require("./constants")
@@ -24,10 +25,12 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const BatchExchange = artifacts.require("BatchExchange")
   const GnosisSafe = artifacts.require("GnosisSafe")
   const FleetFactory = artifacts.require("FleetFactory")
+  const FleetFactoryDeterministic = artifacts.require("FleetFactoryDeterministic")
 
   const exchangePromise = BatchExchange.deployed()
   const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const fleetFactoryPromise = FleetFactory.deployed()
+  const fleetFactoryDeterministicPromise = FleetFactoryDeterministic.deployed()
   const hardcodedTokensByNetwork = require("./hardcoded_tokens")
 
   /**
@@ -248,6 +251,60 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
 
     const transcript = await fleetFactory.deployFleet(masterAddress, fleetSize, gnosisSafeMasterCopy.address)
     return transcript.logs[0].args.fleet
+  }
+
+  /**
+   * Returns a transaction creating a (deterministically generated) fleet of Safes owned by
+   * the given master address for the given nonce.
+   *
+   * @param {Address} masterAddress address of Gnosis Safe (Multi-Sig) owning the Safes that
+   * will be created
+   * @param {number} fleetSize number of safes to be created with masterAddress as owner
+   * @param {string|BN} nonce non-repeating value that is used to determine the fleet addresses
+   * @returns {Transaction} transaction that can be used to deterministically generate a fleet
+   * with the given parameters
+   */
+  const buildDeterministicFleetOfSafes = async function (masterAddress, fleetSize, nonce) {
+    const fleetFactoryDeterministic = await fleetFactoryDeterministicPromise
+    const gnosisSafeMasterCopy = await gnosisSafeMasterCopyPromise
+
+    const data = fleetFactoryDeterministic.contract.methods
+      .deployFleetWithNonce(masterAddress, fleetSize, gnosisSafeMasterCopy.address, nonce)
+      .encodeABI()
+    const transaction = {
+      operation: CALL,
+      to: fleetFactoryDeterministic.address,
+      value: 0,
+      data,
+    }
+
+    return transaction
+  }
+
+  /**
+   * Computes a unique nonce that can be used to create a deterministic fleet deployment for
+   * the given master safe.
+   *
+   * @param {Address|SmartContract} masterSafe Gnosis Safe smart contract (or its address) that
+   * will own the fleet for which the nonce is created.
+   * @param {string} [gnosisSafeNonce=null] If set, the function uses the given nonce instead of
+   * retieving the current transaction nonce of the master safe.
+   * @returns {string} Nonce to be used on a deterministic fleet deployment.
+   */
+  const uniqueNonce = async function (masterSafe, gnosisSafeNonce = null) {
+    masterSafe = typeof masterSafe === "string" ? await getSafe(masterSafe) : masterSafe
+
+    // There can be only one transaction executed with the same Gnosis Safe nonce.
+    // This nonce can be combined with a fixed string to create a number that is
+    // unique for each deployment from the same master Safe.
+    if (gnosisSafeNonce === null) {
+      gnosisSafeNonce = await masterSafe.nonce()
+    }
+    const STRING_DESCRIPTOR = "Custom Market Maker deterministic deployment"
+    const hashInput = STRING_DESCRIPTOR + masterSafe.address + gnosisSafeNonce.toString()
+    const nonce = web3.utils.sha3(hashInput)
+
+    return nonce
   }
 
   /**
@@ -592,6 +649,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     const bracketsAsObjects = events.map((object) => object.returnValues.fleet)
     return [].concat(...bracketsAsObjects)
   }
+
   /**
    * Fetches the brackets deployed with the deterministic fleet factory by a given masterSafe
    * from the blockchaiin via events.
@@ -612,7 +670,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   }
 
   /**
-   * Batches together a collection of transfer-related transaction information.
+   * Returns a list of transfer-related transaction information.
    * Particularly, the resulting transaction is that of transfering all sufficient funds from master
    * to its brackets, then approving and depositing those same tokens into BatchExchange on behalf of each bracket.
    *
@@ -625,10 +683,11 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @param {number} currentPrice current quote price
    * @param {number} depositQuoteToken Amount of quote tokens to be invested (in total)
    * @param {number} depositBaseToken Amount of base tokens to be invested (in total)
-   * @param {boolean} storeDepositsAsFile whether to write the executed deposits to a file (defaults to false)
-   * @returns {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
+   * @param {boolean} [storeDepositsAsFile=false] whether to write the executed deposits to a file (defaults to false)
+   * @param {boolean} [debug=false]  prints log statements when true
+   * @returns {Transaction[]} all the relevant transactions to bundle for executing transfer, approve, deposits
    */
-  const buildTransferApproveDepositFromOrders = async function (
+  const transactionsForTransferApproveDepositFromOrders = async function (
     masterAddress,
     bracketAddresses,
     baseTokenAddress,
@@ -638,7 +697,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     currentPrice,
     depositQuoteToken,
     depositBaseToken,
-    storeDepositsAsFile = false
+    storeDepositsAsFile = false,
+    debug = false
   ) {
     const numBrackets = bracketAddresses.length
     const stepSizeAsMultiplier = Math.pow(highestLimit / lowestLimit, 1 / bracketAddresses.length)
@@ -680,7 +740,28 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
         }
       })
     }
-    return buildTransferApproveDepositFromList(masterAddress, deposits)
+    return transactionsForTransferApproveDepositFromList(masterAddress, deposits, debug)
+  }
+
+  /**
+   * Batches together a collection of transfer-related transaction information.
+   * Particularly, the resulting transaction is that of transfering all sufficient funds from master
+   * to its brackets, then approving and depositing those same tokens into BatchExchange on behalf of each bracket.
+   *
+   * @param {Address} masterAddress Address of the master safe owning the brackets
+   * @param {Address[]} bracketAddresses list of bracket addresses that need the deposit
+   * @param {Address} baseTokenAddress second token to be traded in bracket strategy
+   * @param {Address} quoteTokenAddress one token to be traded in bracket strategy
+   * @param {number} lowestLimit lower price bound
+   * @param {number} highestLimit upper price bound
+   * @param {number} currentPrice current quote price
+   * @param {number} depositQuoteToken Amount of quote tokens to be invested (in total)
+   * @param {number} depositBaseToken Amount of base tokens to be invested (in total)
+   * @param {boolean} storeDepositsAsFile whether to write the executed deposits to a file (defaults to false)
+   * @returns {Transaction} all the relevant transaction information to be used when submitting to the Gnosis Safe Multi-Sig
+   */
+  const buildTransferApproveDepositFromOrders = async function () {
+    return buildBundledTransaction(await transactionsForTransferApproveDepositFromOrders(...arguments))
   }
 
   /**
@@ -843,11 +924,85 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     }
   }
 
+  /**
+   * Assign the project to an employee.
+   *
+   * @param {object} deploymentParameters The parameters used by the deployed strategy.
+   * @param {Address} deploymentParameters.masterAddress Address of the master safe owning the brackets
+   * @param {number} deploymentParameters.fleetSize Number of brackets to be deployed
+   * @param {number} deploymentParameters.baseTokenId ID of token (on BatchExchange) whose target price is to be specified (i.e. ETH)
+   * @param {number} deploymentParameters.quoteTokenId ID of the quote token for the given price (i.e. DAI)
+   * @param {number} deploymentParameters.currentPrice Current price of one base token in quote tokens
+   * @param {number} deploymentParameters.lowestLimit Lower price bound
+   * @param {number} deploymentParameters.highestLimit Highest price bound
+   * @param {number} deploymentParameters.depositBaseToken Amount of base tokens to be invested (in total)
+   * @param {number} deploymentParameters.depositQuoteToken Amount of quote tokens to be invested (in total)
+   * @param {number} [deploymentParameters.masterSafeNonce=null] Gnosis Safe nonce that is used to compute the deployment addresses. If
+   * left empty, the first available nonce is retrieved from the blockchain
+   * @param {number} [deploymentParameters.expiry=DEFAULT_ORDER_EXPIRY] Maximum auction batch for which these orders are valid (e.g. maxU32)
+   * @param {number} [deploymentParameters.debug=false] Prints log statements when true
+   * @returns {Transaction} Multisend transaction that executes a full liquidity deployment
+   */
+  const buildFullLiquidityProvision = async function ({
+    masterAddress,
+    fleetSize,
+    baseTokenId,
+    quoteTokenId,
+    lowestLimit,
+    highestLimit,
+    currentPrice,
+    depositBaseToken,
+    depositQuoteToken,
+    masterSafeNonce = null,
+    expiry = DEFAULT_ORDER_EXPIRY,
+    debug = false,
+  }) {
+    const noncePromise = uniqueNonce(masterAddress, masterSafeNonce)
+    const tokenInfoPromises = fetchTokenInfoFromExchange(await exchangePromise, [baseTokenId, quoteTokenId])
+    const createFleetTransaction = buildDeterministicFleetOfSafes(masterAddress, fleetSize, await noncePromise)
+    const bracketAddresses = await calcSafeAddresses(fleetSize, await noncePromise)
+
+    const createOrderTransactions = transactionsForOrders(
+      masterAddress,
+      bracketAddresses,
+      baseTokenId,
+      quoteTokenId,
+      lowestLimit,
+      highestLimit,
+      debug,
+      expiry
+    )
+
+    const baseTokenAddress = (await tokenInfoPromises[baseTokenId]).address
+    const quoteTokenAddress = (await tokenInfoPromises[quoteTokenId]).address
+    const depositTransactions = transactionsForTransferApproveDepositFromOrders(
+      masterAddress,
+      bracketAddresses,
+      baseTokenAddress,
+      quoteTokenAddress,
+      lowestLimit,
+      highestLimit,
+      currentPrice,
+      depositQuoteToken,
+      depositBaseToken,
+      undefined,
+      debug
+    )
+
+    return buildBundledTransaction([
+      await createFleetTransaction,
+      ...(await createOrderTransactions),
+      ...(await depositTransactions),
+    ])
+  }
+
   return {
     assertNoAllowances,
     assertIsOnlyFleetOwner,
     buildBracketTransactionForTransferApproveDeposit,
     buildDepositFromList,
+    buildDeterministicFleetOfSafes,
+    buildFullLiquidityProvision,
     buildOrders,
     buildTransferApproveDepositFromOrders,
     buildTransferApproveDepositFromList,
@@ -858,6 +1013,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     buildWithdrawRequest,
     transactionsForOrders,
     transactionsForTransferApproveDepositFromList,
+    transactionsForTransferApproveDepositFromOrders,
     checkSufficiencyOfBalance,
     deployFleetOfSafes,
     fetchTokenInfoAtAddresses,
@@ -873,5 +1029,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     isOnlyFleetOwner,
     retrieveTradedTokensPerBracket,
     tokenDetail,
+    uniqueNonce,
   }
 }

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -925,7 +925,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   }
 
   /**
-   * Assign the project to an employee.
+   * Create a single transaction that bundles bracket deployment, order creation, and deposits in a
+   * single transaction that can be executed atomically by the master Safe.
    *
    * @param {object} deploymentParameters The parameters used by the deployed strategy.
    * @param {Address} deploymentParameters.masterAddress Address of the master safe owning the brackets

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -300,6 +300,11 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     if (gnosisSafeNonce === null) {
       gnosisSafeNonce = await masterSafe.nonce()
     }
+
+    // FleetFactoryDeterministic could in principle be used by other projects to deploy their safes.
+    // Without the following string descriptor, the pattern would be very natural (address + some
+    // kind of nonce) so it could inadvertently cause very annoying conflicts with unrelated projects.
+    // With this "string descriptor" instead there would be no such risk of an accidental hash collision.
     const STRING_DESCRIPTOR = "Custom Market Maker deterministic deployment"
     const hashInput = STRING_DESCRIPTOR + masterSafe.address + gnosisSafeNonce.toString()
     const nonce = web3.utils.sha3(hashInput)

--- a/test/fleet_factory.js
+++ b/test/fleet_factory.js
@@ -6,30 +6,9 @@ const GnosisSafe = artifacts.require("GnosisSafe")
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const IProxy = artifacts.require("IProxy")
 const FleetFactory = artifacts.require("FleetFactory")
-const { deploySafe } = require("../scripts/utils/strategy_simulator")(web3, artifacts)
 
-/**
- * Decodes a ProxyCreation raw event from GnosisSafeProxyFactory and tests it for validity.
- *
- * @param {any} rawEvent bytes of an event emmited from GnosisSafeProxyFactory
- * @returns {Address} the address of the newly created proxy.
- */
-const decodeCreateProxy = function (rawEvent) {
-  const { data, topics } = rawEvent
-  const eventSignature = web3.eth.abi.encodeEventSignature("ProxyCreation(address)")
-  assert.equal(topics[0], eventSignature, "Input raw event is not a CreateProxy event")
-  const decoded = web3.eth.abi.decodeLog(
-    [
-      {
-        type: "address",
-        name: "proxy",
-      },
-    ],
-    data,
-    topics
-  )
-  return decoded.proxy
-}
+const { deploySafe } = require("../scripts/utils/strategy_simulator")(web3, artifacts)
+const { decodeCreateProxy } = require("./test_utils")
 
 contract("FleetFactory", function (accounts) {
   let gnosisSafeMasterCopy

--- a/test/fleet_factory_deterministic.js
+++ b/test/fleet_factory_deterministic.js
@@ -7,7 +7,7 @@ const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const IProxy = artifacts.require("IProxy")
 const FleetFactoryDeterministic = artifacts.require("FleetFactoryDeterministic")
 const { deploySafe } = require("../scripts/utils/strategy_simulator")(web3, artifacts)
-const { calcSafeAddresses } = require("../scripts/utils/calculate_fleet_addresses")(web3)
+const { calcSafeAddresses } = require("../scripts/utils/calculate_fleet_addresses")(web3, artifacts)
 
 contract("FleetFactoryDeterministic", function (accounts) {
   let gnosisSafeMasterCopy
@@ -41,7 +41,7 @@ contract("FleetFactoryDeterministic", function (accounts) {
           gnosisSafeMasterCopy.address,
           nonce
         )
-        const fleetCalculated = await calcSafeAddresses(fleetFactory, numberOfSafes, gnosisSafeMasterCopy.address, nonce)
+        const fleetCalculated = await calcSafeAddresses(numberOfSafes, nonce, fleetFactory, gnosisSafeMasterCopy.address)
         // the last event lists all created proxy, and is the only event decoded by Truffle
         assert.equal(transcript.receipt.rawLogs.length, numberOfSafes + 1, "More events than expected")
         assert.equal(transcript.logs.length, 1, "More events than expected")

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -40,7 +40,33 @@ const populatePriceStorage = function () {
   return priceStorage
 }
 
+/**
+ * Decodes a ProxyCreation raw event from GnosisSafeProxyFactory and tests it for validity.
+ *
+ * @param {any} rawEvent bytes of an event emmited from GnosisSafeProxyFactory
+ * @returns {Address} the address of the newly created proxy.
+ */
+const decodeCreateProxy = function (rawEvent) {
+  const { data, topics } = rawEvent
+  const eventSignature = web3.eth.abi.encodeEventSignature("ProxyCreation(address)")
+  if (topics[0] !== eventSignature) {
+    throw new Error("Input raw event is not a CreateProxy event")
+  }
+  const decoded = web3.eth.abi.decodeLog(
+    [
+      {
+        type: "address",
+        name: "proxy",
+      },
+    ],
+    data,
+    topics
+  )
+  return decoded.proxy
+}
+
 module.exports = {
   createTokenAndGetData,
   populatePriceStorage,
+  decodeCreateProxy,
 }


### PR DESCRIPTION
Closes #463.

Creates a script that deploys the brackets in a single transaction along with order creation and fund deposits.

### Test plan

```
npx truffle exec scripts/single_transaction_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=220 --highestLimit=260 --currentPrice=255 --masterSafe=0x04a82eC4857694a28bdDb9cE8E13DCbc090928e7 --depositBaseToken=0.001 --depositQuoteToken=65000 --numBrackets=1 --network=rinkeby
```

And before executing the generated transaction:
```
npx truffle exec scripts/single_transaction_liquidity_provision.js --verify --baseTokenId=1 --quoteTokenId=3 --lowestLimit=220 --highestLimit=260 --currentPrice=255 --masterSafe=0x04a82eC4857694a28bdDb9cE8E13DCbc090928e7 --depositBaseToken=0.001 --depositQuoteToken=65000 --numBrackets=1 --network=rinkeby
``` 

[Sample resulting transaction](https://rinkeby.etherscan.io/tx/0xdf66162be28c48d2895229c921d04b76700e6ef488afbe2d36979300d682ea6d).

Verify that everything went smoothly:
```
$ npx truffle exec scripts/verify_correctness.js --network=rinkeby --brackets=0xb2f7a8ef3babd9e34a859f90e5ad2454253a0d06,0x914f2c61d29705e8a8e3b1c64adfbb13b99a8ef3,0x4278de92c0660edbecf4aeea58f13e254610da43,0x1a285e373b5ed91bba0cb7acee150e4b9f7952e4,0xe5ef1b07c5891debbaa0927505fa6a940f6f0a61,0x0a1c5184696343652aaa911822c947b5c9b48a95,0x2fb502581fc8f80cdda392e240b2766e9416f7e4,0xeb3b55cd357c0e592498abb502f8433124042175,0xffe18fae1dc55ab9e8165c333d6bd685c2592481,0xb514cc6001a9a5ff9fce29a32fc73b71dfa59e50 --masterSafe=0x04a82eC4857694a28bdDb9cE8E13DCbc090928e7
```

### Breaking changes (@andre-meyer)
This PR contains some changes to `calcSafeAddresses` that will most likely require adapting the app.

1. the function input values are rearranged from
   ```
   fleetFactoryDeterministic, bracketCount, gnosisSafeTemplateAddress, saltNonce)
   ```
   to
   ```
   bracketCount, saltNonce, fleetFactoryDeterministic = null, gnosisSafeTemplateAddress = null
   ```
2. importing `scripts/utils/calculate_fleet_addresses.js` now requires an extra `artifacts` argument, in line with the other imports relying on Truffle features.
3. the output addresses of `calcSafeAddresses` are now checksummed.

Motivation: the two input values `fleetFactoryDeterministic` and `gnosisSafeTemplateAddress` are unnecessary in the context of the scripts and only add needless overhead. The function `fleetFactoryDeterministic` uses `artifacts` (also before this PR) but it assumes it's present as a global variable, but this is not true in the context of the scripts.