### PR TITLE
Use web-interface nonce for creating transactions

### DIFF
--- a/scripts/airdrop.js
+++ b/scripts/airdrop.js
@@ -80,7 +80,7 @@ module.exports = async (callback) => {
       }
     } else {
       console.log("Verifying transaction")
-      await transactionExistsOnSafeServer(masterSafe, transaction, argv.network, (await masterSafe.nonce()).toNumber())
+      await transactionExistsOnSafeServer(masterSafe, transaction, argv.network)
     }
 
     callback()

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -76,7 +76,7 @@ const argv = default_yargs
   })
   .option("nonce", {
     type: "number",
-    implies: ["verify"],
+    default: null,
     describe: "Use this specific nonce instead of the next available one",
   })
   .check(checkBracketsForDuplicate).argv

--- a/scripts/deposit.js
+++ b/scripts/deposit.js
@@ -43,7 +43,7 @@ module.exports = async (callback) => {
       }
     } else {
       console.log("Verifying transaction")
-      await transactionExistsOnSafeServer(masterSafe, transaction, argv.network, (await masterSafe.nonce()).toNumber())
+      await transactionExistsOnSafeServer(masterSafe, transaction, argv.network)
     }
 
     callback()

--- a/scripts/single_transaction_liquidity_provision.js
+++ b/scripts/single_transaction_liquidity_provision.js
@@ -57,7 +57,7 @@ const argv = default_yargs
   })
   .option("nonce", {
     type: "number",
-    implies: ["verify"],
+    default: null,
     describe: "Use this specific nonce instead of the next available one",
   })
   .check(checkBracketsForDuplicate).argv

--- a/scripts/utils/gnosis_safe_server_interactions.js
+++ b/scripts/utils/gnosis_safe_server_interactions.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('../typedef.js').Address} Address
  * @typedef {import('../typedef.js').Transaction} Transaction
+ * @typedef {import('../typedef.js').SmartContract} SmartContract
  */
 
 module.exports = function (web3 = web3, artifacts = artifacts) {
@@ -14,18 +15,27 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     mainnet: "",
   }
 
+  const webInterfaceBaseAddress = function (network) {
+    return `https://${linkPrefix[network]}gnosis-safe.io/app/#`
+  }
+
+  const transactionApiBaseAddress = function (network) {
+    return `https://safe-transaction.${network}.gnosis.io/api/v1`
+  }
+
   /**
    * Signs and sends the transaction to the gnosis-safe UI
    *
-   * @param {Address} masterSafe Address of the master safe owning the brackets
+   * @param {SmartContract} masterSafe Address of the master safe owning the brackets
    * @param {Transaction} transaction The transaction to be signed and sent
    * @param {string} network either rinkeby or mainnet
    * @param {number} [nonce=null] specified transaction index. Will fetch correct value if not specified.
    */
   const signAndSend = async function (masterSafe, transaction, network, nonce = null) {
     if (nonce === null) {
-      nonce = (await masterSafe.nonce()).toNumber()
+      nonce = await firstAvailableNonce(masterSafe.address, network)
     }
+
     const safeTxGas = await estimateGas(masterSafe, transaction)
     const transactionHash = await masterSafe.getTransactionHash(
       transaction.to,
@@ -41,10 +51,12 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     )
 
     const signer = (await web3.eth.getAccounts())[0]
-    console.log(`Signing and posting multi-send transaction ${transactionHash} from proposer account ${signer}`)
+    console.log(
+      `Signing and posting multi-send transaction ${transactionHash} from proposer account ${signer} with nonce ${nonce}`
+    )
     const sigs = await getSafeCompatibleSignature(transactionHash, signer)
 
-    const endpoint = `https://safe-transaction.${network}.gnosis.io/api/v1/safes/${masterSafe.address}/transactions/`
+    const endpoint = `${transactionApiBaseAddress(network)}/safes/${masterSafe.address}/transactions/`
     const postData = {
       to: transaction.to,
       value: transaction.value,
@@ -63,19 +75,23 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     await axios.post(endpoint, postData).catch(function (error) {
       throw new Error("Error while talking to the gnosis-interface: " + JSON.stringify(error.response.data))
     })
-    const interfaceLink = `https://${linkPrefix[network]}gnosis-safe.io/app/#/safes/${masterSafe.address}/transactions`
+    const interfaceLink = `${webInterfaceBaseAddress(network)}/safes/${masterSafe.address}/transactions/`
     console.log("Transaction awaiting execution in the interface", interfaceLink)
   }
 
   /**
    * Checks whether a transaction was already proposed to the gnosis-safe UI
    *
-   * @param {Address} masterSafe Address of the master safe owning the brackets
+   * @param {SmartContract} masterSafe Address of the master safe owning the brackets
    * @param {Transaction} transaction The transaction whose existence is checked
    * @param {string} network either rinkeby or mainnet
-   * @param {number} [nonce] Gnosis Safe transaction nonce.
+   * @param {number} [nonce=null] Gnosis Safe transaction nonce.
    */
-  const transactionExistsOnSafeServer = async function (masterSafe, transaction, network, nonce) {
+  const transactionExistsOnSafeServer = async function (masterSafe, transaction, network, nonce = null) {
+    if (nonce === null) {
+      // if no nonce is provided, assume the transaction with the highest nonce is the one to verify
+      nonce = -1 + (await firstAvailableNonce(masterSafe.address, network))
+    }
     const safeTxGas = await estimateGas(masterSafe, transaction)
     const transactionHash = await masterSafe.getTransactionHash(
       transaction.to,
@@ -89,21 +105,62 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
       ZERO_ADDRESS,
       nonce
     )
-    const endpoint = `https://safe-transaction.${network}.gnosis.io/api/v1/transactions/${transactionHash}/`
+    const endpoint = `${transactionApiBaseAddress(network)}/transactions/${transactionHash}/`
     const result = await axios.get(endpoint).catch(function (error) {
       if (error.response.data.detail === "Not found.") {
-        console.log("Error: The transaction does not match any transaction in the interface!")
+        console.log("Error: This transaction does not match the transaction in the interface!")
       } else {
         throw new Error("Error while talking to the gnosis-interface: " + JSON.stringify(error.response.data))
       }
     })
     if (result !== undefined) {
-      const interfaceLink = `https://${linkPrefix[network]}gnosis-safe.io/app/#/safes/${masterSafe.address}/transactions`
-      console.log(`The transaction matches one in the interface with nonce ${nonce} that can be signed here: ${interfaceLink}`)
+      const interfaceLink = `${webInterfaceBaseAddress(network)}/safes/${masterSafe.address}/transactions`
+      console.log(`This transaction matches one in the interface with nonce ${nonce} that can be signed here: ${interfaceLink}`)
     }
   }
 
+  /**
+   * Returns the first unused Safe nonce from the web interface.
+   *
+   * This function does *not* retrieve the nonce from the blockchain
+   * but from the multisig web service. It keeps into account pending
+   * transactions that were created in the web interface but never
+   * executed onchain. If the blockchain nonce were used, the first
+   * pending transaction would be overwritten and only one of the two
+   * transactions (the newly created one and the overwritten one) can
+   * be executed.
+   *
+   * @param {Address} multisigAddress Address of the multisig Safe for
+   * which to retrieve the nonce.
+   * @param {string} network Either rinkeby or mainnet.
+   * @returns {number} The first Safe nonce available for a new transaction.
+   */
+  const firstAvailableNonce = async function (multisigAddress, network) {
+    // https://safe-transaction.gnosis.io#operations-safes-safes_transactions_list
+    const apiGetTtransactionUrl = `${transactionApiBaseAddress(
+      network
+    )}/safes/${multisigAddress}/transactions/?ordering=-nonce&limit=1`
+
+    const result = await axios.get(apiGetTtransactionUrl)
+
+    const hasExpectedEntries = result.data && result.data.results && Array.isArray(result.data.results)
+    if (!hasExpectedEntries) {
+      throw new Error("Failed to decode server response when retrieving nonce from the web interface")
+    }
+    if (result.data.results.length === 0) {
+      // no transactions were ever created with this safe
+      return 0
+    }
+
+    const nonce = result.data.results[0].nonce
+    if (!Number.isInteger(nonce)) {
+      throw new Error("Failed to decode server response when retrieving nonce from the web interface")
+    }
+    return 1 + nonce
+  }
+
   return {
+    firstAvailableNonce,
     signAndSend,
     transactionExistsOnSafeServer,
     linkPrefix,


### PR DESCRIPTION
Closes #477.

Use the first nonce available from the web interface instead of retrieving the nonce onchain.

This PR changes the previous behavior of overwriting pending transactions when running the scripts. In particular, running the scripts two times creates each times a new deployment.
While the overwriting was a nice feature, it appears to be currently broken because of some change in the web interface. When the overwriting behavior will be available again, I plan to create a PR in which the user can specify a `--nonce` for every script that creates a transaction.

### Test plan
A step-by-step test plan that verifies that most scripts work as expected. 
```
# I assume the owned safe holds a bunch of TUSD
export MY_SAFE=<insert safe address>
# do not execute anything in the web interface until instructed
# create single-transaction deployment
npx truffle exec scripts/single_transaction_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=220 --highestLimit=271 --currentPrice=270 --masterSafe=$MY_SAFE --depositBaseToken=0 --depositQuoteToken=10 --numBrackets=3 --network=rinkeby
# verify previous transaction, failure expected because nonce was not specified
npx truffle exec scripts/single_transaction_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=220 --highestLimit=271 --currentPrice=270 --masterSafe=$MY_SAFE --depositBaseToken=0 --depositQuoteToken=10 --numBrackets=3 --network=rinkeby --verify
# as before but with nonce, zero for a new safe, success
npx truffle exec scripts/single_transaction_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=220 --highestLimit=271 --currentPrice=270 --masterSafe=$MY_SAFE --depositBaseToken=0 --depositQuoteToken=10 --numBrackets=3 --network=rinkeby --verify --nonce=0
# just for testing, manually create (not execute!) a transaction on the web interface sending 1 TUSD
# create multi-transaction deployment
npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=220 --highestLimit=271 --currentPrice=270 --masterSafe=$MY_SAFE --depositBaseToken=0 --depositQuoteToken=10 --numBrackets=3 --network=rinkeby
# verify failure without nonce
npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=220 --highestLimit=271 --currentPrice=270 --masterSafe=$MY_SAFE --depositBaseToken=0 --depositQuoteToken=10 --numBrackets=3 --network=rinkeby --verify
# add --brackets and --nonce (at this point it should be 2 for a new safe), everything should verify
export BRACKETS=<insert the three brackets created in the previous deployment>
npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=220 --highestLimit=271 --currentPrice=270 --masterSafe=$MY_SAFE --depositBaseToken=0 --depositQuoteToken=10 --numBrackets=3 --network=rinkeby --verify --brackets=$BRACKETS --nonce=2
# create deposit file just by copypasting the following
export STUFFBEFORE='{"bracketAddress":"'
export STUFFAFTER='", "tokenAddress":"0x0000000000085d4780b73119b644ae5ecd22b376", "amount":"100000000000"}'
echo [$STUFFBEFORE$(echo ${BRACKETS} | sed "s/,/$STUFFAFTER,$STUFFBEFORE/g")$STUFFAFTER] > testDeposits.json
# execute deposit
npx truffle exec scripts/transfer_approve_deposit.j^C--masterSafe=0xb947de73ADe9aBC6D57eb34B2CC2efd41f646636 --depositFile=examples/exampleDepositList.json --network=rinkeby
# there should be 5 transactions pending at this point. Execute everything.
# after five minutes, check balances of all brackets
export BRACKETS=$(npx truffle exec scripts/get_deployed_brackets.js --masterSafe=$MY_SAFE  --network=rinkeby --outputFile=/dev/null | grep --extended-regexp --only-matching '(0x[0-9a-zA-Z]*,)*0x[0-9a-zA-Z]*')
npx truffle exec scripts/balance_viewer.js --network=rinkeby --brackets=$BRACKETS
# Sample output (note that the extra deposits worked and my brackets traded)
#Balance of 0xa069F47C31B9c229b7E3fC6de946d044D774a9e1 for token TUSD: 3.333333433333333333
#Balance of 0xc8Ab5b75A8Ee2A174C19b9451924E73AdBb15DdC for token TUSD: 3.333333433333333333
#Balance of 0x09b3a8104923Df58a9375E621c4837C14d6FB0DE for token WETH: 0.013216357803923834
#Balance of 0x09b3a8104923Df58a9375E621c4837C14d6FB0DE for token TUSD: 0.00001790104460358
#Balance of 0xE257738B7551360dB94ad29ddab9E922DC7C75cD for token TUSD: 3.333333333333333333
#Balance of 0xD8d76601dc5aBa3E0D919b1a193809ea39B3fF3f for token TUSD: 3.333333333333333333
#Balance of 0xc174487d61Ea038E50f300Bf5890272094Ed030A for token WETH: 0.013216357803923836
#Balance of 0xc174487d61Ea038E50f300Bf5890272094Ed030A for token TUSD: 0.000017801044602075
# finally, withdraw everything
npx truffle exec scripts/request_withdraw.js --masterSafe=$MY_SAFE --brackets=$BRACKETS --network=rinkeby --noBalanceCheck
# execute and then claim
npx truffle exec scripts/claim_withdraw.js --masterSafe=$MY_SAFE --brackets=$BRACKETS --network=rinkeby
```