### PR TITLE
No empty withdrawing

### DIFF
--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -122,6 +122,10 @@ module.exports = function (web3, artifacts) {
       )
     )
 
+    if (withdrawals.length === 0) {
+      throw new Error("No funds can be withdrawn for the given parameters.")
+    }
+
     return {
       withdrawals,
       tokenInfoPromises,

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -520,10 +520,14 @@ contract("Withdraw script", function (accounts) {
       }
       const globalPriceStorage = {}
       globalPriceStorage["WETH-USDC"] = { price: 250.0 }
-      const transaction = await prepareWithdrawAndTransferFundsToMaster(argv, false, globalPriceStorage)
-      // if the built transaction used the token balance of the bracket instead of zero, then
-      // the following transaction would fail.
-      await execTransaction(masterSafe, safeOwner, transaction)
+
+      // The transaction creation should be rejected because no funds can be withdrawn
+      // before executing a withdraw request.
+      // If the built transaction used the token balance of the bracket instead of zero,
+      // then the transaction creation would not fail.
+      await assertNodejs.rejects(prepareWithdrawAndTransferFundsToMaster(argv, false, globalPriceStorage), {
+        message: "No funds can be withdrawn for the given parameters.",
+      })
     })
   })
   it("fails on bad input", async () => {


### PR DESCRIPTION
The withdraw scripts should not propose to the user to send an empty withdraw transaction.

### Test plan

See failure when running one of the withdraw script.
```
npx truffle exec scripts/request_withdraw.js --masterSafe=0x0000000000000000000000000000000000000000 --brackets=0x0000000000000000000000000000000000000000 --network=rinkeby
```