### PR TITLE
Simpler retrieval of deployed brackets

### DIFF
--- a/scripts/get_deployed_brackets.js
+++ b/scripts/get_deployed_brackets.js
@@ -4,7 +4,6 @@ const {
   fetchTokenInfoFromExchange,
   getExchange,
   getDeployedBrackets,
-  getDeployedDeterministicBrackets,
 } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { default_yargs } = require("./utils/default_yargs")
 const argv = default_yargs
@@ -21,9 +20,7 @@ const argv = default_yargs
 
 module.exports = async (callback) => {
   try {
-    const nonDeterministicBracketAddresses = await getDeployedBrackets(argv.masterSafe)
-    const deterministicBracketAddresses = await getDeployedDeterministicBrackets(argv.masterSafe)
-    const bracketAddresses = nonDeterministicBracketAddresses.concat(deterministicBracketAddresses)
+    const bracketAddresses = await getDeployedBrackets(argv.masterSafe)
     console.log("The following addresses have been deployed from your MASTER SAFE: ", bracketAddresses.join())
 
     // writing the brackets into a csv file

--- a/scripts/get_deployed_brackets.js
+++ b/scripts/get_deployed_brackets.js
@@ -1,10 +1,9 @@
 const createCsvWriter = require("csv-writer").createObjectCsvWriter
 const { decodeOrders } = require("@gnosis.pm/dex-contracts")
-const {
-  fetchTokenInfoFromExchange,
-  getExchange,
-  getDeployedBrackets,
-} = require("./utils/trading_strategy_helpers")(web3, artifacts)
+const { fetchTokenInfoFromExchange, getExchange, getDeployedBrackets } = require("./utils/trading_strategy_helpers")(
+  web3,
+  artifacts
+)
 const { default_yargs } = require("./utils/default_yargs")
 const argv = default_yargs
   .option("masterSafe", {

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -671,33 +671,19 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    * @returns {Address[]} List of bracket (Safe) addresses
    **/
   const getDeployedBrackets = async function (masterSafe) {
-    const FleetFactory = artifacts.require("FleetFactory")
-    const fleetFactory = await FleetFactory.deployed()
+    const fleetFactory = await fleetFactoryPromise
+    const fleetFactoryDeterministic = await fleetFactoryDeterministicPromise
     const events = await fleetFactory.getPastEvents("FleetDeployed", {
       filter: { owner: masterSafe },
       fromBlock: 0,
       toBlock: "latest",
     })
-    const bracketsAsObjects = events.map((object) => object.returnValues.fleet)
-    return [].concat(...bracketsAsObjects)
-  }
-
-  /**
-   * Fetches the brackets deployed with the deterministic fleet factory by a given masterSafe
-   * from the blockchaiin via events.
-   *
-   * @param {Address} masterSafe
-   * @returns {Address[]} List of bracket (Safe) addresses
-   */
-  const getDeployedDeterministicBrackets = async function (masterSafe) {
-    const FleetFactoryDeterministic = artifacts.require("FleetFactoryDeterministic")
-    const fleetFactoryDeterministic = await FleetFactoryDeterministic.deployed()
-    const events = await fleetFactoryDeterministic.getPastEvents("FleetDeployed", {
+    const eventsDeterministic = await fleetFactoryDeterministic.getPastEvents("FleetDeployed", {
       filter: { owner: masterSafe },
       fromBlock: 0,
       toBlock: "latest",
     })
-    const bracketsAsObjects = events.map((object) => object.returnValues.fleet)
+    const bracketsAsObjects = events.concat(eventsDeterministic).map((object) => object.returnValues.fleet)
     return [].concat(...bracketsAsObjects)
   }
 
@@ -1077,7 +1063,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     fetchTokenInfoForFlux,
     getAllowances,
     getDeployedBrackets,
-    getDeployedDeterministicBrackets,
     getExchange,
     getSafe,
     hasExistingOrders,


### PR DESCRIPTION
The function `getDeployedBrackets` now returns all deployed brackets, including the ones deployed deterministically. This simplifies some calls and makes `scripts/balance_viewer.js` work as expected.

### Test plan

Note that `getDeployedBrackets` is only used in `scripts/balance_viewer.js` and `scripts/get_deployed_brackets.js`.

Compare the output of the following command with this PR and on master (50 vs 10 brackets found).
```
npx truffle exec scripts/balance_viewer.js --network=rinkeby --masterSafe=0x04a82eC4857694a28bdDb9cE8E13DCbc090928e7
```

See that the output of the following command on master is the same with this PR and on master.
```
npx truffle exec scripts/get_deployed_brackets.js --masterSafe=0x04a82eC4857694a28bdDb9cE8E13DCbc090928e7 --network=rinkeby --outputFile=testPr.csv
```