### PR TITLE
Support Parity Nodes for GasEstimation

### DIFF
--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -170,12 +170,18 @@ module.exports = function (web3, artifacts) {
     const estimateCall = masterSafe.contract.methods
       .requiredTxGas(transaction.to, transaction.value, transaction.data, transaction.operation)
       .encodeABI()
-    const estimateResponse = await web3.eth.call({
-      to: masterSafe.address,
-      from: masterSafe.address,
-      data: estimateCall,
-      gasPrice: 0,
-    })
+    let estimateResponse
+    try {
+     estimateResponse = await web3.eth.call({
+        to: masterSafe.address,
+        from: masterSafe.address,
+        data: estimateCall,
+        gasPrice: 0,
+      })
+    } catch(error) {
+      // Parity nodes throw with error message is "VM execution error\n Reverted 0x..."
+      estimateResponse = "0x" + error.message.split("0x").pop()
+    }
     // https://docs.gnosis.io/safe/docs/contracts_tx_execution/#safe-transaction-gas-limit-estimation
     // The value returned by requiredTxGas is encoded in a revert error message. For retrieving the hex
     // encoded uint value the first 68 bytes of the error message need to be removed.

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -178,7 +178,7 @@ module.exports = function (web3, artifacts) {
         data: estimateCall,
         gasPrice: 0,
       })
-    } catch(error) {
+    } catch (error) {
       // Parity nodes throw with error message is "VM execution error\n Reverted 0x..."
       estimateResponse = "0x" + error.message.split("0x").pop()
     }

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -172,7 +172,7 @@ module.exports = function (web3, artifacts) {
       .encodeABI()
     let estimateResponse
     try {
-     estimateResponse = await web3.eth.call({
+      estimateResponse = await web3.eth.call({
         to: masterSafe.address,
         from: masterSafe.address,
         data: estimateCall,


### PR DESCRIPTION
Our current gas estimation expects eth.call to return a revert message, which contains the required amount of gas. This works on geth nodes, on parity however the reverted call causes an exception to be thrown which is not handled in the current code path. This PR adds handling and gas estimate extraction form the exception's error message.

xDAI only runs with parity nodes, so this is needed in order to get the scripts running on xDAI.

### Test Plan

running complete liquidity provision on xDAI (next PR).