### PR TITLE
Allow liquidity provision without Web

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -67,6 +67,10 @@
     "4": {
       "links": {},
       "address": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
+    },
+    "100": {
+      "links": {},
+      "address": "0x6851D6fDFAfD08c0295C392436245E5bc78B0185"
     }
   },
   "GnosisSafeProxyFactory": {
@@ -111,6 +115,10 @@
       "links": {},
       "address": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD",
       "transactionHash": "0x6fabaeeba1dba60983da94818965ecbac7b2ed81fc71c08d6582e29dc05745c7"
+    },
+    "100": {
+      "links": {},
+      "address": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD"
     }
   }
 }

--- a/networks.json
+++ b/networks.json
@@ -1,4 +1,30 @@
 {
+  "BatchExchange": {
+    "1": {
+      "links": {
+        "IdToAddressBiMap": "0xED4d05496C71e71cC2A8726af1242C22108d1761",
+        "IterableAppendOnlySet": "0xCDDB32b6Bb2808D5B5115dAab207479cE98d2636"
+      },
+      "address": "0x6F400810b62df8E13fded51bE75fF5393eaa841F",
+      "transactionHash": "0xe74e8e965afc67f96a38caee794f008be33a7fe7ea96b9baad7b2963250ac36a"
+    },
+    "4": {
+      "links": {
+        "IdToAddressBiMap": "0x5c4C6bf91240A5fdBfB9a1BEd8d43227046e2feA",
+        "IterableAppendOnlySet": "0x0D47D0548FDAD66B06E81a826EED8c687aCddBCB"
+      },
+      "address": "0xC576eA7bd102F7E476368a5E98FA455d1Ea34dE2",
+      "transactionHash": "0xc5bf4f48747093a79b623c2a2392ccbdb73a3d788e7d1f0f53f640ea18496d90"
+    },
+    "100": {
+      "links": {
+        "IdToAddressBiMap": "0x048E53A455a058462eA58442E1D94Fbc955495cB",
+        "IterableAppendOnlySet": "0x57E6B987c2ccd421859A244dd22a0D5a62D88f91"
+      },
+      "address": "0x25B06305CC4ec6AfCF3E7c0b673da1EF8ae26313",
+      "transactionHash": "0xd5e7da686ace1ae7f1917ad54b8610ee936bdc900e56b495739795fba3d5e7c1"
+    }
+  },
   "FleetFactory": {
     "1": {
       "links": {},
@@ -9,6 +35,11 @@
       "links": {},
       "address": "0x1b94BF378B910e5be70b59e774867a1c919821C7",
       "transactionHash": "0xf8256a6b6c92a95f9342d0dbb8afee83d1dd6bec8510278893f568ae0114ee3f"
+    },
+    "100": {
+      "links": {},
+      "address": "0x473E1D34458F26BFeB40f304a13c80FA291d0Abc",
+      "transactionHash": "0x906fbf6b72e2a1d79e2829c5413fdd6102470a06a71fca4cddb534aca8dcac84"
     }
   },
   "FleetFactoryDeterministic": {
@@ -21,6 +52,11 @@
       "links": {},
       "address": "0x6b7aaDEE3F3060c52F1c5Afcfc2F4d25554af3e5",
       "transactionHash": "0x2d5d771058550950b8675fae4e2f09f2e39d0056bd9a831a597ac7b4a72fbed9"
+    },
+    "100": {
+      "links": {},
+      "address": "0xE91c3d95629465e597CC35ee407d0f11aE19646E",
+      "transactionHash": "0xdceb34cf58d94a57627ba569fb03fd73ee103e751f13d9e8caf96ee4ad0d66bc"
     }
   },
   "GnosisSafe": {
@@ -42,6 +78,11 @@
       "links": {},
       "address": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",
       "transactionHash": "0x6b93c236af4d8adf9d9f4aaab07d0158f9ed7dd727141ca117191a3297d6b0e1"
+    },
+    "100": {
+      "links": {},
+      "address": "0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B",
+      "transactionHash": "0x25ecede929e0cf7c19057e66a31d081ebedb34680f7a84db3dd000f379da0487"
     }
   },
   "Migrations": {
@@ -54,6 +95,11 @@
       "links": {},
       "address": "0xAd0B040edF19bB81BDb2f14B26c7ba5F7ec263C2",
       "transactionHash": "0x34f548082b798f50d41ddd036c7fdf15cafda442c7f55947a1a46db8f5632924"
+    },
+    "100": {
+      "links": {},
+      "address": "0x43A58D234283F9AB8872bedf60f06cd88cAea4DE",
+      "transactionHash": "0x3476269d80d50afe4168479135b2f030778f81716631c0507d7bb09e7f7b28e0"
     }
   },
   "MultiSend": {

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "truffle-plugin-verify": "^0.4.0"
   },
   "dependencies": {
-    "@gnosis.pm/dex-contracts": "^0.4.2",
+    "@gnosis.pm/dex-contracts": "^0.4.3",
     "@gnosis.pm/owl-token": "^3.1.0",
-    "@gnosis.pm/safe-contracts": "v1.1.1-dev.2",
+    "@gnosis.pm/safe-contracts": "v1.2.0",
     "@gnosis.pm/solidity-data-structures": "=1.2.4",
-    "@gnosis.pm/util-contracts": "^2.0.6",
+    "@gnosis.pm/util-contracts": "^2.0.7",
     "@openzeppelin/contracts": "=2.5.1",
     "@truffle/contract": "4.2.24",
     "axios": "^0.20.0",

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -169,7 +169,9 @@ module.exports = async (callback) => {
       true
     )
 
-    const signAndSendOrExecuteOnChain = argv.executeOnchain ? async (safe, tx, _, nonce) => signAndExecute(safe, tx, nonce) : signAndSend
+    const signAndSendOrExecuteOnChain = argv.executeOnchain
+      ? async (safe, tx, _, nonce) => signAndExecute(safe, tx, nonce)
+      : signAndSend
 
     if (!argv.verify) {
       console.log(

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -8,7 +8,7 @@ const default_yargs = require("yargs")
   .option("network", {
     type: "string",
     describe: "network where the script is executed",
-    choices: ["rinkeby", "mainnet"],
+    choices: ["rinkeby", "xdai", "mainnet"],
   })
 
 const checkNoDuplicate = function (array) {

--- a/scripts/utils/gnosis_safe_server_interactions.js
+++ b/scripts/utils/gnosis_safe_server_interactions.js
@@ -13,6 +13,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const linkPrefix = {
     rinkeby: "rinkeby.",
     mainnet: "",
+    xdai: "xdai",
   }
 
   const webInterfaceBaseAddress = function (network) {
@@ -28,7 +29,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    *
    * @param {SmartContract} masterSafe Address of the master safe owning the brackets
    * @param {Transaction} transaction The transaction to be signed and sent
-   * @param {string} network either rinkeby or mainnet
+   * @param {string} network either rinkeby, xdai or mainnet
    * @param {number} [nonce=null] specified transaction index. Will fetch correct value if not specified.
    */
   const signAndSend = async function (masterSafe, transaction, network, nonce = null) {
@@ -84,7 +85,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    *
    * @param {SmartContract} masterSafe Address of the master safe owning the brackets
    * @param {Transaction} transaction The transaction whose existence is checked
-   * @param {string} network either rinkeby or mainnet
+   * @param {string} network either rinkeby, xdai or mainnet
    * @param {number} [nonce=null] Gnosis Safe transaction nonce.
    */
   const transactionExistsOnSafeServer = async function (masterSafe, transaction, network, nonce = null) {
@@ -132,7 +133,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    *
    * @param {Address} multisigAddress Address of the multisig Safe for
    * which to retrieve the nonce.
-   * @param {string} network Either rinkeby or mainnet.
+   * @param {string} network Either rinkeby, dai or mainnet.
    * @returns {number} The first Safe nonce available for a new transaction.
    */
   const firstAvailableNonce = async function (multisigAddress, network) {

--- a/scripts/utils/gnosis_safe_server_interactions.js
+++ b/scripts/utils/gnosis_safe_server_interactions.js
@@ -37,7 +37,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     }
 
     const safeTxGas = await estimateGas(masterSafe, transaction)
-    const {signature, signer, transactionHash} = await signTransaction(masterSafe, transaction, safeTxGas, nonce)
+    const { signature, signer, transactionHash } = await signTransaction(masterSafe, transaction, safeTxGas, nonce)
 
     const endpoint = `${transactionApiBaseAddress(network)}/safes/${masterSafe.address}/transactions/`
     const postData = {

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -243,7 +243,6 @@ module.exports = function (web3, artifacts) {
    *
    * @param {SmartContract} masterSafe Address of the master safe owning the brackets
    * @param {Transaction} transaction The transaction to be signed and sent
-   * @param {string} network either rinkeby, xdai or mainnet
    * @param {number} [nonce=null] specified transaction index. Will fetch correct value if not specified.
    */
   const signAndExecute = async function (masterSafe, transaction, nonce = null) {

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -213,13 +213,11 @@ module.exports = function (web3, artifacts) {
     )
 
     const signer = (await web3.eth.getAccounts())[0]
-    console.log(
-      `Signing transaction ${transactionHash} from proposer account ${signer} with nonce ${nonce}`
-    )
+    console.log(`Signing transaction ${transactionHash} from proposer account ${signer} with nonce ${nonce}`)
     return {
       signature: await getSafeCompatibleSignature(transactionHash, signer),
       signer,
-      transactionHash
+      transactionHash,
     }
   }
 
@@ -251,18 +249,19 @@ module.exports = function (web3, artifacts) {
     }
     const safeTxGas = await estimateGas(masterSafe, transaction)
     const { signature } = await signTransaction(masterSafe, transaction, safeTxGas, nonce)
-    
+
     await masterSafe.execTransaction(
-      transaction.to, 
-      transaction.value, 
-      transaction.data, 
-      transaction.operation, 
+      transaction.to,
+      transaction.value,
+      transaction.data,
+      transaction.operation,
       safeTxGas,
-      0, 
-      0, 
-      ZERO_ADDRESS, 
+      0,
+      0,
       ZERO_ADDRESS,
-      signature)
+      ZERO_ADDRESS,
+      signature
+    )
   }
 
   return {

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -170,12 +170,18 @@ module.exports = function (web3, artifacts) {
     const estimateCall = masterSafe.contract.methods
       .requiredTxGas(transaction.to, transaction.value, transaction.data, transaction.operation)
       .encodeABI()
-    const estimateResponse = await web3.eth.call({
-      to: masterSafe.address,
-      from: masterSafe.address,
-      data: estimateCall,
-      gasPrice: 0,
-    })
+    let estimateResponse
+    try {
+     estimateResponse = await web3.eth.call({
+        to: masterSafe.address,
+        from: masterSafe.address,
+        data: estimateCall,
+        gasPrice: 0,
+      })
+    } catch(error) {
+      // Parity nodes throw with error message is "VM execution error\n Reverted 0x..."
+      estimateResponse = "0x" + error.message.split("0x").pop()
+    }
     // https://docs.gnosis.io/safe/docs/contracts_tx_execution/#safe-transaction-gas-limit-estimation
     // The value returned by requiredTxGas is encoded in a revert error message. For retrieving the hex
     // encoded uint value the first 68 bytes of the error message need to be removed.

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -172,7 +172,7 @@ module.exports = function (web3, artifacts) {
       .encodeABI()
     let estimateResponse
     try {
-     estimateResponse = await web3.eth.call({
+      estimateResponse = await web3.eth.call({
         to: masterSafe.address,
         from: masterSafe.address,
         data: estimateCall,

--- a/scripts/utils/liquidity_provision_sanity_checks.js
+++ b/scripts/utils/liquidity_provision_sanity_checks.js
@@ -32,6 +32,7 @@ module.exports = function (web3, artifacts) {
       argv.nonce === null ? firstAvailableNonce(argv.masterSafe, argv.network) : Promise.resolve(argv.nonce)
     const signerPromise = web3.eth.getAccounts().then((accounts) => accounts[0])
     const masterOwnersPromise = masterSafePromise.then((masterSafe) => masterSafe.getOwners())
+    const thresholdPromise = masterSafePromise.then((masterSafe) => masterSafe.getThreshold())
 
     const exchange = await exchangePromise
     const tokenInfoPromises = fetchTokenInfoFromExchange(exchange, [argv.baseTokenId, argv.quoteTokenId])
@@ -72,7 +73,11 @@ module.exports = function (web3, artifacts) {
       }
     }
     if (argv.numBrackets > maxBrackets) {
-      throw new Error("Error: Choose a smaller numBrackets, otherwise your transaction would be too large.")
+      throw new Error("Choose a smaller numBrackets, otherwise your transaction would be too large.")
+    }
+
+    if (argv.executeOnchain && await thresholdPromise != 1) {
+      throw new Error("More than one signature required. Cannot execute on chain immediately.")
     }
 
     return {

--- a/scripts/utils/liquidity_provision_sanity_checks.js
+++ b/scripts/utils/liquidity_provision_sanity_checks.js
@@ -76,7 +76,7 @@ module.exports = function (web3, artifacts) {
       throw new Error("Choose a smaller numBrackets, otherwise your transaction would be too large.")
     }
 
-    if (argv.executeOnchain && await thresholdPromise != 1) {
+    if (argv.executeOnchain && (await thresholdPromise) != 1) {
       throw new Error("More than one signature required. Cannot execute on chain immediately.")
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,7 +293,7 @@
     "@ethersproject/rlp" "^5.0.3"
     "@ethersproject/signing-key" "^5.0.4"
 
-"@gnosis.pm/dex-contracts@^0.4.2":
+"@gnosis.pm/dex-contracts@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/dex-contracts/-/dex-contracts-0.4.3.tgz#b887eb543cae039d1e9607870232394cab5c3be7"
   integrity sha512-ObyItfEzWRwfwWSSncPFP8aT54+Vi7VzTvqCbNYTwF+Einn9kdJvasTWkFaw5eiZE1ykD//kFB4T8xv80F2lBw==
@@ -316,16 +316,16 @@
     "@gnosis.pm/util-contracts" "^2.0.0"
     verify-on-etherscan "^1.1.1"
 
-"@gnosis.pm/safe-contracts@v1.1.1-dev.2":
-  version "1.1.1-dev.2"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.1.1-dev.2.tgz#4a5b9a9befe66d15df87d2216237d4ea4f64118f"
-  integrity sha512-x0x8K3/XzfDmtmL6RaF8eSJUPJVmT7jd29kmwoodm/JlYlyOmdQNBynUZUTkmknIlF1coiypCLls9zDbx8QQfw==
+"@gnosis.pm/safe-contracts@v1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.2.0.tgz#33e8332e09c19e8822fccb06c7d3eff806d091f6"
+  integrity sha512-lcpZodqztDgMICB0kAc8aJdQePwCaLJnbeNjgVTfLAo3fBckVRV06VHXg5IsZ26qLA4JfZ690Cb7TsDVE9ZF3w==
   dependencies:
     "@truffle/hdwallet-provider" "^1.0.0"
     dotenv "^8.0.0"
     openzeppelin-solidity "^2.0.0"
     shelljs "^0.8.3"
-    solc "0.5.14"
+    solc "0.5.17"
     truffle "^5.1.21"
 
 "@gnosis.pm/solidity-data-structures@=1.2.4":
@@ -342,7 +342,7 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/util-contracts/-/util-contracts-2.0.0.tgz#562b14a2d6cb4a59189476dd0f6aaeba5f65abe2"
   integrity sha512-vRgTV36d4ZFdcetKcNbnAtSDrP3OSWEj8YmG3RHK4DBMulPX2asRh8VnopTrZnZQ8enZIDbT1pT7buW+UJqd4g==
 
-"@gnosis.pm/util-contracts@^2.0.0", "@gnosis.pm/util-contracts@^2.0.4", "@gnosis.pm/util-contracts@^2.0.6":
+"@gnosis.pm/util-contracts@^2.0.0", "@gnosis.pm/util-contracts@^2.0.4", "@gnosis.pm/util-contracts@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/util-contracts/-/util-contracts-2.0.7.tgz#b28073890a6a6be8458a7d7952c8541788fd020f"
   integrity sha512-+8V0C/E4aGMudeMQBNDLidE3GwfM4XSySuT39wON8wpj9ocNyIsV4U+4YTfEOyUQ9PafKloWr78W5OhkOX9eqQ==
@@ -6797,10 +6797,10 @@ sol-merger@3.1.0, sol-merger@^3.1.0:
     glob "^7.1.2"
     strip-json-comments "^3.0.1"
 
-solc@0.5.14:
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.14.tgz#7c3ecb2441ac10a15cdfd39207372eb63f2bd00c"
-  integrity sha512-I/MCeOKjnLXxcD65wA+E37BxdERoAYoLeyJ5GnXFijICLmvhzt0xz59R92Zw3TPyJYnHSErKBYpMsfnZVyQJaQ==
+solc@0.5.17:
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.5.17.tgz#8a76c50e98d49ca7610cca2fdc78ff3016540c67"
+  integrity sha512-qpX+PGaU0Q3c6lh2vDzMoIbhv6bIrecI4bYsx+xUs01xsGFnY6Nr0L8y/QMyutTnrHN6Lb/Yl672ZVRqxka96w==
   dependencies:
     command-exists "^1.2.8"
     commander "3.0.2"


### PR DESCRIPTION
This PR makes it so that we can do liquidity provision without requiring the Safe Webinterface (by invoking executeTransaction directly, assuming a single owner safe).

This will be particularly useful on xDAI where the Safe ecosystem won't be ready before earliest the end of next week. The default behaviour didn't change.

### Test Plan

Old way still works:

```
yarn truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=8 --lowestLimit=300 --highestLimit=400 --currentPrice=340 --masterSafe=$MASTER_SAFE --depositBaseToken=0 --depositQuoteToken=0 --numBrackets=10 --network=$NETWORK_NAME
```

But also new way works and leads to executed txs (e.g. [this one](https://blockscout.com/poa/xdai/tx/0x93e5608647859c8f0486f92b9fdee2e52689fc605ff1e4d3e7f5208208b49a17/token-transfers))
```
 yarn truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=8 --lowestLimit=300 --highestLimit=400 --currentPrice=340 --masterSafe=$MASTER_SAFE --depositBaseToken=0 --depositQuoteToken=0 --numBrackets=10 --network=$NETWORK_NAME --executeOnchain --nonce 4
```