### PR TITLE
Use GnosisSafe npm artefact instead of local compilation

### DIFF
--- a/migrations/2_dev_dependencies.js
+++ b/migrations/2_dev_dependencies.js
@@ -1,5 +1,6 @@
+const Artifactor = require("@truffle/artifactor")
 const migrateBatchExchange = require("@gnosis.pm/dex-contracts/src/migration/PoC_dfusion")
-const GnosisSafe = artifacts.require("./GnosisSafe.sol")
+const { GnosisSafe } = require("../scripts/utils/dependencies")(web3, artifacts)
 const ProxyFactory = artifacts.require("./GnosisSafeProxyFactory.sol")
 const MultiSend = artifacts.require("./MultiSend.sol")
 
@@ -13,16 +14,21 @@ module.exports = async function (deployer, network, accounts) {
     web3,
   })
 
-  const Artifactor = require("@truffle/artifactor")
   const artifactor = new Artifactor("build/contracts/")
   await artifactor.save(artefact)
 
   if (network === "development") {
-    await deployer.deploy(GnosisSafe)
+    await deploySafe(deployer)
     await deployer.deploy(ProxyFactory)
     await deployer.deploy(MultiSend)
   } else {
     // eslint-disable-next-line no-console
     console.log("Not in development, so nothing to do. Current network is %s", network)
   }
+}
+
+async function deploySafe(deployer) {
+  await deployer.deploy(GnosisSafe)
+  const artifactor = new Artifactor("node_modules/@gnosis.pm/safe-contracts/build/contracts/")
+  await artifactor.save(GnosisSafe)
 }

--- a/networks.json
+++ b/networks.json
@@ -23,16 +23,6 @@
       "transactionHash": "0x2d5d771058550950b8675fae4e2f09f2e39d0056bd9a831a597ac7b4a72fbed9"
     }
   },
-  "GnosisSafe": {
-    "1": {
-      "links": {},
-      "address": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
-    },
-    "4": {
-      "links": {},
-      "address": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
-    }
-  },
   "GnosisSafeProxyFactory": {
     "1": {
       "links": {},

--- a/scripts/airdrop.js
+++ b/scripts/airdrop.js
@@ -67,7 +67,7 @@ module.exports = async (callback) => {
       }
     }
 
-    const GnosisSafe = artifacts.require("GnosisSafe")
+    const { GnosisSafe } = require("./utils/dependencies")(web3, artifacts)
     const masterSafe = await GnosisSafe.at(argv.fundAccount)
 
     console.log("Preparing transaction data...")

--- a/scripts/deposit.js
+++ b/scripts/deposit.js
@@ -23,7 +23,7 @@ const argv = default_yargs
 
 module.exports = async (callback) => {
   try {
-    const GnosisSafe = artifacts.require("GnosisSafe")
+    const { GnosisSafe } = require("./utils/dependencies")(web3, artifacts)
     const masterSafe = await GnosisSafe.at(argv.masterSafe)
 
     const deposits = JSON.parse(await fs.readFile(argv.depositFile, "utf8"))

--- a/scripts/testing/setup_thegraph_data.js
+++ b/scripts/testing/setup_thegraph_data.js
@@ -1,6 +1,6 @@
 const { deployNewStrategy } = require("../utils/strategy_simulator")(web3, artifacts)
 const BatchExchange = artifacts.require("BatchExchange")
-const GnosisSafe = artifacts.require("GnosisSafe")
+const { GnosisSafe } = require("../utils/dependencies")(web3, artifacts)
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const { default_yargs } = require("../utils/default_yargs")
 const argv = default_yargs.argv

--- a/scripts/transfer_approve_deposit.js
+++ b/scripts/transfer_approve_deposit.js
@@ -21,7 +21,7 @@ const argv = default_yargs
 
 module.exports = async (callback) => {
   try {
-    const GnosisSafe = artifacts.require("GnosisSafe")
+    const { GnosisSafe } = require("./utils/dependencies")(web3, artifacts)
     const masterSafe = await GnosisSafe.at(argv.masterSafe)
 
     const deposits = JSON.parse(await fs.readFile(argv.depositFile, "utf8"))

--- a/scripts/utils/calculate_fleet_addresses.js
+++ b/scripts/utils/calculate_fleet_addresses.js
@@ -1,6 +1,6 @@
 module.exports = function (web3, artifacts) {
   const GnosisSafeProxyFactory = artifacts.require("GnosisSafeProxyFactory")
-  const GnosisSafe = artifacts.require("GnosisSafe")
+  const { GnosisSafe } = require("./dependencies")(web3, artifacts)
 
   const { generateAddress2, toBuffer, bufferToHex } = require("ethereumjs-util")
   const { toBN, sha3 } = web3.utils

--- a/scripts/utils/dependencies.js
+++ b/scripts/utils/dependencies.js
@@ -1,0 +1,14 @@
+module.exports = function (web3, artifacts) {
+  const truffleContract = require("@truffle/contract")
+  const Migrations = artifacts.require("Migrations")
+
+  const GnosisSafeBuildInfo = require("@gnosis.pm/safe-contracts/build/contracts/GnosisSafe.json")
+  const GnosisSafe = truffleContract(GnosisSafeBuildInfo)
+  GnosisSafe.setProvider(web3.currentProvider)
+  // Borrow dynamic config from native contract
+  GnosisSafe.defaults(Migrations.defaults())
+  GnosisSafe.setNetwork(Migrations.network_id)
+  return {
+    GnosisSafe,
+  }
+}

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -10,6 +10,7 @@ module.exports = function (web3, artifacts) {
   const IProxy = artifacts.require("IProxy")
   const MultiSend = artifacts.require("MultiSend")
 
+  const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const multiSendPromise = MultiSend.deployed()
 
   const jsonrpc = "2.0"
@@ -135,7 +136,7 @@ module.exports = function (web3, artifacts) {
    * @returns {Transaction} Transaction calling execTransaction; should be executed by master
    */
   const buildExecTransaction = async function (masterAddress, bracketAddress, transaction) {
-    const gnosisSafeMasterCopy = await GnosisSafe.deployed() // TODO: do we need the master copy instance?
+    const gnosisSafeMasterCopy = await gnosisSafeMasterCopyPromise // TODO: do we need the master copy instance?
 
     const execData = await execTransactionData(gnosisSafeMasterCopy, masterAddress, transaction)
     const execTransaction = {

--- a/scripts/utils/internals.js
+++ b/scripts/utils/internals.js
@@ -5,12 +5,11 @@
 
 module.exports = function (web3, artifacts) {
   const { ZERO_ADDRESS, CALL, DELEGATECALL } = require("./constants")
+  const { GnosisSafe } = require("./dependencies")(web3, artifacts)
 
   const IProxy = artifacts.require("IProxy")
-  const GnosisSafe = artifacts.require("GnosisSafe.sol")
   const MultiSend = artifacts.require("MultiSend")
 
-  const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const multiSendPromise = MultiSend.deployed()
 
   const jsonrpc = "2.0"
@@ -136,7 +135,7 @@ module.exports = function (web3, artifacts) {
    * @returns {Transaction} Transaction calling execTransaction; should be executed by master
    */
   const buildExecTransaction = async function (masterAddress, bracketAddress, transaction) {
-    const gnosisSafeMasterCopy = await gnosisSafeMasterCopyPromise // TODO: do we need the master copy instance?
+    const gnosisSafeMasterCopy = await GnosisSafe.deployed() // TODO: do we need the master copy instance?
 
     const execData = await execTransactionData(gnosisSafeMasterCopy, masterAddress, transaction)
     const execTransaction = {

--- a/scripts/utils/strategy_simulator.js
+++ b/scripts/utils/strategy_simulator.js
@@ -5,7 +5,7 @@ module.exports = function (web3, artifacts) {
     artifacts
   )
   const { ZERO_ADDRESS } = require("./constants")
-  const GnosisSafe = artifacts.require("GnosisSafe")
+  const { GnosisSafe } = require("./dependencies")(web3, artifacts)
   const TokenOWL = artifacts.require("TokenOWL")
   const TestToken = artifacts.require("DetailedMintableToken")
   const assert = require("assert")

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -28,6 +28,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const FleetFactoryDeterministic = artifacts.require("FleetFactoryDeterministic")
 
   const exchangePromise = BatchExchange.deployed()
+  const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const fleetFactoryPromise = FleetFactory.deployed()
   const fleetFactoryDeterministicPromise = FleetFactoryDeterministic.deployed()
   const hardcodedTokensByNetwork = require("./hardcoded_tokens")
@@ -246,7 +247,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    */
   const deployFleetOfSafes = async function (masterAddress, fleetSize) {
     const fleetFactory = await fleetFactoryPromise
-    const gnosisSafeMasterCopy = await GnosisSafe.deployed()
+    const gnosisSafeMasterCopy = await gnosisSafeMasterCopyPromise
 
     const transcript = await fleetFactory.deployFleet(masterAddress, fleetSize, gnosisSafeMasterCopy.address)
     return transcript.logs[0].args.fleet
@@ -265,7 +266,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    */
   const buildDeterministicFleetOfSafes = async function (masterAddress, fleetSize, nonce) {
     const fleetFactoryDeterministic = await fleetFactoryDeterministicPromise
-    const gnosisSafeMasterCopy = await GnosisSafe.deployed()
+    const gnosisSafeMasterCopy = await gnosisSafeMasterCopyPromise
 
     const data = fleetFactoryDeterministic.contract.methods
       .deployFleetWithNonce(masterAddress, fleetSize, gnosisSafeMasterCopy.address, nonce)

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -20,15 +20,14 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   const { shortenedAddress, toErc20Units, fromErc20Units } = require("./printing_tools")
   const { uniqueItems } = require("./js_helpers")
   const { DEFAULT_ORDER_EXPIRY, CALL } = require("./constants")
+  const { GnosisSafe } = require("./dependencies")(web3, artifacts)
 
   const ERC20 = artifacts.require("ERC20Detailed")
   const BatchExchange = artifacts.require("BatchExchange")
-  const GnosisSafe = artifacts.require("GnosisSafe")
   const FleetFactory = artifacts.require("FleetFactory")
   const FleetFactoryDeterministic = artifacts.require("FleetFactoryDeterministic")
 
   const exchangePromise = BatchExchange.deployed()
-  const gnosisSafeMasterCopyPromise = GnosisSafe.deployed()
   const fleetFactoryPromise = FleetFactory.deployed()
   const fleetFactoryDeterministicPromise = FleetFactoryDeterministic.deployed()
   const hardcodedTokensByNetwork = require("./hardcoded_tokens")
@@ -247,7 +246,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    */
   const deployFleetOfSafes = async function (masterAddress, fleetSize) {
     const fleetFactory = await fleetFactoryPromise
-    const gnosisSafeMasterCopy = await gnosisSafeMasterCopyPromise
+    const gnosisSafeMasterCopy = await GnosisSafe.deployed()
 
     const transcript = await fleetFactory.deployFleet(masterAddress, fleetSize, gnosisSafeMasterCopy.address)
     return transcript.logs[0].args.fleet
@@ -266,7 +265,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
    */
   const buildDeterministicFleetOfSafes = async function (masterAddress, fleetSize, nonce) {
     const fleetFactoryDeterministic = await fleetFactoryDeterministicPromise
-    const gnosisSafeMasterCopy = await gnosisSafeMasterCopyPromise
+    const gnosisSafeMasterCopy = await GnosisSafe.deployed()
 
     const data = fleetFactoryDeterministic.contract.methods
       .deployFleetWithNonce(masterAddress, fleetSize, gnosisSafeMasterCopy.address, nonce)

--- a/scripts/utils/verify_scripts.js
+++ b/scripts/utils/verify_scripts.js
@@ -8,8 +8,8 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
   )
   const { getMasterCopy, getFallbackHandler } = require("./internals")(web3, artifacts)
   const { getOneinchPrice, checkNoProfitableOffer } = require("./price_utils")
+  const { GnosisSafe } = require("./dependencies")(web3, artifacts)
 
-  const GnosisSafe = artifacts.require("GnosisSafe.sol")
   const GnosisSafeProxyFactory = artifacts.require("GnosisSafeProxyFactory.sol")
   const gnosisSafeMasterCopy = GnosisSafe.deployed()
   const expectedBytecodePromise = GnosisSafeProxyFactory.deployed().then((proxyFactory) => proxyFactory.proxyRuntimeCode())

--- a/scripts/wrap_eth.js
+++ b/scripts/wrap_eth.js
@@ -24,7 +24,7 @@ module.exports = async (callback) => {
 
     const weth = await WETH.deployed()
 
-    const GnosisSafe = artifacts.require("GnosisSafe")
+    const { GnosisSafe } = require("./utils/dependencies")(web3, artifacts)
     const masterSafe = await GnosisSafe.at(argv.masterSafe)
 
     const decimals = await weth.decimals()

--- a/test/dfusion_multi_safes.js
+++ b/test/dfusion_multi_safes.js
@@ -1,11 +1,11 @@
 const BN = require("bn.js")
 const assertNodejs = require("assert")
 const { decodeOrders } = require("@gnosis.pm/dex-contracts")
+const { GnosisSafe } = require("./../scripts/utils/dependencies")(web3, artifacts)
 
 const BatchExchange = artifacts.require("BatchExchange")
 const ERC20 = artifacts.require("ERC20Detailed")
 const TokenOWL = artifacts.require("TokenOWL")
-const GnosisSafe = artifacts.require("GnosisSafe")
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const TestToken = artifacts.require("DetailedMintableToken")
 

--- a/test/fleet_factory.js
+++ b/test/fleet_factory.js
@@ -2,7 +2,7 @@
  * @typedef {import('../scripts/typedef.js').Address} Address
  */
 
-const GnosisSafe = artifacts.require("GnosisSafe")
+const { GnosisSafe } = require("../scripts/utils/dependencies")(web3, artifacts)
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const IProxy = artifacts.require("IProxy")
 const FleetFactory = artifacts.require("FleetFactory")

--- a/test/fleet_factory_deterministic.js
+++ b/test/fleet_factory_deterministic.js
@@ -2,7 +2,7 @@
  * @typedef {import('../scripts/typedef.js').Address} Address
  */
 
-const GnosisSafe = artifacts.require("GnosisSafe")
+const { GnosisSafe } = require("../scripts/utils/dependencies")(web3, artifacts)
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const IProxy = artifacts.require("IProxy")
 const FleetFactoryDeterministic = artifacts.require("FleetFactoryDeterministic")

--- a/test/scripts/deposit.js
+++ b/test/scripts/deposit.js
@@ -1,5 +1,5 @@
 const BatchExchange = artifacts.require("BatchExchange")
-const GnosisSafe = artifacts.require("GnosisSafe")
+const { GnosisSafe } = require("../../scripts/utils/dependencies")(web3, artifacts)
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 
 const { addCustomMintableTokenToExchange, deploySafe } = require("../../scripts/utils/strategy_simulator")(web3, artifacts)

--- a/test/scripts/test_airdrop.js
+++ b/test/scripts/test_airdrop.js
@@ -2,7 +2,7 @@ const assert = require("assert")
 const BN = require("bn.js")
 
 const MintableToken = artifacts.require("DetailedMintableToken")
-const GnosisSafe = artifacts.require("GnosisSafe")
+const { GnosisSafe } = require("../../scripts/utils/dependencies")(web3, artifacts)
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 
 const { deploySafe } = require("../../scripts/utils/strategy_simulator")(web3, artifacts)

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -6,7 +6,7 @@ const assertNodejs = require("assert")
 const BatchExchange = artifacts.require("BatchExchange")
 const ERC20 = artifacts.require("ERC20Detailed")
 const MintableToken = artifacts.require("DetailedMintableToken")
-const GnosisSafe = artifacts.require("GnosisSafe")
+const { GnosisSafe } = require("../../scripts/utils/dependencies")(web3, artifacts)
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 
 const { deploySafe, addCustomMintableTokenToExchange, deployNewStrategy } = require("../../scripts/utils/strategy_simulator")(

--- a/test/verification_script.js
+++ b/test/verification_script.js
@@ -2,7 +2,7 @@ const BN = require("bn.js")
 const assert = require("assert")
 const { getUnlimitedOrderAmounts } = require("@gnosis.pm/dex-contracts")
 
-const GnosisSafe = artifacts.require("GnosisSafe")
+const { GnosisSafe } = require("../scripts/utils/dependencies")(web3, artifacts)
 const ProxyFactory = artifacts.require("GnosisSafeProxyFactory")
 const EvilGnosisSafeProxy = artifacts.require("EvilGnosisSafeProxy")
 


### PR DESCRIPTION
As discussed on #518 relying on our local compilation of dependent contracts can be error-prone if we e.g. update the GnosisSafe contract but don't remember to do a full local "re-migration".

This PR is a first step to removing our external dependecies (Safe, SafeFactory, MultiSend, BatchExchange) by using the artefact from the npm package directly.

The challenge with this was that in tests, we need a locally deployed instance (so that we can call GnosisSafe.deployed even on ganache). To achieve this we now use artefactor to write the locally deployed json back into the dependent npm folder.

Also tagging @rmeissner as he might have some idea of how to better accomplish what we want.

### Test Plan

complete liquidity provision still works on Rinkeby + unit tests pass