### PR TITLE
Allow withdrawl of balances < 1$

### DIFF
--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -149,7 +149,7 @@ contract("Withdraw script", function (accounts) {
         withdrawalFile: depositFile.path,
         withdraw: true,
       }
-      const claimTx = await prepareWithdraw(argv2, false, globalPriceStorage)
+      const claimTx = await prepareWithdraw(argv2, false)
       await execTransaction(masterSafe, safeOwner, claimTx)
 
       for (const { amount, tokenAddress, bracketAddress } of deposits) {
@@ -178,10 +178,10 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
-      const claimTx = await prepareWithdraw(argv, false, globalPriceStorage)
+      const claimTx = await prepareWithdraw(argv, false)
       await execTransaction(masterSafe, safeOwner, claimTx)
 
-      const transferTx = await prepareTransferFundsToMaster(argv, false, globalPriceStorage)
+      const transferTx = await prepareTransferFundsToMaster(argv, false)
       await execTransaction(masterSafe, safeOwner, transferTx)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -213,7 +213,7 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
-      const claimAndTransferTx = await prepareWithdrawAndTransferFundsToMaster(argv, false, globalPriceStorage)
+      const claimAndTransferTx = await prepareWithdrawAndTransferFundsToMaster(argv, false)
       await execTransaction(masterSafe, safeOwner, claimAndTransferTx)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -368,7 +368,7 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, transaction1)
       await waitForNSeconds(301)
 
-      const transaction2 = await prepareWithdraw(argv, false, globalPriceStorage)
+      const transaction2 = await prepareWithdraw(argv, false)
       await execTransaction(masterSafe, safeOwner, transaction2)
 
       for (const { amount, tokenAddress, bracketAddress } of deposits) {
@@ -398,14 +398,13 @@ contract("Withdraw script", function (accounts) {
       const argv = {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
-        noBalanceCheck: true,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
       const requestTransaction = await prepareWithdrawRequest(argv, false, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, requestTransaction)
       await waitForNSeconds(301)
 
-      const claimTransaction = await prepareWithdraw(argv, false, globalPriceStorage)
+      const claimTransaction = await prepareWithdraw(argv, false)
       await execTransaction(masterSafe, safeOwner, claimTransaction)
 
       const usdcAddress = tokenInfo[0].address
@@ -414,11 +413,10 @@ contract("Withdraw script", function (accounts) {
         const pendingWithdraw = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0]
         if (tokenAddress === usdcAddress) {
           assert.equal(bracketBalance, "0", "Not expecting to claim USDC balance")
-          assert(pendingWithdraw.gt(new BN(0)), "Should still have non-zero pending withdraw!")
         } else {
           assert.equal(bracketBalance, amount, "Bad amount requested to withdraw")
-          assert.equal(pendingWithdraw, "0", "A withdrawal request is still pending")
         }
+        assert.equal(pendingWithdraw, "0", "A withdrawal request is still pending")
       }
     })
     it("transfers funds to master", async () => {
@@ -448,10 +446,10 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, requestTransaction)
       await waitForNSeconds(301)
 
-      const claimTransaction = await prepareWithdraw(argv, false, globalPriceStorage)
+      const claimTransaction = await prepareWithdraw(argv, false)
       await execTransaction(masterSafe, safeOwner, claimTransaction)
 
-      const transferTransaction = await prepareTransferFundsToMaster(argv, false, globalPriceStorage)
+      const transferTransaction = await prepareTransferFundsToMaster(argv, false)
       await execTransaction(masterSafe, safeOwner, transferTransaction)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -492,7 +490,7 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
-      const claimAndTransferTx = await prepareWithdrawAndTransferFundsToMaster(argv, false, globalPriceStorage)
+      const claimAndTransferTx = await prepareWithdrawAndTransferFundsToMaster(argv, false)
       await execTransaction(masterSafe, safeOwner, claimAndTransferTx)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -518,14 +516,12 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address],
       }
-      const globalPriceStorage = {}
-      globalPriceStorage["WETH-USDC"] = { price: 250.0 }
 
       // The transaction creation should be rejected because no funds can be withdrawn
       // before executing a withdraw request.
       // If the built transaction used the token balance of the bracket instead of zero,
       // then the transaction creation would not fail.
-      await assertNodejs.rejects(prepareWithdrawAndTransferFundsToMaster(argv, false, globalPriceStorage), {
+      await assertNodejs.rejects(prepareWithdrawAndTransferFundsToMaster(argv, false), {
         message: "No funds can be withdrawn for the given parameters.",
       })
     })


### PR DESCRIPTION
We have a feature preventing small amounts (<$1) from being withdrawn, since on mainnet this is likely not economically viable. However, this feature heavily relies on a working 1Inch price estimator. This may not work for some tokens such as wxDAI. Also such a limit does not necessarily make sense on other networks where gas fees are low ($1 seems a bit arbitrary and should probably be configurable to begin with). 

We do have an option for the `request_withdraw` script that will ignore this "protection" and withdraw amounts regardless of value. However, the check for small balance not only happens in the amount estimation function ([here](https://github.com/gnosis/dex-liquidity-provision/blob/f80edbdeb3f11c97f400eb0e974815417c37693e/scripts/wrapper/withdraw.js#L141-L149)) but also in `getWithdrawalsAndTokenInfo` where the `noBalanceCheck` flag is not considered. Thus this check will fail even if we specify `--noBalanceCheck`.

Thus it is currently not possible to force withdrawal of small amounts.

This PR removes the second balance check in `getWithdrawalsAndTokenInfo` as it doesn't seem necessary. If the balance is not sufficient to begin with we will have not requested a small amount to be withdrawn and thus won't even attempt to claim the 0 withdraw. While at it I changed the string comparison to a BigNumber comparison as some `getAmount` functions returned a BN (in `prepareWithdraw` & `prepareWithdrawAndTransferFundsToMaster`). Thus we were comparing Strings with BN via `===` (typescript would have caught this).

### Test Plan

Withdrawing my test liquidity on xDAI works without a 1Inch price estimation failure

```
yarn truffle exec scripts/request_withdraw.js --masterSafe=$MASTER_SAFE --brackets=0x5D6b329918c2BF4d9B722c5c8F8d981E61974d03,0x52033e1F448C69eD6AdDCebF47f9a5836df6395D,0x9A5aB9da6Ee6D9907B19738824C25dfAf0482CD6,0x876EF54A5833DaF55F2c27b4fD098cfdbdb92b70,0x0BdB46E41c80749F5506f51037a981276Dd982E4,0x463Ba08241022F65416a57b428EE32cB25402918,0xf1E115BB04789f85A85f033be932953Cb09DFc72,0xAB795A52D809e4Aa56da23b215Db7663d57CDE3A,0x45d8a3d10cd7Da86Dac21a51B305312Ebf80072d,0x2952bC69739c9534d09525ccCa33950F311CbE88 --tokenIds=1,4 --network=$NETWORK_NAME --executeOnchain --noBalanceCheck
```

Also unit tests still pass.