### PR TITLE
[Easy] Allow withdraw scripts to be directly executed onchain

### DIFF
--- a/scripts/claim_withdraw.js
+++ b/scripts/claim_withdraw.js
@@ -1,3 +1,4 @@
+const { signAndExecute } = require("./utils/internals")(web3, artifacts)
 const { signAndSend } = require("./utils/gnosis_safe_server_interactions")(web3, artifacts)
 const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { defaultWithdrawYargs, prepareWithdrawAndTransferFundsToMaster } = require("./wrapper/withdraw")(web3, artifacts)
@@ -12,7 +13,8 @@ module.exports = async (callback) => {
     const transaction = await prepareWithdrawAndTransferFundsToMaster(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
-      await signAndSend(await masterSafe, transaction, argv.network)
+      const signAndSendOrExecuteOnChain = argv.executeOnchain ? async (safe, tx) => signAndExecute(safe, tx) : signAndSend
+      await signAndSendOrExecuteOnChain(await masterSafe, transaction, argv.network)
     }
 
     callback()

--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -170,7 +170,7 @@ module.exports = async (callback) => {
     )
 
     const signAndSendOrExecuteOnChain = argv.executeOnchain
-      ? async (safe, tx, _, nonce) => signAndExecute(safe, tx, nonce)
+      ? (safe, tx, _, nonce) => signAndExecute(safe, tx, nonce)
       : signAndSend
 
     if (!argv.verify) {

--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -18,7 +18,7 @@ module.exports = async (callback) => {
     const transaction = await prepareWithdrawRequest(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
-      const signAndSendOrExecuteOnChain = argv.executeOnchain ? async (safe, tx) => signAndExecute(safe, tx) : signAndSend
+      const signAndSendOrExecuteOnChain = argv.executeOnchain ? (safe, tx) => signAndExecute(safe, tx) : signAndSend
       await signAndSendOrExecuteOnChain(await masterSafe, transaction, argv.network)
     }
 

--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -1,6 +1,7 @@
 const { signAndSend } = require("./utils/gnosis_safe_server_interactions")(web3, artifacts)
 const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { defaultWithdrawYargs, prepareWithdrawRequest } = require("./wrapper/withdraw")(web3, artifacts)
+const { signAndExecute } = require("./utils/internals")(web3, artifacts)
 const { promptUser } = require("./utils/user_interface_helpers")
 
 const argv = defaultWithdrawYargs.option("noBalanceCheck", {
@@ -17,7 +18,8 @@ module.exports = async (callback) => {
     const transaction = await prepareWithdrawRequest(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
-      await signAndSend(await masterSafe, transaction, argv.network)
+      const signAndSendOrExecuteOnChain = argv.executeOnchain ? async (safe, tx) => signAndExecute(safe, tx) : signAndSend
+      await signAndSendOrExecuteOnChain(await masterSafe, transaction, argv.network)
     }
 
     callback()

--- a/scripts/transfer_funds_to_master.js
+++ b/scripts/transfer_funds_to_master.js
@@ -13,7 +13,7 @@ module.exports = async (callback) => {
     const transaction = await prepareTransferFundsToMaster(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
-      const signAndSendOrExecuteOnChain = argv.executeOnchain ? async (safe, tx) => signAndExecute(safe, tx) : signAndSend
+      const signAndSendOrExecuteOnChain = argv.executeOnchain ? (safe, tx) => signAndExecute(safe, tx) : signAndSend
       await signAndSendOrExecuteOnChain(await masterSafe, transaction, argv.network)
     }
 

--- a/scripts/transfer_funds_to_master.js
+++ b/scripts/transfer_funds_to_master.js
@@ -1,3 +1,4 @@
+const { signAndExecute } = require("./utils/internals")(web3, artifacts)
 const { signAndSend } = require("./utils/gnosis_safe_server_interactions")(web3, artifacts)
 const { getSafe } = require("./utils/trading_strategy_helpers")(web3, artifacts)
 const { defaultWithdrawYargs, prepareTransferFundsToMaster } = require("./wrapper/withdraw")(web3, artifacts)
@@ -12,7 +13,8 @@ module.exports = async (callback) => {
     const transaction = await prepareTransferFundsToMaster(argv, true)
     const answer = await promptUser("Are you sure you want to send this transaction to the EVM? [yN] ")
     if (answer == "y" || answer.toLowerCase() == "yes") {
-      await signAndSend(await masterSafe, transaction, argv.network)
+      const signAndSendOrExecuteOnChain = argv.executeOnchain ? async (safe, tx) => signAndExecute(safe, tx) : signAndSend
+      await signAndSendOrExecuteOnChain(await masterSafe, transaction, argv.network)
     }
 
     callback()

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -299,6 +299,11 @@ module.exports = function (web3, artifacts) {
         return str.split(",")
       },
     })
+    .option("executeOnchain", {
+      type: "boolean",
+      default: false,
+      describe: "Directly execute transaction on-chain instead of sending to the backend",
+    })
     .check(checkBracketsForDuplicate)
 
   return {

--- a/test/scripts/withdraw.js
+++ b/test/scripts/withdraw.js
@@ -149,7 +149,7 @@ contract("Withdraw script", function (accounts) {
         withdrawalFile: depositFile.path,
         withdraw: true,
       }
-      const claimTx = await prepareWithdraw(argv2, false, globalPriceStorage)
+      const claimTx = await prepareWithdraw(argv2, false)
       await execTransaction(masterSafe, safeOwner, claimTx)
 
       for (const { amount, tokenAddress, bracketAddress } of deposits) {
@@ -178,10 +178,10 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
-      const claimTx = await prepareWithdraw(argv, false, globalPriceStorage)
+      const claimTx = await prepareWithdraw(argv, false)
       await execTransaction(masterSafe, safeOwner, claimTx)
 
-      const transferTx = await prepareTransferFundsToMaster(argv, false, globalPriceStorage)
+      const transferTx = await prepareTransferFundsToMaster(argv, false)
       await execTransaction(masterSafe, safeOwner, transferTx)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -213,7 +213,7 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
-      const claimAndTransferTx = await prepareWithdrawAndTransferFundsToMaster(argv, false, globalPriceStorage)
+      const claimAndTransferTx = await prepareWithdrawAndTransferFundsToMaster(argv, false)
       await execTransaction(masterSafe, safeOwner, claimAndTransferTx)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -368,7 +368,7 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, transaction1)
       await waitForNSeconds(301)
 
-      const transaction2 = await prepareWithdraw(argv, false, globalPriceStorage)
+      const transaction2 = await prepareWithdraw(argv, false)
       await execTransaction(masterSafe, safeOwner, transaction2)
 
       for (const { amount, tokenAddress, bracketAddress } of deposits) {
@@ -398,14 +398,13 @@ contract("Withdraw script", function (accounts) {
       const argv = {
         masterSafe: masterSafe.address,
         brackets: bracketAddresses,
-        noBalanceCheck: true,
         tokens: [tokenInfo[0].address, tokenInfo[1].address],
       }
       const requestTransaction = await prepareWithdrawRequest(argv, false, globalPriceStorage)
       await execTransaction(masterSafe, safeOwner, requestTransaction)
       await waitForNSeconds(301)
 
-      const claimTransaction = await prepareWithdraw(argv, false, globalPriceStorage)
+      const claimTransaction = await prepareWithdraw(argv, false)
       await execTransaction(masterSafe, safeOwner, claimTransaction)
 
       const usdcAddress = tokenInfo[0].address
@@ -414,11 +413,10 @@ contract("Withdraw script", function (accounts) {
         const pendingWithdraw = (await exchange.getPendingWithdraw(bracketAddress, tokenAddress))[0]
         if (tokenAddress === usdcAddress) {
           assert.equal(bracketBalance, "0", "Not expecting to claim USDC balance")
-          assert(pendingWithdraw.gt(new BN(0)), "Should still have non-zero pending withdraw!")
         } else {
           assert.equal(bracketBalance, amount, "Bad amount requested to withdraw")
-          assert.equal(pendingWithdraw, "0", "A withdrawal request is still pending")
         }
+        assert.equal(pendingWithdraw, "0", "A withdrawal request is still pending")
       }
     })
     it("transfers funds to master", async () => {
@@ -448,10 +446,10 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, requestTransaction)
       await waitForNSeconds(301)
 
-      const claimTransaction = await prepareWithdraw(argv, false, globalPriceStorage)
+      const claimTransaction = await prepareWithdraw(argv, false)
       await execTransaction(masterSafe, safeOwner, claimTransaction)
 
-      const transferTransaction = await prepareTransferFundsToMaster(argv, false, globalPriceStorage)
+      const transferTransaction = await prepareTransferFundsToMaster(argv, false)
       await execTransaction(masterSafe, safeOwner, transferTransaction)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -492,7 +490,7 @@ contract("Withdraw script", function (accounts) {
       await execTransaction(masterSafe, safeOwner, requestTx)
       await waitForNSeconds(301)
 
-      const claimAndTransferTx = await prepareWithdrawAndTransferFundsToMaster(argv, false, globalPriceStorage)
+      const claimAndTransferTx = await prepareWithdrawAndTransferFundsToMaster(argv, false)
       await execTransaction(masterSafe, safeOwner, claimAndTransferTx)
 
       for (const { tokenAddress, bracketAddress } of deposits) {
@@ -518,14 +516,12 @@ contract("Withdraw script", function (accounts) {
         brackets: bracketAddresses,
         tokens: [tokenInfo[0].address],
       }
-      const globalPriceStorage = {}
-      globalPriceStorage["WETH-USDC"] = { price: 250.0 }
 
       // The transaction creation should be rejected because no funds can be withdrawn
       // before executing a withdraw request.
       // If the built transaction used the token balance of the bracket instead of zero,
       // then the transaction creation would not fail.
-      await assertNodejs.rejects(prepareWithdrawAndTransferFundsToMaster(argv, false, globalPriceStorage), {
+      await assertNodejs.rejects(prepareWithdrawAndTransferFundsToMaster(argv, false), {
         message: "No funds can be withdrawn for the given parameters.",
       })
     })


### PR DESCRIPTION
Similar to #519 but for withdrawals. This will allow us to easily relaunch strategies until the Safe Web is available.

### Test Plan

Withdraw my test liquidity (between WETH and wxDAI)

```sh
yarn truffle exec scripts/request_withdraw.js --masterSafe=$MASTER_SAFE --brackets=0x5D6b329918c2BF4d9B722c5c8F8d981E61974d03,0x52033e1F448C69eD6AdDCebF47f9a5836df6395D,0x9A5aB9da6Ee6D9907B19738824C25dfAf0482CD6,0x876EF54A5833DaF55F2c27b4fD098cfdbdb92b70,0x0BdB46E41c80749F5506f51037a981276Dd982E4,0x463Ba08241022F65416a57b428EE32cB25402918,0xf1E115BB04789f85A85f033be932953Cb09DFc72,0xAB795A52D809e4Aa56da23b215Db7663d57CDE3A,0x45d8a3d10cd7Da86Dac21a51B305312Ebf80072d,0x2952bC69739c9534d09525ccCa33950F311CbE88 --tokenIds=1,4 --network=$NETWORK_NAME --executeOnchain --noBalanceCheck
# Wait 5 minutes
yarn truffle exec scripts/claim_withdraw.js --masterSafe=$MASTER_SAFE --brackets=0x5D6b329918c2BF4d9B722c5c8F8d981E61974d03,0x52033e1F448C69eD6AdDCebF47f9a5836df6395D,0x9A5aB9da6Ee6D9907B19738824C25dfAf0482CD6,0x876EF54A5833DaF55F2c27b4fD098cfdbdb92b70,0x0BdB46E41c80749F5506f51037a981276Dd982E4,0x463Ba08241022F65416a57b428EE32cB25402918,0xf1E115BB04789f85A85f033be932953Cb09DFc72,0xAB795A52D809e4Aa56da23b215Db7663d57CDE3A,0x45d8a3d10cd7Da86Dac21a51B305312Ebf80072d,0x2952bC69739c9534d09525ccCa33950F311CbE88 --tokenIds=1,4 --network=$NETWORK_NAME --executeOnchain
```