### PR TITLE
Add single function to manage transaction submission

### DIFF
--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -1002,6 +1002,7 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     const tokenInfoPromises = fetchTokenInfoFromExchange(await exchangePromise, [baseTokenId, quoteTokenId])
     const createFleetTransaction = buildDeterministicFleetOfSafes(masterAddress, fleetSize, await noncePromise)
     const bracketAddresses = await calcSafeAddresses(fleetSize, await noncePromise)
+    console.log(bracketAddresses)
 
     const createOrderTransactions = transactionsForOrders(
       masterAddress,

--- a/scripts/utils/trading_strategy_helpers.js
+++ b/scripts/utils/trading_strategy_helpers.js
@@ -1002,7 +1002,6 @@ module.exports = function (web3 = web3, artifacts = artifacts) {
     const tokenInfoPromises = fetchTokenInfoFromExchange(await exchangePromise, [baseTokenId, quoteTokenId])
     const createFleetTransaction = buildDeterministicFleetOfSafes(masterAddress, fleetSize, await noncePromise)
     const bracketAddresses = await calcSafeAddresses(fleetSize, await noncePromise)
-    console.log(bracketAddresses)
 
     const createOrderTransactions = transactionsForOrders(
       masterAddress,


### PR DESCRIPTION
Prune repeating logic when sending transactions. See #549 for an example use case.

As a proof of concept, I used this function to implement `--executeOnchain` for `single_transaction_liquidity_provision`.

### Test plan

Try that everything works as expected, for example:
```
npx truffle exec scripts/single_transaction_liquidity_provision.js --baseTokenId=0 --quoteTokenId=3 --lowestLimit=1 --highestLimit=100 --currentPrice=1.1 --masterSafe $MASTER_SAFE --depositBaseToken=0 --depositQuoteToken=10000 --numBrackets=10 --network=rinkeby
```

Then follow the instructions on screen to test that verification is working and execute the transaction.

Finally test `--executeOnchain`:
```

npx truffle exec scripts/single_transaction_liquidity_provision.js --baseTokenId=0 --quoteTokenId=3 --lowestLimit=1 --highestLimit=100 --currentPrice=1.1 --masterSafe $MASTER_SAFE --depositBaseToken=0 --depositQuoteToken=10000 --numBrackets=10 --network=rinkeby --executeOnchain
```