### PR TITLE
Fix incorrect use of Yarn conflicts

### DIFF
--- a/scripts/complete_liquidity_provision.js
+++ b/scripts/complete_liquidity_provision.js
@@ -15,7 +15,7 @@ const { signAndExecute } = require("./utils/internals")(web3, artifacts)
 const { proceedAnyways } = require("./utils/user_interface_helpers")
 const { sleep } = require("./utils/js_helpers")
 const { DEFAULT_NUM_SAFES } = require("./utils/constants")
-const { default_yargs, checkBracketsForDuplicate } = require("./utils/default_yargs")
+const { default_yargs, checkBracketsForDuplicate, noNonceWithExecuteOnchain } = require("./utils/default_yargs")
 
 const argv = default_yargs
   .option("masterSafe", {
@@ -78,7 +78,6 @@ const argv = default_yargs
   .option("executeOnchain", {
     type: "boolean",
     default: false,
-    conflicts: ["nonce"],
     describe: "Directly execute transaction on-chain instead of sending to the backend",
   })
   .option("nonce", {
@@ -86,6 +85,7 @@ const argv = default_yargs
     default: null,
     describe: "Use this specific nonce instead of the next available one",
   })
+  .check(noNonceWithExecuteOnchain)
   .check(checkBracketsForDuplicate).argv
 
 const findBracketsWithExistingOrders = async function (bracketAddresses, exchange) {

--- a/scripts/utils/default_yargs.js
+++ b/scripts/utils/default_yargs.js
@@ -27,7 +27,22 @@ function checkBracketsForDuplicate(argv) {
   return true
 }
 
+/**
+ * Throws if --executeOnchain and --nonce are used simultaneously,
+ * otherwise returns true.
+ *
+ * @param {object} argv script arguments.
+ * @returns {boolean} true, throw if both flags are used.
+ */
+function noNonceWithExecuteOnchain(argv) {
+  if (argv.executeOnchain && argv.nonce !== null) {
+    throw new Error("Arguments --executeOnchain and --nonce are mutually exclusive")
+  }
+  return true
+}
+
 module.exports = {
   default_yargs,
   checkBracketsForDuplicate,
+  noNonceWithExecuteOnchain,
 }

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -12,7 +12,7 @@ module.exports = function (web3, artifacts) {
     buildWithdrawAndTransferFundsToMaster,
     retrieveTradedTokensPerBracket,
   } = require("../utils/trading_strategy_helpers")(web3, artifacts)
-  const { default_yargs, checkBracketsForDuplicate } = require("../utils/default_yargs")
+  const { default_yargs, checkBracketsForDuplicate, noNonceWithExecuteOnchain } = require("../utils/default_yargs")
   const { fromErc20Units, shortenedAddress } = require("../utils/printing_tools")
   const { MAXUINT256, ONE, ZERO } = require("../utils/constants")
   const { uniqueItems } = require("../utils/js_helpers")
@@ -308,9 +308,9 @@ module.exports = function (web3, artifacts) {
     .option("executeOnchain", {
       type: "boolean",
       default: false,
-      conflicts: ["nonce"],
       describe: "Directly execute transaction on-chain instead of sending to the backend",
     })
+    .check(noNonceWithExecuteOnchain)
     .check(checkBracketsForDuplicate)
 
   return {


### PR DESCRIPTION
This bug fixes a recent issue in the script because of the newly introduced flags `--nonce` and `--executeOnchain`. Currently, the complete_liquidity_provision script is not working on master because of a yargs mismatch.

Currently, we use Yargs's `conflicts` to enforce that the two flags are not used together. However, since we give a default value to both (different from `undefined`) this counts as if both flags were set.

This PR gets rid of the `conflicts` flag and replaces it with a custom function.

### Test plan.

Run the following command both in master and on the curent PR to see the improvement. (No need to execute or send transactions, it's enough to see that the options are properly parsed.)
```
npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=200 --highestLimit=250 --currentPrice=245 --masterSafe $MASTER_SAFE --depositBaseToken=0 --depositQuoteToken=0 --numBrackets=5 --network=rinkeby
```

Test for (expected) failure with both flags:
```
npx truffle exec scripts/complete_liquidity_provision.js --baseTokenId=1 --quoteTokenId=3 --lowestLimit=200 --highestLimit=250 --currentPrice=245 --masterSafe $MASTER_SAFE --depositBaseToken=0 --depositQuoteToken=0 --numBrackets=5 --network=rinkeby --nonce=10 --executeOnchain
```