### PR TITLE
Patch changes to 1inch API WETH handling

### DIFF
--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -131,11 +131,14 @@ const getOneinchPrice = async function (baseToken, quoteToken, globalPriceStorag
     throw new Error("Invalid token input for retrieving price from aggregator.")
   }
   const quoteTokenAmount = toErc20Units("1", quoteToken.decimals)
+  // 1inch API does not treat WETH like a real token, so ETH must be used instead
+  const quoteTokenSymbol = quoteToken.symbol === "WETH" ? "ETH" : quoteToken.symbol
+  const baseTokenSymbol = baseToken.symbol === "WETH" ? "ETH" : baseToken.symbol
   const url =
     "https://api.1inch.exchange/v1.1/quote?fromTokenSymbol=" +
-    quoteToken.symbol +
+    quoteTokenSymbol +
     "&toTokenSymbol=" +
-    baseToken.symbol +
+    baseTokenSymbol +
     "&amount=" +
     quoteTokenAmount.toString()
   let price


### PR DESCRIPTION
It seems like 1inch changed their API in a way that makes WETH an invalid token (price returned is zero). Compare a [WETH](https://api.1inch.exchange/v1.1/quote?fromTokenSymbol=USDC&toTokenSymbol=WETH&amount=1000000) trade with an [ETH](https://api.1inch.exchange/v1.1/quote?fromTokenSymbol=USDC&toTokenSymbol=ETH&amount=1000000) trade. (Zero `toTokenAmount` in one case, reasonable value in the other case.)

This PR patches this change by replacing `WETH` with `ETH` in the function that retrieves 1inch prices.

### Test plan

Try to request withdraw WETH without ignoring the price check. Unit tests.