### PR TITLE
Reorganize balance checks on request withdraw

### DIFF
--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -14,7 +14,7 @@ const argv = defaultWithdrawYargs
   .option("onlySkipNonzero", {
     type: "boolean",
     default: false,
-    describe: "Withdraw balance of all nonzero balances, even if the amounts have very small USD value",
+    describe: "Withdraw balance of all non-zero balances, even if the amounts have very small USD value",
   }).argv
 
 module.exports = async (callback) => {

--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -11,7 +11,7 @@ const argv = defaultWithdrawYargs
     describe:
       "Request withdraw of all funds on each bracket for each traded tokens, independently of their actual balance. Selected brackets will stop any trading from the following batch",
   })
-  .option("onlySkipNonzero", {
+  .option("skipZero", {
     type: "boolean",
     default: false,
     describe: "Withdraw balance of all non-zero balances, even if the amounts have very small USD value",

--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -4,12 +4,18 @@ const { defaultWithdrawYargs, prepareWithdrawRequest } = require("./wrapper/with
 const { signAndExecute } = require("./utils/internals")(web3, artifacts)
 const { promptUser } = require("./utils/user_interface_helpers")
 
-const argv = defaultWithdrawYargs.option("noBalanceCheck", {
-  type: "boolean",
-  default: false,
-  describe:
-    "Request withdraw for tokens without checking if the token has no balance. Useful to account for trading that might be happening during the withdraw request",
-}).argv
+const argv = defaultWithdrawYargs
+  .option("stopTrading", {
+    type: "boolean",
+    default: false,
+    describe:
+      "Request withdraw of all funds on each bracket for each traded tokens, independently of their actual balance. Selected brackets will stop any trading from the following batch",
+  })
+  .option("onlySkipNonzero", {
+    type: "boolean",
+    default: false,
+    describe: "Withdraw balance of all nonzero balances, even if the amounts have very small USD value",
+  }).argv
 
 module.exports = async (callback) => {
   try {

--- a/scripts/utils/price_utils.js
+++ b/scripts/utils/price_utils.js
@@ -232,11 +232,11 @@ const orderSellValueInUSD = async (order, tokenInfo, globalPriceStorage = null) 
     .toBN()
 }
 
-const amountUSDValue = async function (amount, tokenInfo, globalPriceStorage = null) {
+const amountUSDValue = async function (amountPromise, tokenInfo, globalPriceStorage = null) {
   const currentMarketPriceSlice = await getOneinchPrice(tokenInfo, { symbol: "USDC", decimals: 6 }, globalPriceStorage)
   const currentMarketPrice = currentMarketPriceSlice.price
   return Fraction.fromNumber(parseFloat(currentMarketPrice))
-    .mul(new Fraction(new BN(amount), new BN(10).pow(new BN(tokenInfo.decimals))))
+    .mul(new Fraction(new BN(await amountPromise), new BN(10).pow(new BN(tokenInfo.decimals))))
     .toBN()
 }
 

--- a/scripts/wrapper/withdraw.js
+++ b/scripts/wrapper/withdraw.js
@@ -36,8 +36,8 @@ module.exports = function (web3, artifacts) {
       }
     }
 
-    if (argv.stopTrading && argv.onlySkipNonzero) {
-      throw new Error("Argument error: --stopTrading and --onlySkipNonzero cannot be used simultaneously")
+    if (argv.stopTrading && argv.skipZero) {
+      throw new Error("Argument error: --stopTrading and --skipZero cannot be used simultaneously")
     }
   }
 
@@ -143,14 +143,14 @@ module.exports = function (web3, artifacts) {
     } else {
       amountFunction = async function (bracketAddress, tokenData, exchange) {
         const amountPromise = exchange.getBalance(bracketAddress, tokenData.address)
-        if (!argv.stopTrading && !argv.onlySkipNonzero) {
+        if (!argv.stopTrading && !argv.skipZero) {
           const usdValue = await amountUSDValue(amountPromise, tokenData, globalPriceStorage)
           if (usdValue.lt(ONE)) {
             log(`Skipping request for ${tokenData.symbol} on bracket ${bracketAddress} since USD value < 1`)
             return ZERO
           }
         }
-        if (argv.onlySkipNonzero) {
+        if (argv.skipZero) {
           if ((await amountPromise).eq(ZERO)) {
             return ZERO
           }


### PR DESCRIPTION
This PR introduces a new flag `--onlySkipNonzero` for `request_withdraw.js`. If a withdraw is requested with this flag, all nonzero user balances are requested to be withdrawn from the exchange. This is helpful to more efficiently withdraw tokens that aren't priced by our price oracle (e.g. `xDAI`), which currently require skipping the balance check altogether, and was explicitly requested for the development of the CMM app (please confirm this works for you @andre-meyer).

The default behavior of the scripts is still to check the withdrawn balance, since trading on GP always leaves some dust amounts unmatched.

Two more minor changes are part of this reorganization:
1. the flag `--noBalanceCheck` is replaced by `--stopTrading`, to reflect the main purpose of this flag after introducing the new flag.
2. `amountUSDValue` accepts the promise of an amount, in this way the price request to 1inch can be executed in parallel to the retrieving of the balance onchain.

### Test plan

Deploy a strategy with some funds, e.g.:
```
npx truffle exec scripts/single_transaction_liquidity_provision.js --baseTokenId=4 --quoteTokenId=3 --lowestLimit=0.9 --highestLimit=1 --currentPrice=0.92 --masterSafe $MASTER_SAFE --depositBaseToken=1 --depositQuoteToken=10000 --numBrackets=10 --network=rinkeby --executeOnchain
```

Try all new combinations of withdraw flags and see in the resulting console output that everything behaves as expected (no need to send the transaction):
1. skips value <1$
```
npx truffle exec scripts/request_withdraw.js --masterSafe $MASTER_SAFE --brackets $BRACKETS --network=rinkeby
```
2. skips only empty balances
```
npx truffle exec scripts/request_withdraw.js --masterSafe $MASTER_SAFE --brackets $BRACKETS --network=rinkeby --onlySkipNonzero
```
3. withdraws everything
```
npx truffle exec scripts/request_withdraw.js --masterSafe $MASTER_SAFE --brackets $BRACKETS --network=rinkeby --stopTrading
```
4. failure, invalid arguments
```
npx truffle exec scripts/request_withdraw.js --masterSafe $MASTER_SAFE --brackets $BRACKETS --network=rinkeby --stopTrading --onlySkipNonzero
```