### PR TITLE
Adjust BalanceViewer to alert on lowBalanceThreshold

### DIFF
--- a/scripts/balance_viewer.js
+++ b/scripts/balance_viewer.js
@@ -31,7 +31,7 @@ const argv = default_yargs
   })
   .option("lowBalanceThreshold", {
     type: "number",
-    describe: "error when the total balance of one of the token held is less than the threshold",
+    describe: "error when the total balance of one of the tokens held is less than the threshold",
   })
   .option("alias", {
     type: "string",

--- a/scripts/balance_viewer.js
+++ b/scripts/balance_viewer.js
@@ -29,6 +29,15 @@ const argv = default_yargs
       return str.split(",")
     },
   })
+  .option("lowBalanceThreshold", {
+    type: "number",
+    describe: "error when the total balance of one of the token held is less than the threshold",
+  })
+  .option("alias", {
+    type: "string",
+    describe: "An optional description of the bracket strategy",
+    default: "Bracket Strategy",
+  })
   .check(noMasterSafeAndBracketsTogether)
   .check(checkBracketsForDuplicate).argv
 
@@ -132,12 +141,12 @@ module.exports = async (callback) => {
         requestedForWithdraw: requestedForWithdrawSum[tokenId],
         storedInBracket: storedInBracketSum[tokenId],
       })
-      console.log(
-        `Total ${tokenData.symbol} in all brackets: ${fromErc20Units(
-          totalBalanceSum[tokenId].toString(),
-          tokenData.decimals
-        )}${optionalString}`
-      )
+      const balance_string = fromErc20Units(totalBalanceSum[tokenId].toString(), tokenData.decimals)
+      console.log(`Total ${tokenData.symbol} in all brackets: ${balance_string}${optionalString}`)
+
+      if (argv.lowBalanceThreshold && argv.lowBalanceThreshold > parseFloat(balance_string)) {
+        console.error(`${argv.alias} has low token balance: ${balance_string} ${tokenData.symbol}`)
+      }
     }
 
     callback()


### PR DESCRIPTION
This PR adjusts the balance viewer script to allow emitting an error if a given `lowBalanceThreshold` is not achieved by the sum of all brackets that were checked.

This will allow us to create a cron job monitoring our brackets and emitting an `stderr` message (which we can forward into slack) if a certain strategy is no longer funded.

For the shell script I'm envisioning something like

```sh
#!/bin/bash
INPUT=`curl -s https://gist.githubusercontent.com/fleupold/d1d1b7ade5be110a243bc0b60c4510fd/raw/42b145e5e2c1ebfc43a98bf877d5bccb68562300/watch_brackets.tsv`
NETWORK=mainnet
THRESHOLD=1000
OLDIFS=$IFS
IFS=' '
while read strategy brackets
do
	yarn truffle exec scripts/balance_viewer.js --network $NETWORK --lowBalanceThreshold $THRESHOLD --brackets $brackets --alias $strategy
done <<< $INPUT
IFS=$OLDIFS
```


### Test Plan

```
yarn truffle exec scripts/balance_viewer.js --network mainnet --brackets 0xf5173728238e1438c6c194c2bc75cfd59249a022,0xa82ae0e45619e0a7589114cd8e8de1e845c7efc6,0x1603b1d86203234dd1ca4519ba611122cd72e425,0x314296905033bd1cb75eb009b4a56a54e3dac33e --lowBalanceThreshold 1
```

shows low balance alert.

```
yarn truffle exec scripts/balance_viewer.js --network mainnet --brackets 0x8259fc4ccde00d5a6d55bf4958a25493f0e8a0b8 --lowBalanceThreshold 1
```

doesn't show low balance alert.